### PR TITLE
fix: fixed card heading css rules

### DIFF
--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -78,9 +78,7 @@ const CardWithImageRssTemplate = ({
                       )}
                       <span>{getViewDate(item.pubDate, intl.locale)}</span>{' '}
                     </div>
-                    <CardTitle className="big-heading" tag="h6">
-                      {item.title}
-                    </CardTitle>
+                    <CardTitle tag="h6">{item.title}</CardTitle>
                   </CardBody>
                   <CardReadMore
                     iconName="it-arrow-right"

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -67,9 +67,7 @@ const CardWithoutImageRssTemplate = ({
                         </span>
                       )}
                     </div>
-                    <CardTitle className="big-heading" tag="h5">
-                      {item.title}
-                    </CardTitle>
+                    <CardTitle tag="h5">{item.title}</CardTitle>
                     <CardText tag="p" className="font-serif">
                       {item.contentSnippet}
                     </CardText>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithImageRssTemplateSkeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithImageRssTemplateSkeleton.jsx
@@ -34,7 +34,7 @@ const CardWithImageRssTemplateSkeleton = ({ isEditMode, data = {} }) => {
 
                 <CardBody tag="div" className="px-4">
                   <div className="category-top"></div>
-                  <CardTitle className="big-heading" tag="h6"></CardTitle>
+                  <CardTitle tag="h6"></CardTitle>
                 </CardBody>
                 <CardReadMore
                   iconName="it-arrow-right"

--- a/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithoutImageRssTemplateSkeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithoutImageRssTemplateSkeleton.jsx
@@ -28,7 +28,7 @@ const CardWithoutImageRssTemplateSkeleton = ({ isEditMode, data = {} }) => {
               <Card noWrapper={false} tag="div">
                 <CardBody tag="div">
                   <div className="category-top"></div>
-                  <CardTitle className="big-heading" tag="h5"></CardTitle>
+                  <CardTitle tag="h5"></CardTitle>
                   <CardText tag="p" className="font-serif"></CardText>
                 </CardBody>
                 <CardReadMore

--- a/src/components/ItaliaTheme/View/Commons/NewsCard.jsx
+++ b/src/components/ItaliaTheme/View/Commons/NewsCard.jsx
@@ -28,7 +28,7 @@ const NewsCard = ({ title, typology, effective, description, id }) => {
             </span>
           ) : null}
         </div>
-        <h5 className="card-title big-heading">
+        <h5 className="card-title">
           <UniversalLink href={flattenToAppURL(id)}>{title}</UniversalLink>
         </h5>
         <div className="card-text">{description}</div>

--- a/src/components/ItaliaTheme/View/UOView/UOPeople.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOPeople.jsx
@@ -37,7 +37,6 @@ const UOPeople = ({ content }) => {
                 className={'shadow'}
                 showImage={true}
                 titleTagName={'h5'}
-                titleClassName={'big-heading'}
                 listingText={p?.incarichi}
               />
             </Col>

--- a/src/components/ItaliaTheme/View/UOView/UOServices.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOServices.jsx
@@ -36,7 +36,7 @@ const UOServices = ({ content }) => {
             <Card className="shadow rounded">
               <CardBody>
                 <CardCategory date="">{servizio.parent_title}</CardCategory>
-                <CardTitle tag="h5" className="big-heading">
+                <CardTitle tag="h5">
                   <UniversalLink href={servizio['@id']}>
                     {servizio.title}
                   </UniversalLink>

--- a/src/components/ItaliaTheme/View/UOView/UOStructure.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOStructure.jsx
@@ -119,7 +119,6 @@ const UOStructure = ({ content }) => {
                   className={'shadow'}
                   showImage={true}
                   titleTagName={'h5'}
-                  titleClassName={'big-heading'}
                   listingText={item.incarichi}
                 />
               </Col>
@@ -141,7 +140,6 @@ const UOStructure = ({ content }) => {
                   className={'shadow'}
                   showImage={true}
                   titleTagName={'h5'}
-                  titleClassName={'big-heading'}
                   listingText={item.incarichi}
                 />
               </Col>

--- a/theme/ItaliaTheme/Blocks/_simpleCardTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_simpleCardTemplate.scss
@@ -53,10 +53,33 @@
         margin-bottom: 10px;
 
         a {
+          @include rem-size(font-size, 24);
+          @include rem-size(line-height, 26);
+          font-weight: 700;
           &:hover,
           &:active {
             text-decoration: underline;
           }
+        }
+      }
+
+      .category-top {
+        span.text {
+          span.text.fw-bold {
+            font-size: 0.875rem;
+            line-height: 1.313rem;
+            letter-spacing: 1px;
+            font-weight: 600 !important;
+            color: $primary;
+          }
+        }
+      }
+
+      p.card-text {
+        font-size: 1rem;
+        line-height: 1.5rem;
+        div.document-date {
+          @include rem-size(font-size, 14);
         }
       }
     }
@@ -95,6 +118,21 @@
   .card-teaser-wrapper {
     .icon-argument-container + .card-body {
       margin-left: 1em;
+    }
+
+    .card-title {
+      margin-bottom: 10px;
+
+      a {
+        @include rem-size(font-size, 32);
+        @include rem-size(line-height, 32);
+        font-weight: 700;
+        text-decoration: none;
+        &:hover,
+        &:active {
+          text-decoration: underline;
+        }
+      }
     }
 
     .card-teaser {

--- a/theme/ItaliaTheme/Components/_card.scss
+++ b/theme/ItaliaTheme/Components/_card.scss
@@ -25,6 +25,7 @@
     h5.card-title,
     .text.fw-bold {
       color: $primary;
+      font-weight: 600;
       a {
         @include rem-size(font-size, 24);
         @include rem-size(line-height, 32);
@@ -52,6 +53,8 @@
     padding: 0px !important;
     h5.card-title {
       margin-bottom: 0.3em !important;
+      font-weight: 600;
+
       a {
         @include rem-size(font-size, 24);
         @include rem-size(line-height, 32);
@@ -130,7 +133,7 @@
 
       h3.card-title {
         a {
-          font-size: 1.5rem;
+          font-size: 1.3rem;
           line-height: 1.75rem;
           font-weight: 700;
           color: $primary;
@@ -141,36 +144,6 @@
         font-size: 1rem;
         line-height: 1.5rem;
         color: $secondary;
-      }
-    }
-  }
-}
-
-.simple-card-default {
-  .card-title {
-    @include rem-size(font-size, 24px);
-    @include rem-size(line-height, 32px);
-    font-weight: 700;
-  }
-
-  .card-body {
-    .category-top {
-      span.text {
-        span.text.fw-bold {
-          font-size: 0.875rem;
-          line-height: 1.313rem;
-          letter-spacing: 1px;
-          font-weight: 600 !important;
-          color: $primary;
-        }
-      }
-    }
-
-    p.card-text {
-      font-size: 1rem;
-      line-height: 1.5rem;
-      div.document-date {
-        @include rem-size(font-size, 14);
       }
     }
   }
@@ -187,6 +160,17 @@
       }
       svg {
         fill: $primary;
+      }
+    }
+  }
+}
+
+.block.highlitedContent {
+  div.card {
+    h2.card-title {
+      a {
+        color: $primary;
+        font-size: 1.7rem;
       }
     }
   }

--- a/theme/ItaliaTheme/Views/_common.scss
+++ b/theme/ItaliaTheme/Views/_common.scss
@@ -109,12 +109,6 @@ picture.volto-image.responsive img.full-width {
     margin: 0 !important;
     margin-bottom: 1rem !important;
     line-height: 1em;
-
-    &:not(.big-heading) a {
-      color: $primary;
-      @include rem-size(font-size, 24);
-      @include rem-size(line-height, 28);
-    }
   }
 
   .genericcard {


### PR DESCRIPTION
Tutte le card dovrebbero essere governate da regole specifiche in base al tipo di card, con caratteristiche diverse in base a quanto definito con i Gialli.
Ho controllato le varie card anche nei vari CT e regolato tutto quello che discostava. Dovrebbero essere tutte a posto.

La regola `&:not(.big-heading)` non è più necessaria, l'ho quindi rimossa.