### PR TITLE
FEAT: new Ergo features

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -41,7 +41,7 @@ msgid "Add accordion item"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Alert
+# defaultMessage: Blocco alert
 msgid "Alert"
 msgstr ""
 
@@ -95,6 +95,11 @@ msgstr ""
 msgid "Cartella modulistica"
 msgstr ""
 
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Centrare i card
+msgid "Center block cards"
+msgstr ""
+
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 # defaultMessage: Cerca
 msgid "Cerca"
@@ -125,21 +130,6 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -298,6 +288,11 @@ msgstr ""
 msgid "In this section"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazione
+msgid "Info"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
 msgid "Inserisci il testo…"
@@ -392,7 +387,6 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra lo sfondo del blocco
 msgid "Mostra lo sfondo del blocco"
@@ -605,7 +599,6 @@ msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Titolo
 msgid "Titolo"
 msgstr ""
@@ -749,6 +742,11 @@ msgstr ""
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Vai alla ricerca per sezioni avanzata
 msgid "advandedSectionsFilters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+# defaultMessage: Centrare i card
+msgid "alignCards"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
@@ -1076,6 +1074,8 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore di sfondo
 msgid "bg_color"
 msgstr ""
@@ -1085,9 +1085,9 @@ msgstr ""
 msgid "biografia"
 msgstr ""
 
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore di sfondo
-msgid "block_bg_color"
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Colore
+msgid "border_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
@@ -1123,6 +1123,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Mostra l'immagine
 msgid "cardImageEnable"
+msgstr ""
+
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Colore di sfondo
+msgid "card_bg_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
@@ -1194,15 +1199,35 @@ msgstr ""
 msgid "closeSearch"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Primario
 msgid "color_primary"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioComeAccedere
@@ -2103,11 +2128,6 @@ msgstr ""
 #: helpers/ListingHelper
 # defaultMessage: Questo evento ha più date: vedi tutte
 msgid "listing_event_recurrence_label"
-msgstr ""
-
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore dell'elemento
-msgid "listing_items_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -80,6 +80,7 @@ msgstr ""
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -40,11 +40,6 @@ msgstr ""
 msgid "Add accordion item"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Blocco alert
-msgid "Alert"
-msgstr ""
-
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Allow Externals
 msgid "Allow Externals"
@@ -286,11 +281,6 @@ msgstr ""
 #: components/ItaliaTheme/View/PageView/PageView
 # defaultMessage: In questa sezione
 msgid "In this section"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Blocco informazione
-msgid "Info"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/CountDown/Edit
@@ -1083,6 +1073,16 @@ msgstr ""
 #: components/ItaliaTheme/View/PersonaView/PersonaRuolo
 # defaultMessage: Biografia
 msgid "biografia"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Blocco alert
+msgid "blocco_alert"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazioni
+msgid "blocco_info"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -25,11 +25,6 @@ msgstr "Login to your personal area"
 msgid "Add accordion item"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Blocco alert
-msgid "Alert"
-msgstr ""
-
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Allow Externals
 msgid "Allow Externals"
@@ -272,11 +267,6 @@ msgstr "Cookies settings"
 # defaultMessage: In questa sezione
 msgid "In this section"
 msgstr "In this section"
-
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Blocco informazione
-msgid "Info"
-msgstr ""
 
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
@@ -1069,6 +1059,16 @@ msgstr ""
 # defaultMessage: Biografia
 msgid "biografia"
 msgstr "Biography"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Blocco alert
+msgid "blocco_alert"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazioni
+msgid "blocco_info"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -65,6 +65,7 @@ msgstr "Show"
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -26,7 +26,7 @@ msgid "Add accordion item"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Alert
+# defaultMessage: Blocco alert
 msgid "Alert"
 msgstr ""
 
@@ -80,6 +80,11 @@ msgstr ""
 msgid "Cartella modulistica"
 msgstr "Forms folder"
 
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Centrare i card
+msgid "Center block cards"
+msgstr ""
+
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 # defaultMessage: Cerca
 msgid "Cerca"
@@ -110,21 +115,6 @@ msgstr "Click here to replace file"
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -283,6 +273,11 @@ msgstr "Cookies settings"
 msgid "In this section"
 msgstr "In this section"
 
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazione
+msgid "Info"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
 msgid "Inserisci il testo…"
@@ -377,7 +372,6 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra lo sfondo del blocco
 msgid "Mostra lo sfondo del blocco"
@@ -590,7 +584,6 @@ msgid "Title placeholder"
 msgstr "Title..."
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Titolo
 msgid "Titolo"
 msgstr ""
@@ -735,6 +728,11 @@ msgstr "View actions"
 # defaultMessage: Vai alla ricerca per sezioni avanzata
 msgid "advandedSectionsFilters"
 msgstr "Go to advanced search by sections"
+
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+# defaultMessage: Centrare i card
+msgid "alignCards"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Tutto
@@ -1061,6 +1059,8 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore di sfondo
 msgid "bg_color"
 msgstr ""
@@ -1070,9 +1070,9 @@ msgstr ""
 msgid "biografia"
 msgstr "Biography"
 
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore di sfondo
-msgid "block_bg_color"
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Colore
+msgid "border_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
@@ -1108,6 +1108,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Mostra l'immagine
 msgid "cardImageEnable"
+msgstr ""
+
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Colore di sfondo
+msgid "card_bg_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
@@ -1179,15 +1184,35 @@ msgstr "close"
 msgid "closeSearch"
 msgstr "Close search"
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Primario
 msgid "color_primary"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioComeAccedere
@@ -2089,11 +2114,6 @@ msgstr "Useful links"
 # defaultMessage: Questo evento ha più date: vedi tutte
 msgid "listing_event_recurrence_label"
 msgstr "This event has multiple dates: see all"
-
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore dell'elemento
-msgid "listing_items_color"
-msgstr ""
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -43,7 +43,7 @@ msgid "Add accordion item"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Alert
+# defaultMessage: Blocco alert
 msgid "Alert"
 msgstr "Alerte"
 
@@ -97,6 +97,11 @@ msgstr ""
 msgid "Cartella modulistica"
 msgstr "Dossier de formulaires"
 
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Centrare i card
+msgid "Center block cards"
+msgstr ""
+
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 # defaultMessage: Cerca
 msgid "Cerca"
@@ -127,21 +132,6 @@ msgstr "Cliquez ici pour remplacer le fichier"
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -300,6 +290,11 @@ msgstr "Paramètres des cookies"
 msgid "In this section"
 msgstr "Dans cette section"
 
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazione
+msgid "Info"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
 msgid "Inserisci il testo…"
@@ -394,7 +389,6 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra lo sfondo del blocco
 msgid "Mostra lo sfondo del blocco"
@@ -607,7 +601,6 @@ msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Titolo
 msgid "Titolo"
 msgstr ""
@@ -752,6 +745,11 @@ msgstr "Voir les actions"
 # defaultMessage: Vai alla ricerca per sezioni avanzata
 msgid "advandedSectionsFilters"
 msgstr "Aller à la recherche avancée par rubrique"
+
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+# defaultMessage: Centrare i card
+msgid "alignCards"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Tutto
@@ -1078,6 +1076,8 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore di sfondo
 msgid "bg_color"
 msgstr ""
