### PR TITLE
fix: objectBrowser breadcrumb tooltip visibility

### DIFF
--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -282,15 +282,15 @@ body.cms-ui {
               text-overflow: unset;
             }
           }
-          &:hover .tooltip-text {
-            visibility: visible;
-            opacity: 1;
-          }
         }
         .tooltip {
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
+          &:hover + .tooltip-text {
+            visibility: visible;
+            opacity: 1;
+          }
           &:last-child {
             max-width: none;
             white-space: normal;
@@ -299,6 +299,7 @@ body.cms-ui {
         }
         .tooltip-text {
           position: absolute;
+          visibility: hidden;
           z-index: 1;
           bottom: 125%;
           left: 50%;


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/40157-mettere-il-tooltip-sotto-anziche-sopra

- fix tooltip visibility when the cursor is above the tooltip. The tooltip needs to disappear to show what's underneath