### PR TITLE
fix: fixed site of ufficio_responsabile condition

### DIFF
--- a/src/components/ItaliaTheme/View/ServizioView/ServizioMetatag.jsx
+++ b/src/components/ItaliaTheme/View/ServizioView/ServizioMetatag.jsx
@@ -60,7 +60,7 @@ const ServizioMetatag = ({ content }) => {
       name: content.ufficio_responsabile[0].title,
     };
 
-    if (content.ufficio_responsabile[0].sede[0]) {
+    if (content.ufficio_responsabile[0]?.sede[0]) {
       schemaOrg.availableChannel.serviceLocation.address = {
         '@type': 'PostalAddress',
         streetAddress: content.ufficio_responsabile[0].sede[0].street,


### PR DESCRIPTION
Abbiamo CT Servizi vecchi che si rompono in visualizzazione

<img width="1873" alt="Screenshot 2023-05-17 alle 16 04 51" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/752b1ecd-fe05-489a-bfb2-50c90430d691">

Credo non sia stato gestito l'eventuale mancanza nei dati del campo `sede` che nella nuova struttura del servizio -> ufficio responsabile è un campo obbligatorio.