@@ -1087,9 +1087,9 @@ msgstr ""
 msgid "biografia"
 msgstr "Biographie"
 
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore di sfondo
-msgid "block_bg_color"
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Colore
+msgid "border_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
@@ -1125,6 +1125,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Mostra l'immagine
 msgid "cardImageEnable"
+msgstr ""
+
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Colore di sfondo
+msgid "card_bg_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
@@ -1196,15 +1201,35 @@ msgstr "Fermer"
 msgid "closeSearch"
 msgstr "Fermer la recherche"
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Primario
 msgid "color_primary"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioComeAccedere
@@ -2106,11 +2131,6 @@ msgstr "Liens utiles"
 # defaultMessage: Questo evento ha più date: vedi tutte
 msgid "listing_event_recurrence_label"
 msgstr "Cet événement a plusieurs dates: tout voir"
-
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore dell'elemento
-msgid "listing_items_color"
-msgstr ""
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -42,11 +42,6 @@ msgstr "Accéder à l'espace personnel"
 msgid "Add accordion item"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Blocco alert
-msgid "Alert"
-msgstr "Alerte"
-
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Allow Externals
 msgid "Allow Externals"
@@ -289,11 +284,6 @@ msgstr "Paramètres des cookies"
 # defaultMessage: In questa sezione
 msgid "In this section"
 msgstr "Dans cette section"
-
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Blocco informazione
-msgid "Info"
-msgstr ""
 
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
@@ -1086,6 +1076,16 @@ msgstr ""
 # defaultMessage: Biografia
 msgid "biografia"
 msgstr "Biographie"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Blocco alert
+msgid "blocco_alert"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazioni
+msgid "blocco_info"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -82,6 +82,7 @@ msgstr "Voir"
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -26,9 +26,9 @@ msgid "Add accordion item"
 msgstr "Aggiungi un elemento"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Alert
+# defaultMessage: Blocco alert
 msgid "Alert"
-msgstr "Alert"
+msgstr "Blocco alert"
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Allow Externals
@@ -80,6 +80,11 @@ msgstr ""
 msgid "Cartella modulistica"
 msgstr "Cartella modulistica"
 
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Centrare i card
+msgid "Center block cards"
+msgstr "Centrare i card"
+
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 # defaultMessage: Cerca
 msgid "Cerca"
@@ -111,21 +116,6 @@ msgstr "Clicca qui per sostituire il file"
 # defaultMessage: Colore
 msgid "Color"
 msgstr "Colore"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr "Rosso"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr "Giallo"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
-msgstr "Arancione"
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
 # defaultMessage: Contatti
@@ -283,6 +273,11 @@ msgstr ""
 msgid "In this section"
 msgstr "In questa sezione"
 
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazione
+msgid "Info"
+msgstr "Blocco informazione"
+
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
 msgid "Inserisci il testo…"
@@ -377,7 +372,6 @@ msgstr "Mostra i filtri per percorso"
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra lo sfondo del blocco
 msgid "Mostra lo sfondo del blocco"
@@ -590,7 +584,6 @@ msgid "Title placeholder"
 msgstr "Titolo..."
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Titolo
 msgid "Titolo"
 msgstr "Titolo"
@@ -735,6 +728,11 @@ msgstr "Vedi azioni"
 # defaultMessage: Vai alla ricerca per sezioni avanzata
 msgid "advandedSectionsFilters"
 msgstr ""
+
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+# defaultMessage: Centrare i card
+msgid "alignCards"
+msgstr "Centrare i card"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Tutto
@@ -1061,6 +1059,8 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore di sfondo
 msgid "bg_color"
 msgstr "Colore di sfondo"
@@ -1070,10 +1070,10 @@ msgstr "Colore di sfondo"
 msgid "biografia"
 msgstr "Biografia"
 
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore di sfondo
-msgid "block_bg_color"
-msgstr "Colore di sfondo"
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Colore
+msgid "border_color"
+msgstr "Colore"
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 # defaultMessage: Calendario
@@ -1109,6 +1109,11 @@ msgstr "Seleziona l'immagine da mostrare"
 # defaultMessage: Mostra l'immagine
 msgid "cardImageEnable"
 msgstr "Mostra l'immagine"
+
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Colore di sfondo
+msgid "card_bg_color"
+msgstr "Colore di sfondo"
 
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/Listing/TemplatesSkeletons/CardWithSlideUpTextTemplateSkeleton
@@ -1179,16 +1184,36 @@ msgstr "chiudi"
 msgid "closeSearch"
 msgstr "Chiudi ricerca"
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr "Rosso"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr "Arancione"
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Primario
 msgid "color_primary"
 msgstr "Colore primario"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
 msgstr "Trasparente"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
+msgstr "Giallo"
 
 #: components/ItaliaTheme/View/ServizioView/ServizioComeAccedere
 # defaultMessage: Come si fa
@@ -2089,11 +2114,6 @@ msgstr "Link utili"
 # defaultMessage: Questo evento ha più date: vedi tutte
 msgid "listing_event_recurrence_label"
 msgstr "Questo evento ha più date: vedi tutte"
-
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore dell'elemento
-msgid "listing_items_color"
-msgstr "Colore dell'elemento"
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -25,11 +25,6 @@ msgstr "Accedi all'area personale"
 msgid "Add accordion item"
 msgstr "Aggiungi un elemento"
 
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Blocco alert
-msgid "Alert"
-msgstr "Blocco alert"
-
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Allow Externals
 msgid "Allow Externals"
@@ -272,11 +267,6 @@ msgstr ""
 # defaultMessage: In questa sezione
 msgid "In this section"
 msgstr "In questa sezione"
-
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Blocco informazione
-msgid "Info"
-msgstr "Blocco informazione"
 
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
@@ -1069,6 +1059,16 @@ msgstr "Colore di sfondo"
 # defaultMessage: Biografia
 msgid "biografia"
 msgstr "Biografia"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Blocco alert
+msgid "blocco_alert"
+msgstr "Blocco alert"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazioni
+msgid "blocco_info"
+msgstr "Blocco informazioni"
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -65,10 +65,11 @@ msgstr "Vedi"
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
-msgstr ""
+msgstr "Dimensione immagine"
 
 #: config/Views/views
 # defaultMessage: Cartella modulistica

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-04-26T13:45:10.282Z\n"
+"POT-Creation-Date: 2023-04-27T07:59:08.112Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -25,11 +25,6 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
 # defaultMessage: Aggiungi elemento
 msgid "Add accordion item"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Blocco alert
-msgid "Alert"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
@@ -273,11 +268,6 @@ msgstr ""
 #: components/ItaliaTheme/View/PageView/PageView
 # defaultMessage: In questa sezione
 msgid "In this section"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Blocco informazione
-msgid "Info"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/CountDown/Edit
@@ -1070,6 +1060,16 @@ msgstr ""
 #: components/ItaliaTheme/View/PersonaView/PersonaRuolo
 # defaultMessage: Biografia
 msgid "biografia"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Blocco alert
+msgid "blocco_alert"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazioni
+msgid "blocco_info"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-04-27T07:59:08.112Z\n"
+"POT-Creation-Date: 2023-04-28T08:29:06.188Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -67,6 +67,7 @@ msgstr ""
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-03-08T16:36:56.204Z\n"
+"POT-Creation-Date: 2023-04-26T13:45:10.282Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -28,7 +28,7 @@ msgid "Add accordion item"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Alert
+# defaultMessage: Blocco alert
 msgid "Alert"
 msgstr ""
 
