### PR TITLE
Rimossa patch per le variabili in fase di build

### DIFF
--- a/.github/workflows/cekk.yml
+++ b/.github/workflows/cekk.yml
@@ -1,0 +1,29 @@
+name: Docker build for latest develop version
+on:
+  push:
+    branches: [cekk_fix_build_variables]
+
+jobs:
+  build_develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: redturtletech/io-comune-base:cekk_fix_build_variables
+          pull: true
+          push: true
+          cache-from: type=registry,ref=redturtletech/io-comune-base:cekk_fix_build_variables
+          cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ FROM base as build
 WORKDIR /home/node/app
 USER root
 
-ENV RAZZLE_API_PATH=VOLTO_API_PATH
-ENV RAZZLE_INTERNAL_API_PATH=VOLTO_INTERNAL_API_PATH
-
 #RUN buildDeps="build-essential ca-certificates git-core openssl" && \
 RUN buildDeps="make" && \
     apt-get update && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ function apply_path {
 }
 
 # Should we monkey patch?
-test -n "$RAZZLE_API_PATH" && apply_path
+# test -n "$RAZZLE_API_PATH" && apply_path
 
 #./create-sentry-release.sh
 


### PR DESCRIPTION
Non serve più fare questo lavoro, basta mettere a runtime.

Anzi, in teoria non servono manco più li con il seamless (testato in RER).

Se è ok, finisco di pulire questa pr togliendo del tutto la roba dentro entrypoint.sh