### PR TITLE
US 39507 warning testo customer satisfaction

### DIFF
--- a/theme/ItaliaTheme/Components/_customerSatisfaction.scss
+++ b/theme/ItaliaTheme/Components/_customerSatisfaction.scss
@@ -70,6 +70,9 @@
         margin: 0;
         padding: 0.25rem 0.5rem;
         font-size: 0.777rem;
+        &.invalid-feedback {
+          display: block;
+        }
       }
       label.active {
         color: #596d88;


### PR DESCRIPTION
fix: invalid-feedback text was removed by some css in the kit, added it back