@@ -82,6 +82,11 @@ msgstr ""
 msgid "Cartella modulistica"
 msgstr ""
 
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Centrare i card
+msgid "Center block cards"
+msgstr ""
+
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 # defaultMessage: Cerca
 msgid "Cerca"
@@ -112,21 +117,6 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -285,6 +275,11 @@ msgstr ""
 msgid "In this section"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Blocco informazione
+msgid "Info"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/CountDown/Edit
 # defaultMessage: Inserisci il testo…
 msgid "Inserisci il testo…"
@@ -379,7 +374,6 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra lo sfondo del blocco
 msgid "Mostra lo sfondo del blocco"
@@ -592,7 +586,6 @@ msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
-#: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Titolo
 msgid "Titolo"
 msgstr ""
@@ -736,6 +729,11 @@ msgstr ""
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Vai alla ricerca per sezioni avanzata
 msgid "advandedSectionsFilters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+# defaultMessage: Centrare i card
+msgid "alignCards"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
@@ -1063,6 +1061,8 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Colore di sfondo
 msgid "bg_color"
 msgstr ""
@@ -1072,9 +1072,9 @@ msgstr ""
 msgid "biografia"
 msgstr ""
 
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore di sfondo
-msgid "block_bg_color"
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Colore
+msgid "border_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
@@ -1110,6 +1110,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Mostra l'immagine
 msgid "cardImageEnable"
+msgstr ""
+
+#: config/Blocks/ListingOptions/defaultOptions
+# defaultMessage: Colore di sfondo
+msgid "card_bg_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
@@ -1181,15 +1186,35 @@ msgstr ""
 msgid "closeSearch"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Primario
 msgid "color_primary"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/IconBlocks/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioComeAccedere
@@ -2090,11 +2115,6 @@ msgstr ""
 #: helpers/ListingHelper
 # defaultMessage: Questo evento ha più date: vedi tutte
 msgid "listing_event_recurrence_label"
-msgstr ""
-
-#: config/Blocks/ListingOptions/defaultOptions
-# defaultMessage: Colore dell'elemento
-msgid "listing_items_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock

--- a/src/components/ItaliaTheme/Blocks/Alert/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Edit.jsx
@@ -79,7 +79,9 @@ class Edit extends Component {
                     <img
                       src={`data:${this.props.data.image['content-type']};${this.props.data.image.encoding},${this.props.data.image.data}`}
                       alt=""
-                      className="left-image"
+                      className={cx('left-image', [
+                        'size-' + this.props.data.sizeImage,
+                      ])}
                     />
                   </Col>
                 )}

