### PR TITLE
feat: block maps not accessible by default

### DIFF
--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -325,6 +325,10 @@ export default function applyConfig(voltoConfig) {
       ...config.blocks.blocksConfig.slateTable,
       restricted: true,
     },
+    maps: {
+      ...config.blocks.blocksConfig.maps,
+      restricted: true,
+    },
   };
 
   config.blocks = {

--- a/src/config/volto-gdpr-privacy-defaultPanelConfig.js
+++ b/src/config/volto-gdpr-privacy-defaultPanelConfig.js
@@ -167,7 +167,7 @@ const defaultPanelConfig = {
           },
         },
       },
-      {
+      /*       {
         config_key: 'GOOGLEMAPS',
         referenceUrls: ['google.com/maps'],
         text: {
@@ -196,7 +196,7 @@ const defaultPanelConfig = {
               'Pour afficher la carte, veuillez accepter les cookies de Google Maps.',
           },
         },
-      },
+      }, */
       {
         config_key: 'META',
         referenceUrls: ['facebook.com', 'instagram.com'],


### PR DESCRIPTION
Block maps removed from blocks options
Google Maps cookies removed from GPDR banner

Left there for future use.