### PR TITLE
fix: IntersectionObserver.unobserve: Argument 1 is not an object

### DIFF
--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -99,7 +99,9 @@ const Image = ({
             entries.forEach((entry) => {
               if (entry.isIntersecting && !actualSrcSet) {
                 srcSet && applySrcSet();
-                observer.unobserve(imageRef.current);
+                if (imageRef.current instanceof Element) {
+                  observer.unobserve(imageRef.current);
+                }
               }
             });
           },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/182599/209338163-05c0d5d5-c3fe-4126-b5ee-950656790084.png)
