### PR TITLE
fix: fixed integer field value of FormValidationHelpers

### DIFF
--- a/src/helpers/FormValidation/FormValidationHelpers.js
+++ b/src/helpers/FormValidation/FormValidationHelpers.js
@@ -77,6 +77,8 @@ export const getRealEmptyField = (
     );
   } else if (type === 'string' && widget === 'richtext') {
     return !(formData?.[field]?.data?.replace(/(<([^>]+)>)/g, '').length > 0);
+  } else if (type === 'integer') {
+    return formData?.[field] === null || formData?.[field] === undefined;
   } else {
     return isEmpty(formData[field]);
   }


### PR DESCRIPTION
Durante la validazione alcuni campi di tipo "number" risultavano vuoti anche se compilati

![Screenshot 2023-06-22 alle 15 14 49](https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/ef9ce740-2e30-4ae8-b29e-1ddfdee62e90)

Ho aggiunto una condizione anche per questi fields.