### PR TITLE
Fix: A11y small modifications

### DIFF
--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -36,6 +36,7 @@ const HeaderCenter = () => {
         <div className="it-brand-wrapper">
           <UniversalLink
             href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : '/'}
+            title="homepage"
           >
             {subsite?.subsite_logo ? logoSubsite : <Logo />}
             <BrandText subsite={subsite} />

--- a/src/components/ItaliaTheme/Header/SocialHeader.jsx
+++ b/src/components/ItaliaTheme/Header/SocialHeader.jsx
@@ -17,6 +17,10 @@ const messages = defineMessages({
     id: 'Seguici su',
     defaultMessage: 'Seguici su',
   },
+  socialOpen: {
+    id: 'Nuova scheda',
+    defaultMessage: '- apri in nuova scheda',
+  },
 });
 
 const SocialHeader = () => {
@@ -46,7 +50,9 @@ const SocialHeader = () => {
           {socials?.map((social, idx) => (
             <li key={idx}>
               <a
-                title={social.title}
+                title={
+                  social.title + ' ' + intl.formatMessage(messages.socialOpen)
+                }
                 href={social.url}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/theme/ItaliaTheme/Blocks/_listing.scss
+++ b/theme/ItaliaTheme/Blocks/_listing.scss
@@ -14,7 +14,7 @@
 
     display: flex;
     align-items: center;
-    color: $card-link-color;
+    color: $body-color;
     font-size: $card-category-size;
     letter-spacing: $card-category-l-spacing;
   }

--- a/theme/ItaliaTheme/Components/_pageHeader.scss
+++ b/theme/ItaliaTheme/Components/_pageHeader.scss
@@ -3,15 +3,6 @@
     p {
       margin-bottom: 0.5rem;
     }
-
-    a {
-      text-decoration: none;
-
-      &:hover,
-      &:focus {
-        text-decoration: underline;
-      }
-    }
   }
 
   .header-image {


### PR DESCRIPTION
- Added title text to logo link
- added "- apri in nuova scheda" on social links title
- text-underline re-added on "Informazioni aggiuntive per la testata"
<img width="1041" alt="Schermata 2022-11-25 alle 17 28 20" src="https://user-images.githubusercontent.com/60133113/204025487-c20dbdfb-f17f-4ab5-98be-7fab941dda61.png">

- link color inside single card changed to fulfill minimal contrast
<img width="317" alt="Schermata 2022-11-25 alle 17 29 42" src="https://user-images.githubusercontent.com/60133113/204025819-521646f0-4677-4421-a616-1d8186ce0baa.png">


Related US's: 
https://redturtle.tpondemand.com/entity/21123-logo-manca-alt-e-title
https://redturtle.tpondemand.com/entity/21124-link-social-title-per-nuova-scheda
https://redturtle.tpondemand.com/entity/21129-contatti-link-sottolineati
https://redturtle.tpondemand.com/entity/21139-contrasto-evento-piu-date