### PR TITLE
fix: padding weekday date search left padding

### DIFF
--- a/src/theme/ItaliaTheme/Blocks/_eventSearch.scss
+++ b/src/theme/ItaliaTheme/Blocks/_eventSearch.scss
@@ -1,3 +1,10 @@
 .event-search {
   @extend .search-block-filters;
+  .DayPicker {
+    .DayPicker_weekHeader {
+      .DayPicker_weekHeader_ul {
+        padding-left: 0;
+      }
+    }
+  }
 }

--- a/src/theme/ItaliaTheme/Blocks/_eventSearch.scss
+++ b/src/theme/ItaliaTheme/Blocks/_eventSearch.scss
@@ -1,10 +1,3 @@
 .event-search {
   @extend .search-block-filters;
-  .DayPicker {
-    .DayPicker_weekHeader {
-      .DayPicker_weekHeader_ul {
-        padding-left: 0;
-      }
-    }
-  }
 }

--- a/src/theme/ItaliaTheme/Blocks/_search.scss
+++ b/src/theme/ItaliaTheme/Blocks/_search.scss
@@ -83,9 +83,6 @@
             border-bottom: none;
           }
         }
-        .DayPicker_weekHeader_ul {
-          padding-left: 0 !important;
-        }
       }
       .select-facet {
         // Same div, but for some reason when built, valuecontainer

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -348,3 +348,12 @@ iframe {
     @include rem-size(font-size, 24);
   }
 }
+
+//search weekday fix
+.DayPicker {
+  .DayPicker_weekHeader {
+    .DayPicker_weekHeader_ul {
+      padding-left: 0;
+    }
+  }
+}


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/43017-calendario-eventi-date-calendarietto-sfasate

Event search daypicker weekdays with padding-left

 
<img width="1483" alt="Schermata 2023-06-26 alle 16 59 54" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/14fd3cec-5eb8-450b-ada7-758ad56b4c87">
