### PR TITLE
feat: new color for links inside the draftjs editor on footer site config

### DIFF
--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -345,6 +345,17 @@ body.cms-ui {
       text-decoration: $link-decoration;
     }
   }
+  .footer-configuration-widget {
+    .DraftEditor-editorContainer {
+      a.link-anchorlink-theme {
+        color: #06c;
+
+        &:hover {
+          color: darken(#06c, 20);
+        }
+      }
+    }
+  }
 
   &.section-controlpanel {
     a {


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/37761-link-in-colonne-footer-editor-non

Io-comune links uses the $primary color for all links. Now, the links inside draftjs editor (cms settings) on site configurations footer are the io-comune blue (#06c) as default color. 

<img width="1134" alt="Schermata 2023-01-25 alle 09 05 15" src="https://user-images.githubusercontent.com/60133113/214510564-c7f0b01d-cf91-42aa-be9a-d6d14ba396ca.png">