--- a/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Segment } from 'semantic-ui-react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { FileWidget, FormFieldWrapper } from '@plone/volto/components';
+import { FileWidget } from '@plone/volto/components';
 import { ColorListWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import ImageSizeWidget from '@plone/volto/components/manage/Widgets/ImageSizeWidget';
 
@@ -27,8 +27,8 @@ const messages = defineMessages({
     id: 'Image',
     defaultMessage: 'Immagine',
   },
-  size_image: {
-    id: 'size_image',
+  CardImageSize: {
+    id: 'CardImageSize',
     defaultMessage: 'Dimensione immagine',
   },
   CardImageSize: {
@@ -94,7 +94,7 @@ class Sidebar extends Component {
           />
           <ImageSizeWidget
             id="sizeImage"
-            title={this.props.intl.formatMessage(messages.size_image)}
+            title={this.props.intl.formatMessage(messages.CardImageSize)}
             onChange={(name, value) => {
               this.props.onChangeBlock(this.props.block, {
                 ...this.props.data,

--- a/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
@@ -55,7 +55,7 @@ class Sidebar extends Component {
       <Segment.Group raised>
         <header className="header pulled">
           <h2>
-            <FormattedMessage id="Alert" defaultMessage="Blocco alert" />
+            <FormattedMessage id="blocco_alert" defaultMessage="Blocco alert" />
           </h2>
         </header>
 

--- a/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
@@ -2,8 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Segment } from 'semantic-ui-react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { FileWidget } from '@plone/volto/components';
+import { FileWidget, FormFieldWrapper } from '@plone/volto/components';
 import { ColorListWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import ImageSizeWidget from '@plone/volto/components/manage/Widgets/ImageSizeWidget';
 
 const messages = defineMessages({
   Color: {
@@ -25,6 +26,14 @@ const messages = defineMessages({
   Image: {
     id: 'Image',
     defaultMessage: 'Immagine',
+  },
+  size_image: {
+    id: 'size_image',
+    defaultMessage: 'Dimensione immagine',
+  },
+  CardImageSize: {
+    id: 'CardImageSize',
+    defaultMessage: 'Dimensione immagine',
   },
 });
 
@@ -82,6 +91,17 @@ class Sidebar extends Component {
                 image: value,
               });
             }}
+          />
+          <ImageSizeWidget
+            id="sizeImage"
+            title={this.props.intl.formatMessage(messages.size_image)}
+            onChange={(name, value) => {
+              this.props.onChangeBlock(this.props.block, {
+                ...this.props.data,
+                sizeImage: value,
+              });
+            }}
+            value={this.props.data.sizeImage}
           />
         </Segment>
       </Segment.Group>

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Edit.jsx
@@ -56,12 +56,18 @@ class Edit extends SubblocksEdit {
       return <div />;
     }
 
+    if (!this.props.data.bg_color) {
+      this.props.data.bg_color = 'primary';
+    }
+
     return (
       <div className="public-ui">
         <div className="full-width section py-5">
           {this.props.data.background?.[0] ? (
             <div
-              className="background-image"
+              className={cx('background-image', {
+                [this.props.data.bg_color]: this.props.data.bg_color,
+              })}
               style={{
                 backgroundImage: `url(${
                   this.props.data.background[0]?.image?.scales?.huge
@@ -71,7 +77,11 @@ class Edit extends SubblocksEdit {
               }}
             ></div>
           ) : (
-            <div className="background-image"></div>
+            <div
+              className={cx('background-image', {
+                [this.props.data.bg_color]: this.props.data.bg_color,
+              })}
+            ></div>
           )}
 
           <Container className="px-md-4">

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Edit.jsx
@@ -20,6 +20,7 @@ import { TextEditorWidget } from 'design-comuni-plone-theme/components/ItaliaThe
 
 import EditBlock from './Block/EditBlock';
 import Sidebar from './Sidebar.jsx';
+import cx from 'classnames';
 
 const messages = defineMessages({
   addItem: {
@@ -117,7 +118,7 @@ class Edit extends SubblocksEdit {
             </div>
 
             <SubblocksWrapper node={this.node}>
-              <Row>
+              <Row className={cx({ center: this.props.data.alignCards })}>
                 {this.state.subblocks.map((subblock, subindex) => (
                   <Col lg="4" xl="3" key={subblock.id}>
                     <EditBlock

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Sidebar.jsx
@@ -11,6 +11,7 @@ import {
   ObjectBrowserWidget,
   CheckboxWidget,
 } from '@plone/volto/components';
+import { ColorListWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
 
@@ -37,6 +38,22 @@ const messages = defineMessages({
     id: 'alignCards',
     defaultMessage: 'Centrare i card',
   },
+  bg_color: {
+    id: 'bg_color',
+    defaultMessage: 'Colore di sfondo',
+  },
+  color_primary: {
+    id: 'color_primary',
+    defaultMessage: 'Primario',
+  },
+  color_secondary: {
+    id: 'color_primary',
+    defaultMessage: 'Primario',
+  },
+  color_transparent: {
+    id: 'color_transparent',
+    defaultMessage: 'Trasparente',
+  },
 });
 
 const Sidebar = ({
@@ -49,6 +66,17 @@ const Sidebar = ({
   openObjectBrowser,
 }) => {
   const intl = useIntl();
+
+  const bg_colors = [
+    {
+      name: 'transparent',
+      label: intl.formatMessage(messages.color_transparent),
+    },
+    { name: 'primary', label: intl.formatMessage(messages.color_primary) },
+    { name: 'secondary', label: intl.formatMessage(messages.color_secondary) },
+  ];
+
+  console.log(data.bg_color);
 
   return (
     <Segment.Group raised>
@@ -82,6 +110,18 @@ const Sidebar = ({
             onChange={(name, checked) => {
               onChangeBlock(block, { ...data, [name]: checked });
             }}
+          />
+          <ColorListWidget
+            id="bg_color"
+            title={intl.formatMessage(messages.bg_color)}
+            value={data.bg_color}
+            onChange={(id, value) => {
+              onChangeBlock(block, {
+                ...data,
+                [id]: value,
+              });
+            }}
+            colors={bg_colors}
           />
           <TextWidget
             id="linkMoreTitle"

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Sidebar.jsx
@@ -76,8 +76,6 @@ const Sidebar = ({
     { name: 'secondary', label: intl.formatMessage(messages.color_secondary) },
   ];
 
-  console.log(data.bg_color);
-
   return (
     <Segment.Group raised>
       <header className="header pulled">

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Sidebar.jsx
@@ -5,7 +5,12 @@ import { Segment, Accordion } from 'semantic-ui-react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import redraft from 'redraft';
 
-import { TextWidget, Icon, ObjectBrowserWidget } from '@plone/volto/components';
+import {
+  TextWidget,
+  Icon,
+  ObjectBrowserWidget,
+  CheckboxWidget,
+} from '@plone/volto/components';
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
 
@@ -26,6 +31,11 @@ const messages = defineMessages({
   backgroundImage: {
     id: 'backgroundImage',
     defaultMessage: 'Immagine di sfondo',
+  },
+
+  alignCards: {
+    id: 'alignCards',
+    defaultMessage: 'Centrare i card',
   },
 });
 
@@ -64,6 +74,14 @@ const Sidebar = ({
             onChange={(id, value) =>
               onChangeBlock(block, { ...data, [id]: value })
             }
+          />
+          <CheckboxWidget
+            id="alignCards"
+            title={intl.formatMessage(messages.alignCards)}
+            value={data.alignCards ? data.alignCards : false}
+            onChange={(name, checked) => {
+              onChangeBlock(block, { ...data, [name]: checked });
+            }}
           />
           <TextWidget
             id="linkMoreTitle"

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -27,7 +27,9 @@ const AccordionView = ({ data, block }) => {
         <div className="full-width section py-5">
           {data.background?.[0] ? (
             <div
-              className="background-image"
+              className={cx('background-image', {
+                [data.bg_color]: data.bg_color,
+              })}
               style={{
                 backgroundImage: `url(${
                   data.background[0]?.image?.scales?.huge?.download ??
@@ -36,7 +38,11 @@ const AccordionView = ({ data, block }) => {
               }}
             ></div>
           ) : (
-            <div className="background-image"></div>
+            <div
+              className={cx('background-image', {
+                [data.bg_color]: data.bg_color,
+              })}
+            ></div>
           )}
           <Container className="px-md-4">
             <div className="block-header">

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -11,6 +11,7 @@ import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL, addAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
 import config from '@plone/volto/registry';
+import cx from 'classnames';
 
 /**
  * View Accordion block class.
@@ -58,7 +59,7 @@ const AccordionView = ({ data, block }) => {
                 </div>
               )}
             </div>
-            <Row>
+            <Row className={cx({ center: data.alignCards })}>
               {data.subblocks.map((subblock, index) => (
                 <Col lg="4" xl="3" key={subblock.id}>
                   <ViewBlock

--- a/src/components/ItaliaTheme/Blocks/Info/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/Edit.jsx
@@ -80,7 +80,7 @@ class Edit extends Component {
           >
             <Container className="ui">
               <Row className="align-items-start">
-                <Col sm={2} className="pb-3 image-col">
+                <Col sm={1} className="pb-3 image-col">
                   <Icon
                     className="left-image"
                     icon="it-info-circle"

--- a/src/components/ItaliaTheme/Blocks/Info/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/Edit.jsx
@@ -1,0 +1,130 @@
+/**
+ * Edit Alert block.
+ * @module components/manage/Blocks/Image/Edit
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { injectIntl } from 'react-intl';
+import cx from 'classnames';
+import {
+  Container,
+  Row,
+  Col,
+  Icon,
+} from 'design-react-kit/dist/design-react-kit';
+
+import { createContent } from '@plone/volto/actions';
+import { SidebarPortal } from '@plone/volto/components';
+import { EditTextBlock } from '@plone/volto/components';
+
+import { InfoSidebar } from 'design-comuni-plone-theme/components/ItaliaTheme';
+/**
+ * Edit Alert block class.
+ * @class Edit
+ * @extends Component
+ */
+class Edit extends Component {
+  /**
+   * Property types.
+   * @property {Object} propTypes Property types.
+   * @static
+   */
+  static propTypes = {
+    selected: PropTypes.bool.isRequired,
+    block: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    data: PropTypes.objectOf(PropTypes.any).isRequired,
+    content: PropTypes.objectOf(PropTypes.any).isRequired,
+    request: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
+    pathname: PropTypes.string.isRequired,
+    onChangeBlock: PropTypes.func.isRequired,
+    onSelectBlock: PropTypes.func.isRequired,
+    onDeleteBlock: PropTypes.func.isRequired,
+    onFocusPreviousBlock: PropTypes.func.isRequired,
+    onFocusNextBlock: PropTypes.func.isRequired,
+    handleKeyDown: PropTypes.func.isRequired,
+    createContent: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    if (!this.props.data.color) {
+      this.props.data.color = 'warning';
+    }
+    this.blockNode = React.createRef();
+  }
+
+  render() {
+    if (__SERVER__) {
+      return <div />;
+    }
+    return (
+      <div className="public-ui">
+        <div
+          className={cx('infoblock', {
+            selected: this.props.selected,
+          })}
+        >
+          <Row
+            className={cx('py-3', {
+              ['bg-alert-' + this.props.data.color]: this.props.data.color,
+              ['bg-color-' + this.props.data.bg_color]:
+                this.props.data.bg_color,
+            })}
+          >
+            <Container className="ui">
+              <Row className="align-items-start">
+                <Col sm={2} className="pb-3 image-col">
+                  <Icon
+                    className="left-image"
+                    icon="it-info-circle"
+                    size="lg"
+                    loading="lazy"
+                  />
+                </Col>
+
+                <Col>
+                  <EditTextBlock
+                    data={this.props.data}
+                    detached={true}
+                    index={this.props.index}
+                    selected={this.props.selected}
+                    block={this.props.block}
+                    onAddBlock={this.props.onAddBlock}
+                    onChangeBlock={this.props.onChangeBlock}
+                    onDeleteBlock={this.props.onDeleteBlock}
+                    onMutateBlock={this.props.onMutateBlock}
+                    onFocusPreviousBlock={this.props.onFocusPreviousBlock}
+                    onFocusNextBlock={this.props.onFocusNextBlock}
+                    onSelectBlock={this.props.onSelectBlock}
+                    blockNode={this.blockNode}
+                  />
+                </Col>
+              </Row>
+            </Container>
+          </Row>
+        </div>
+        <SidebarPortal selected={this.props.selected}>
+          <InfoSidebar {...this.props} />
+        </SidebarPortal>
+      </div>
+    );
+  }
+}
+
+export default compose(
+  injectIntl,
+  connect(
+    (state) => ({
+      request: state.content.create,
+      content: state.content.data,
+    }),
+    { createContent },
+  ),
+)(Edit);

--- a/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
@@ -2,12 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Segment } from 'semantic-ui-react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { FileWidget } from '@plone/volto/components';
 import { ColorListWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { CheckboxWidget } from '@plone/volto/components';
 
 const messages = defineMessages({
-  Color: {
-    id: 'Color',
+  border_color: {
+    id: 'border_color',
     defaultMessage: 'Colore',
   },
   color_warning: {
@@ -22,9 +22,9 @@ const messages = defineMessages({
     id: 'color_danger',
     defaultMessage: 'Rosso',
   },
-  Image: {
-    id: 'Image',
-    defaultMessage: 'Immagine',
+  bg_color: {
+    id: 'bg_color',
+    defaultMessage: 'Colore di sfondo',
   },
 });
 
@@ -55,14 +55,14 @@ class Sidebar extends Component {
       <Segment.Group raised>
         <header className="header pulled">
           <h2>
-            <FormattedMessage id="Alert" defaultMessage="Blocco alert" />
+            <FormattedMessage id="Info" defaultMessage="Blocco informazione" />
           </h2>
         </header>
 
         <Segment className="form">
           <ColorListWidget
             id="color"
-            title={this.props.intl.formatMessage(messages.Color)}
+            title={this.props.intl.formatMessage(messages.border_color)}
             value={this.props.data.border_color}
             onChange={(id, value) => {
               this.props.onChangeBlock(this.props.block, {
@@ -72,14 +72,14 @@ class Sidebar extends Component {
             }}
             colors={bg_colors}
           />
-          <FileWidget
-            id="image"
-            title={this.props.intl.formatMessage(messages.Image)}
-            value={this.props.data.image}
-            onChange={(name, value) => {
+          <CheckboxWidget
+            id="bg_color"
+            title={this.props.intl.formatMessage(messages.bg_color)}
+            value={this.props.data.bg_color ? this.props.data.bg_color : false}
+            onChange={(name, checked) => {
               this.props.onChangeBlock(this.props.block, {
                 ...this.props.data,
-                image: value,
+                [name]: checked,
               });
             }}
           />

--- a/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
@@ -55,7 +55,10 @@ class Sidebar extends Component {
       <Segment.Group raised>
         <header className="header pulled">
           <h2>
-            <FormattedMessage id="Info" defaultMessage="Blocco informazione" />
+            <FormattedMessage
+              id="blocco_info"
+              defaultMessage="Blocco informazioni"
+            />
           </h2>
         </header>
 

--- a/src/components/ItaliaTheme/Blocks/Info/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/View.jsx
@@ -1,0 +1,71 @@
+/**
+ * View Alert block.
+ * @module components/manage/Blocks/Hero/View
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import redraft from 'redraft';
+import {
+  Container,
+  Row,
+  Col,
+  Icon,
+} from 'design-react-kit/dist/design-react-kit';
+//import { isCmsUi } from '@plone/volto/helpers';
+import config from '@plone/volto/registry';
+
+/**
+ * View Alert block class.
+ * @class View
+ * @extends Component
+ */
+const View = ({ data, pathname }) => {
+  //const isCmsUI = pathname ? isCmsUi(pathname) : false
+
+  const content = data.text
+    ? redraft(
+        data.text,
+        config.settings.richtextViewSettings.ToHTMLRenderers,
+        config.settings.richtextViewSettings.ToHTMLOptions,
+      )
+    : '';
+
+  return (
+    <section role="alert" className="block infoblock">
+      <Row
+        className={cx('py-3', {
+          ['bg-alert-' + data.color]: data.color,
+          ['bg-color-' + data.bg_color]: data.bg_color,
+        })}
+      >
+        <Container>
+          <Row className="align-items-start">
+            <Col sm={2} className="pb-3 image-col">
+              <Icon
+                className="left-image"
+                icon="it-info-circle"
+                size="lg"
+                loading="lazy"
+              />
+            </Col>
+
+            <Col>{content}</Col>
+          </Row>
+        </Container>
+      </Row>
+    </section>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+View.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default React.memo(View);

--- a/src/components/ItaliaTheme/Blocks/Info/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/View.jsx
@@ -42,7 +42,7 @@ const View = ({ data, pathname }) => {
       >
         <Container>
           <Row className="align-items-start">
-            <Col sm={2} className="pb-3 image-col">
+            <Col sm={1} className="pb-3 image-col">
               <Icon
                 className="left-image"
                 icon="it-info-circle"

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -76,6 +76,7 @@ const BandiInEvidenceTemplate = ({
   show_description,
   linkTitle,
   linkHref,
+  center_cards,
 }) => {
   const intl = useIntl();
 
@@ -91,7 +92,11 @@ const BandiInEvidenceTemplate = ({
             </Col>
           </Row>
         )}
-        <div className="bandi-in-evidence-cards-wrapper mb-5">
+        <div
+          className={cx('bandi-in-evidence-cards-wrapper mb-5', {
+            'center-cards': center_cards,
+          })}
+        >
           {items.map((item, index) => {
             const listingText = <ListingText item={item} />;
             return (

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -53,6 +53,7 @@ const CardWithImageTemplate = (props) => {
     hide_dates = false,
     natural_image_size = false,
     id_lighthouse,
+    center_cards,
   } = props;
 
   const imagesToShow = set_four_columns ? 4 : 3;
@@ -69,7 +70,7 @@ const CardWithImageTemplate = (props) => {
             </Col>
           </Row>
         )}
-        <Row className="items">
+        <Row className={cx('items', { 'center-cards': center_cards })}>
           {items.map((item, index) => {
             const icon = show_icon ? getItemIcon(item) : null;
             const date = hide_dates ? null : getCalendarDate(item);

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -26,6 +26,7 @@ const CompleteBlockLinksTemplate = ({
   show_description = true,
   id_lighthouse,
   center_cards,
+  bg_card_color = 'secondary',
 }) => {
   return (
     <div className="complete-block-links-template">
@@ -45,7 +46,7 @@ const CompleteBlockLinksTemplate = ({
               <Col md="6" lg="3" key={item['@id']} className="col-item">
                 <Card
                   color=""
-                  className="card-bg rounded"
+                  className={cx('card-bg rounded', bg_card_color)}
                   noWrapper={false}
                   tag="div"
                 >

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { UniversalLink } from '@plone/volto/components';
+import cx from 'classnames';
 import {
   Card,
   CardBody,
@@ -24,6 +25,7 @@ const CompleteBlockLinksTemplate = ({
   show_block_bg,
   show_description = true,
   id_lighthouse,
+  center_cards,
 }) => {
   return (
     <div className="complete-block-links-template">
@@ -35,7 +37,7 @@ const CompleteBlockLinksTemplate = ({
             </Col>
           </Row>
         )}
-        <Row className="items">
+        <Row className={cx('items', { 'center-cards': center_cards })}>
           {items.map((item, index) => {
             const image = ListingImage({ item, className: '' });
 

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -48,6 +48,7 @@ const InEvidenceTemplate = (props) => {
     linkTitle,
     linkHref,
     id_lighthouse,
+    center_cards,
   } = props;
 
   return (
@@ -62,7 +63,11 @@ const InEvidenceTemplate = (props) => {
             </Col>
           </Row>
         )}
-        <div className="in-evidence-cards-wrapper mb-5">
+        <div
+          className={cx('in-evidence-cards-wrapper mb-5', {
+            'center-cards': center_cards,
+          })}
+        >
           {items.map((item, index) => {
             const icon = show_icon ? getItemIcon(item) : null;
             const date = hide_dates ? null : getCalendarDate(item);

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -55,6 +55,7 @@ const RibbonCardTemplate = (props) => {
     show_type,
     hide_dates,
     id_lighthouse,
+    center_cards,
   } = props;
 
   return (
@@ -68,7 +69,7 @@ const RibbonCardTemplate = (props) => {
           </Row>
         )}
 
-        <Row className="mb-4">
+        <Row className={cx('mb-4', { 'center-cards': center_cards })}>
           {items.map((item, index) => {
             const itemTitle = item.title || item.id;
             const showRibbon =

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -25,6 +25,7 @@ const SimpleCardTemplateCompact = ({
   show_block_bg,
   title,
   id_lighthouse,
+  center_cards,
 }) => {
   return (
     <div className="simple-card-compact-template">
@@ -35,7 +36,12 @@ const SimpleCardTemplateCompact = ({
           </Col>
         </Row>
       )}
-      <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3 mb-3">
+      <div
+        className={cx(
+          'card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3 mb-3',
+          { 'center-cards': center_cards },
+        )}
+      >
         {items.map((item, index) => (
           <Card
             className="align-items-center rounded shadow"

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -57,6 +57,7 @@ const SimpleCardTemplateDefault = (props) => {
     addFilters,
     additionalFilters = [],
     id_lighthouse,
+    center_cards,
   } = props;
 
   let currentPathFilter = additionalFilters
@@ -156,7 +157,12 @@ const SimpleCardTemplateDefault = (props) => {
         </Row>
       )}
 
-      <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3 mb-3">
+      <div
+        className={cx(
+          'card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3 mb-3',
+          { 'center-cards': center_cards },
+        )}
+      >
         {items.map((item, index) => {
           const icon = show_icon ? getItemIcon(item) : null;
           const itemTitle = item.title || item.id;

--- a/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { UniversalLink } from '@plone/volto/components';
+import cx from 'classnames';
 
 import {
   ListingLinkMore,
@@ -15,6 +16,7 @@ const SmallBlockLinksTemplate = ({
   show_block_bg,
   linkTitle,
   linkHref,
+  center_cards,
 }) => {
   return (
     <div className="small-block-links">
@@ -26,7 +28,7 @@ const SmallBlockLinksTemplate = ({
             </Col>
           </Row>
         )}
-        <Row className="items">
+        <Row className={cx('items', { 'center-cards': center_cards })}>
           {items.map((item, index) => {
             const image = ListingImage({ item, maxSize: 200, style: {} });
 

--- a/src/components/ItaliaTheme/index.js
+++ b/src/components/ItaliaTheme/index.js
@@ -67,6 +67,7 @@ export CustomerSatisfaction from 'design-comuni-plone-theme/components/ItaliaThe
 
 /********* BLOCKS ********* */
 export AlertSidebar from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Alert/Sidebar';
+export InfoSidebar from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Info/Sidebar';
 export BlockSearchSectionsSidebar from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/SearchSections/SideBar';
 export BlockSearchSectionsBody from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/SearchSections/Body';
 export ArgumentsInEvidenceBackground from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Background';

--- a/src/components/ItaliaTheme/manage/Widgets/ColorListWidget.jsx
+++ b/src/components/ItaliaTheme/manage/Widgets/ColorListWidget.jsx
@@ -44,16 +44,8 @@ class ColorListWidget extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
-    const {
-      id,
-      title,
-      required,
-      value,
-      onChange,
-      intl,
-      colors,
-      className,
-    } = this.props;
+    const { id, title, required, value, onChange, intl, colors, className } =
+      this.props;
 
     return colors.length > 0 ? (
       <Form.Field

--- a/src/config/Blocks/ListingOptions/completeBlockLinksTemplate.js
+++ b/src/config/Blocks/ListingOptions/completeBlockLinksTemplate.js
@@ -1,6 +1,7 @@
 import {
   templatesOptions,
   addDefaultOptions,
+  addSchemaField,
 } from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
 
 import { addLighthouseField } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/utils';
@@ -12,10 +13,24 @@ export const addCompleteBlockLinksTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+  let listing_items_colors = [
+    { name: 'transparent', label: 'Trasparente' },
+    { name: 'primary', label: 'Primario' },
+    { name: 'secondary', label: 'Secondario' },
+  ];
 
   pos = addLighthouseField(schema, intl, pos);
 
   pos = addDefaultOptions(schema, formData, intl, pos);
+
+  pos = addSchemaField(
+    schema,
+    'bg_card_color',
+    'Sfondo card colore',
+    null,
+    { widget: 'color_list', intl: intl, colors: listing_items_colors },
+    pos,
+  );
 
   pos = templatesOptions(
     schema,

--- a/src/config/Blocks/ListingOptions/defaultOptions.js
+++ b/src/config/Blocks/ListingOptions/defaultOptions.js
@@ -1,86 +1,58 @@
 import { defineMessages } from 'react-intl';
-import {
-  addSchemaField,
-  addDefaultAdditionalOptions,
-} from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
+import { addSchemaField } from '@italia/config/Blocks/ListingOptions';
 
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
-  title: {
-    id: 'Titolo',
-    defaultMessage: 'Titolo',
+  center_cards: {
+    id: 'Center block cards',
+    defaultMessage: 'Centrare i card',
   },
-  show_block_bg: {
-    id: 'Mostra lo sfondo del blocco',
-    defaultMessage: 'Mostra lo sfondo del blocco',
-  },
-  items_color: {
-    id: 'listing_items_color',
-    defaultMessage: "Colore dell'elemento",
-  },
-  bg_color: {
-    id: 'block_bg_color',
+  card_bg_color: {
+    id: 'card_bg_color',
     defaultMessage: 'Colore di sfondo',
   },
 });
 
 /** DEFAULT **/
 
-const addDefaultOptions = (schema, formData, intl, position = 0) => {
-  let listing_items_colors =
-    config.blocks.blocksConfig.listing?.listing_items_colors || [];
-  let listing_bg_colors =
-    config.blocks.blocksConfig.listing?.listing_bg_colors || [];
-
+const addDefaultAdditionalOptions = (schema, formData, intl, position = 0) => {
   let pos = position;
-  addSchemaField(
-    schema,
-    'title',
-    intl.formatMessage(messages.title),
-    null,
-    null,
-    pos,
-  );
-  pos++;
-
-  if (listing_items_colors.length > 0) {
+  let listing_items_colors = [
+    { name: 'red', label: 'Red' },
+    { name: 'light-blue', label: 'Light blue' },
+    { name: 'sidebar-background', label: 'Grey' },
+  ];
+  if (
+    formData.variation === 'simpleCard' ||
+    formData.variation === 'completeBlockLinksTemplate' ||
+    formData.variation === 'cardWithImageTemplate' ||
+    formData.variation === 'ribbonCardTemplate' ||
+    formData.variation === 'smallBlockLinksTemplate' ||
+    formData.variation === 'bandiInEvidenceTemplate'
+  ) {
     addSchemaField(
       schema,
-      'items_color',
-      intl.formatMessage(messages.items_color),
+      'center_cards',
+      intl.formatMessage(messages.center_cards),
+      null,
+      { type: 'boolean', default: false },
+      pos,
+    );
+    pos++;
+  }
+
+  /* if (formData.variation === 'simpleCard') {
+    addSchemaField(
+      schema,
+      'card_bg_color',
+      intl.formatMessage(messages.card_bg_color),
       null,
       { widget: 'color_list', intl: intl, colors: listing_items_colors },
       pos,
     );
-    pos++;
-  }
-
-  addSchemaField(
-    schema,
-    'show_block_bg',
-    intl.formatMessage(messages.show_block_bg),
-    null,
-    { type: 'boolean' },
-    pos,
-  );
-  pos++;
-
-  if (listing_bg_colors.length > 0) {
-    addSchemaField(
-      schema,
-      'bg_color',
-      intl.formatMessage(messages.bg_color),
-      null,
-      { widget: 'color_list', intl: intl, colors: listing_bg_colors },
-      pos,
-    );
-    pos++;
-  }
-
-  pos = addDefaultAdditionalOptions(schema, formData, intl, pos);
-
+  } */
   return pos;
 };
 
-export default addDefaultOptions;
+export default addDefaultAdditionalOptions;

--- a/src/config/Blocks/blocks.js
+++ b/src/config/Blocks/blocks.js
@@ -9,7 +9,7 @@ import alertSVG from '@plone/volto/icons/alert.svg';
 import AlertView from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Alert/View';
 import AlertEdit from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Alert/Edit';
 
-import infoSVG from '@plone/volto/icons/alert.svg';
+import infoSVG from '@plone/volto/icons/info.svg';
 import InfoView from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Info/View';
 import InfoEdit from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Info/Edit';
 
@@ -212,7 +212,7 @@ const italiaBlocks = {
 
   info: {
     id: 'info',
-    title: 'Info',
+    title: 'Informazioni',
     icon: infoSVG,
     group: 'text',
     view: InfoView,

--- a/src/config/Blocks/blocks.js
+++ b/src/config/Blocks/blocks.js
@@ -9,6 +9,10 @@ import alertSVG from '@plone/volto/icons/alert.svg';
 import AlertView from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Alert/View';
 import AlertEdit from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Alert/Edit';
 
+import infoSVG from '@plone/volto/icons/alert.svg';
+import InfoView from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Info/View';
+import InfoEdit from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Info/Edit';
+
 import divideHorizontalSVG from '@plone/volto/icons/divide-horizontal.svg';
 import ViewBreak from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Break/View';
 import EditBreak from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Break/Edit';
@@ -196,6 +200,23 @@ const italiaBlocks = {
     group: 'text',
     view: AlertView,
     edit: AlertEdit,
+    restricted: false,
+    mostUsed: false,
+    blockHasOwnFocusManagement: true,
+    security: {
+      addPermission: [],
+      view: [],
+    },
+    sidebarTab: 1,
+  },
+
+  info: {
+    id: 'info',
+    title: 'Info',
+    icon: infoSVG,
+    group: 'text',
+    view: InfoView,
+    edit: InfoEdit,
     restricted: false,
     mostUsed: false,
     blockHasOwnFocusManagement: true,

--- a/theme/ItaliaTheme/Blocks/_alert.scss
+++ b/theme/ItaliaTheme/Blocks/_alert.scss
@@ -77,11 +77,9 @@
 
     img.left-image {
       object-fit: unset;
+      max-width: 80%;
       @media (min-width: #{map-get($grid-breakpoints, md)}) {
         &.size {
-          &-l {
-            max-height: 80%;
-          }
           &-m {
             max-width: 50%;
           }

--- a/theme/ItaliaTheme/Blocks/_alert.scss
+++ b/theme/ItaliaTheme/Blocks/_alert.scss
@@ -76,8 +76,20 @@
     }
 
     img.left-image {
-      max-width: 80%;
       object-fit: unset;
+      @media (min-width: #{map-get($grid-breakpoints, md)}) {
+        &.size {
+          &-l {
+            max-height: 80%;
+          }
+          &-m {
+            max-width: 50%;
+          }
+          &-s {
+            max-width: 30%;
+          }
+        }
+      }
     }
 
     .image-col {

--- a/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
@@ -29,11 +29,33 @@
     }
   }
 
-  .card.card-bg {
-    background-color: $secondary;
-
+  .card {
     a {
       color: $secondary-text;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    &.card-bg {
+      &.secondary {
+        background-color: $secondary;
+      }
+      &.primary {
+        background-color: $primary;
+      }
+      &.transparent {
+        .text-secondary {
+          color: $body-color !important;
+        }
+        a {
+          color: $body-color;
+          text-decoration: none;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
     }
   }
 

--- a/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -38,6 +38,11 @@
       content: '';
     }
   }
+  .container {
+    .row.center {
+      justify-content: center;
+    }
+  }
 
   .block-header {
     .title {

--- a/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -181,8 +181,8 @@
       }
 
       .icon {
-        width: 3.35rem;
-        height: auto;
+        width: auto;
+        height: 4rem;
         color: $tertiary;
       }
     }

--- a/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -167,7 +167,6 @@
     .iconblock-icon {
       margin-bottom: 2rem;
       text-align: center;
-      min-height: 5rem;
 
       .icon-placeholder {
         display: inline-block;

--- a/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -159,6 +159,7 @@
     .iconblock-icon {
       margin-bottom: 2rem;
       text-align: center;
+      min-height: 5rem;
 
       .icon-placeholder {
         display: inline-block;

--- a/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -34,8 +34,16 @@
       position: absolute;
       width: 100%;
       height: 100%;
-      background-color: rgba($primary, 0.85);
       content: '';
+    }
+    &.primary:after {
+      background-color: rgba($primary, 0.85);
+    }
+    &.secondary:after {
+      background-color: rgba($secondary, 0.85);
+    }
+    &.transparent:after {
+      background-color: none;
     }
   }
   .container {

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -1,28 +1,36 @@
 .public-ui {
-  .block.infoblock,
   .infoblock {
+    .bg-alert-warning-orange,
+    .bg-alert-warning,
+    .bg-alert-danger {
+      border-style: solid;
+      border-width: 2px 2px 2px 10px;
+    }
+
     .bg-alert-warning-orange,
     .bg-alert-warning {
       color: $black;
-      .public-DraftEditorPlaceholder-inner {
-        color: $black;
-      }
-
       h1,
       h2,
       h3,
       h4,
       h5,
-      h6 {
+      h6,
+      a,
+      .public-DraftEditorPlaceholder-inner {
         color: $black;
       }
-
-      a {
-        color: $black;
+      &.bg-color-true {
+        svg.icon,
+        .public-DraftEditorPlaceholder-inner {
+          fill: $black;
+          color: $black;
+        }
       }
     }
+
     .bg-alert-danger {
-      border: solid 2px #a32219;
+      border-color: #a32219;
       color: $black;
       svg.icon {
         fill: #a32219;
@@ -30,47 +38,23 @@
       &.bg-color-true {
         background-color: #a32219;
         color: #fff;
-        .public-DraftEditorPlaceholder-inner {
-          color: #fff;
-        }
-
+        svg.icon,
+        .public-DraftEditorPlaceholder-inner,
         h1,
         h2,
         h3,
         h4,
         h5,
-        h6 {
-          color: #fff;
-        }
-
+        h6,
         a {
           color: #fff;
-        }
-        svg.icon {
           fill: #fff;
         }
-      }
-
-      .public-DraftEditorPlaceholder-inner {
-        color: $black;
-      }
-
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        color: $black;
-      }
-
-      a {
-        color: $black;
       }
     }
 
     .bg-alert-warning-orange {
-      border: solid 2px #eb973f;
+      border-color: #eb973f;
       svg.icon {
         fill: #eb973f;
       }
@@ -80,8 +64,10 @@
     }
 
     .bg-alert-warning {
-      border: solid 2px #f0c250;
-
+      border-color: #f0c250;
+      svg.icon {
+        fill: #f0c250;
+      }
       &.bg-color-true {
         background-color: #f0c250;
       }

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -1,0 +1,121 @@
+.public-ui {
+  .block.infoblock,
+  .infoblock {
+    .bg-alert-warning-orange,
+    .bg-alert-warning {
+      color: $black;
+      .public-DraftEditorPlaceholder-inner {
+        color: $black;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        color: $black;
+      }
+
+      a {
+        color: $black;
+      }
+    }
+    .bg-alert-danger {
+      border: solid 2px #a32219;
+      color: $black;
+      svg.icon {
+        fill: #a32219;
+      }
+      &.bg-color-true {
+        background-color: #a32219;
+        color: #fff;
+        .public-DraftEditorPlaceholder-inner {
+          color: #fff;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+          color: #fff;
+        }
+
+        a {
+          color: #fff;
+        }
+        svg.icon {
+          fill: #fff;
+        }
+      }
+
+      .public-DraftEditorPlaceholder-inner {
+        color: $black;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        color: $black;
+      }
+
+      a {
+        color: $black;
+      }
+    }
+
+    .bg-alert-warning-orange {
+      border: solid 2px #eb973f;
+      svg.icon {
+        fill: #eb973f;
+      }
+      &.bg-color-true {
+        background-color: #eb973f;
+      }
+    }
+
+    .bg-alert-warning {
+      border: solid 2px #f0c250;
+
+      &.bg-color-true {
+        background-color: #f0c250;
+      }
+    }
+
+    .DraftEditor-root {
+      background: none;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    img.left-image {
+      max-width: 80%;
+      object-fit: unset;
+    }
+
+    .image-col {
+      text-align: center;
+    }
+
+    div + h3,
+    p + h3,
+    h3 + div,
+    h3 + p {
+      margin-top: 1.33rem;
+    }
+
+    div + h2,
+    p + h2,
+    h2 + div,
+    h2 + p {
+      margin-top: 1rem;
+    }
+  }
+}

--- a/theme/ItaliaTheme/_common.scss
+++ b/theme/ItaliaTheme/_common.scss
@@ -38,4 +38,20 @@
       }
     }
   }
+  .center-cards:not(.in-evidence-cards-wrapper) {
+    justify-content: space-around !important;
+    gap: auto;
+    &:after {
+      display: none;
+    }
+  }
+  .center-cards.in-evidence-cards-wrapper {
+    grid-template-columns: repeat(3, 1fr);
+    justify-content: center;
+    .card-wrapper {
+      &:last-child {
+        align-self: center;
+      }
+    }
+  }
 }

--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -289,6 +289,19 @@ body.cms-ui {
     .button.secondary.active {
       background-color: $secondary;
     }
+    //blocks Alert and Info
+    .button.warning,
+    .button.warning.active {
+      background-color: #f0c250;
+    }
+    .button.danger,
+    .button.danger.active {
+      background-color: #a32219;
+    }
+    .button.warning-orange,
+    .button.warning-orange.active {
+      background-color: #eb973f;
+    }
   }
 
   .path-filter-widget {

--- a/theme/site.scss
+++ b/theme/site.scss
@@ -42,6 +42,7 @@
 @import 'ItaliaTheme/Blocks/common/searchBlockFilters';
 @import 'ItaliaTheme/Blocks/calendar';
 @import 'ItaliaTheme/Blocks/alert';
+@import 'ItaliaTheme/Blocks/info';
 @import 'ItaliaTheme/Blocks/highlitedContent';
 @import 'ItaliaTheme/Blocks/iconBlocks';
 @import 'ItaliaTheme/Blocks/imageBlock';


### PR DESCRIPTION
ER.GO ci ha chiesto alcune cose e Baio ha chiesto di farli su io-comune-v2 come new feature

1. Blocchi elenco 
- Dare la possibilità, quando possibile, di centrare i card. 
- https://redturtle.tpondemand.com/entity/40894-inserire-una-opzione-nel-blocco-elenco
- I blocchi con la modifica: 
```
    formData.variation === 'simpleCard' ||
    formData.variation === 'completeBlockLinksTemplate' ||
    formData.variation === 'cardWithImageTemplate' ||
    formData.variation === 'ribbonCardTemplate' ||
    formData.variation === 'smallBlockLinksTemplate' ||
    formData.variation === 'bandiInEvidenceTemplate'
```

2. Blocco con icone 
- dare la possibilità di centrare i card e cambiare colore dello sfondo del blocco. 
- min-height per l'icone, per allineare i titoli.
- https://redturtle.tpondemand.com/entity/40424-inserire-unopzione-nel-blocco-blocco-con
- https://redturtle.tpondemand.com/entity/40224-blocco-con-icone-inserire-un-flag
- https://redturtle.tpondemand.com/entity/40982-icone

3. Blocco Alert 
- Select per scegliere la dimensione dell'immagine
- https://redturtle.tpondemand.com/entity/40952-blocco-alert

4. Nuovo blocco Info 
- Icone sempre fisso, con bordo o bg colorato -  più semplice se vedi la US 
-  https://redturtle.tpondemand.com/entity/40427-blocco-info

5. Sidebar blocco alert e info 
- cambiato component per i colori con il selettore colore default
**- Baio ha chiesto se questo non deve essere fatto sulla V3**
- vedere l'esempio qua: https://redturtle.tpondemand.com/entity/40427-blocco-info

6. Blocco link completo 
- dare la possibilità di cambiare lo sfondo dei card
- https://redturtle.tpondemand.com/entity/40425-blocco-link-completo-inserire-opzione-per

