### PR TITLE
fix: fixed logout icon color

### DIFF
--- a/src/theme/bootstrap-override/bootstrap-italia/_headerslim.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_headerslim.scss
@@ -16,6 +16,7 @@
       .icon {
         margin-right: 0.5rem;
         color: $primary;
+        fill: $primary;
       }
     }
 


### PR DESCRIPTION
Icona del logout non prende il color ma il fill
<img width="401" alt="menu-log" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/51b29af7-3a17-448f-994e-22578bbe92de">