### PR TITLE
Feat: Icon component | Alert and Info Blocks

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Info/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/View.jsx
@@ -7,12 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import redraft from 'redraft';
-import {
-  Container,
-  Row,
-  Col,
-  Icon,
-} from 'design-react-kit/dist/design-react-kit';
+import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
+import { Icon } from '@italia/components/ItaliaTheme';
 //import { isCmsUi } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 

--- a/src/components/ItaliaTheme/Icons/DesignIcon.jsx
+++ b/src/components/ItaliaTheme/Icons/DesignIcon.jsx
@@ -41,7 +41,7 @@ const Icon = ({ icon, title, className, size }) => {
     const { current: name } = ImportedIconRef;
     return (
       <svg
-        xmlns={name.attributes && name.attributes.xmlns}
+        xmlns={name.attributes?.xmlns || 'http://www.w3.org/2000/svg'}
         viewBox={name.attributes && name.attributes.viewBox}
         style={{ height: size, width: 'auto' }}
         className={className}

--- a/theme/ItaliaTheme/Blocks/_alert.scss
+++ b/theme/ItaliaTheme/Blocks/_alert.scss
@@ -1,6 +1,18 @@
 .public-ui {
   .block.alertblock,
   .alertblock {
+    .bg-alert-warning-orange,
+    .bg-alert-warning,
+    .bg-alert-danger {
+      .draftjs-buttons a {
+        background-color: #fff;
+        color: $body-color;
+        &:hover {
+          background-color: #000;
+          color: #fff;
+        }
+      }
+    }
     .bg-alert-danger {
       background-color: #a32219;
       color: $white;

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -5,6 +5,19 @@
     .bg-alert-danger {
       border-style: solid;
       border-width: 2px 2px 2px 10px;
+      .draftjs-buttons a {
+        color: $body-color;
+      }
+      &.bg-color-true {
+        .draftjs-buttons a {
+          background-color: #fff;
+          color: $body-color;
+          &:hover {
+            background-color: #000;
+            color: #fff;
+          }
+        }
+      }
     }
 
     .bg-alert-warning-orange,
@@ -32,6 +45,13 @@
     .bg-alert-danger {
       border-color: #a32219;
       color: $black;
+      .draftjs-buttons a {
+        background-color: #a32219;
+        color: #fff;
+        &:hover {
+          background-color: darken(#a32219, 10%);
+        }
+      }
       svg.icon {
         fill: #a32219;
       }
@@ -55,6 +75,12 @@
 
     .bg-alert-warning-orange {
       border-color: #eb973f;
+      .draftjs-buttons a {
+        background-color: #eb973f;
+        &:hover {
+          background-color: darken(#eb973f, 10%);
+        }
+      }
       svg.icon {
         fill: #eb973f;
       }
@@ -65,6 +91,12 @@
 
     .bg-alert-warning {
       border-color: #f0c250;
+      .draftjs-buttons a {
+        background-color: #f0c250;
+        &:hover {
+          background-color: darken(#f0c250, 10%);
+        }
+      }
       svg.icon {
         fill: #f0c250;
       }


### PR DESCRIPTION
Fixed icon component to show xmlns on Safari/IOS
New colors for draftjs button inside alert and info blocks

<img width="1563" alt="Schermata 2023-05-10 alle 15 12 28" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/0df9ea71-1464-4e48-a54e-3dd36e807240">
