### PR TITLE
fix: mobile text not visible

### DIFF
--- a/theme/ItaliaTheme/Addons/customerSatisfaction.scss
+++ b/theme/ItaliaTheme/Addons/customerSatisfaction.scss
@@ -37,4 +37,20 @@
       max-height: 800px;
     }
   }
+  .comment {
+    @media (max-width: #{map-get($grid-breakpoints, lg)}) {
+      margin-top: 3.5rem;
+      .form-group {
+        label {
+          padding-bottom: 1rem;
+        }
+      }
+    }
+    .form-group {
+      label {
+        line-height: unset;
+        white-space: unset;
+      }
+    }
+  }
 }

--- a/theme/ItaliaTheme/Addons/customerSatisfaction.scss
+++ b/theme/ItaliaTheme/Addons/customerSatisfaction.scss
@@ -38,7 +38,7 @@
     }
   }
   .comment {
-    @media (max-width: #{map-get($grid-breakpoints, lg)}) {
+    @media (max-width: #{map-get($grid-breakpoints, lg) - 1px }) {
       margin-top: 3.5rem;
       .form-group {
         label {


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/38772-modifica-testo-nella-sezione-di-feedback

The text wasn't visible on mobile screens because of a wrap inside the label. I was necessary to change the distance between text and button when the input receives the focus.

<img width="568" alt="Schermata 2023-02-13 alle 14 38 29" src="https://user-images.githubusercontent.com/60133113/218473031-87f4fbcd-dd63-4370-8d75-ddc29b8b8b80.png">
<img width="572" alt="Schermata 2023-02-13 alle 14 38 33" src="https://user-images.githubusercontent.com/60133113/218473042-33651051-e53c-4021-831a-65882ecd56f8.png">
