### PR TITLE
fix: header image height fixed

### DIFF
--- a/theme/ItaliaTheme/Views/_common.scss
+++ b/theme/ItaliaTheme/Views/_common.scss
@@ -71,7 +71,8 @@ picture.volto-image.responsive img.full-width {
   left: 50%;
   width: 100vw !important;
   max-width: initial !important;
-  height: 480px;
+  height: auto;
+  max-height: 480px;
   margin-right: -50vw !important;
   margin-left: -50vw !important;
   object-fit: cover;

--- a/theme/ItaliaTheme/_common.scss
+++ b/theme/ItaliaTheme/_common.scss
@@ -39,11 +39,3 @@
     }
   }
 }
-#main {
-  picture.volto-image.responsive {
-    img.full-width {
-      height: auto;
-      max-height: 480px;
-    }
-  }
-}

--- a/theme/ItaliaTheme/_common.scss
+++ b/theme/ItaliaTheme/_common.scss
@@ -39,3 +39,11 @@
     }
   }
 }
+#main {
+  picture.volto-image.responsive {
+    img.full-width {
+      height: auto;
+      max-height: 480px;
+    }
+  }
+}


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/40040-immagine-da-mobile

- display all image when in full-width mode inside mobiles (responsive class) 
- fixed max-height for desktop view

Before:
<img width="518" alt="Schermata 2023-03-22 alle 14 46 13" src="https://user-images.githubusercontent.com/60133113/226925883-a1955332-1b6d-4365-86eb-93407e8677f9.png">

After:
<img width="486" alt="Schermata 2023-03-22 alle 14 45 36" src="https://user-images.githubusercontent.com/60133113/226925937-7178500b-41a7-41e9-9fe1-d4b29c47dd39.png">
