### PR TITLE
fix: sync datetimewidget customization

### DIFF
--- a/src/customizations/volto/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/DatetimeWidget.jsx
@@ -2,24 +2,37 @@
  * DatetimeWidget component.
  * @module components/manage/Widgets/DatetimeWidget
  *
+ * https://github.com/plone/volto/blob/16.x.x/src/components/manage/Widgets/DatetimeWidget.jsx
+ * https://github.com/plone/volto/blob/7ec45f7b4d46233236c651f39a951bad8e389184/src/components/manage/Widgets/DatetimeWidget.jsx
+ * 
  * CUSTOMIZATIONS:
- * - accept calendar open direction prop and use it in SingleDatePicker,
+ * - accept calendar `openDirection` prop and use it in SingleDatePicker,
  *   default to down if no openDirection is given
  */
+/**
+ * DatetimeWidget component.
+ * @module components/manage/Widgets/DatetimeWidget
+ */
 import React, { Component } from 'react';
+import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
-import moment from 'moment';
-import { SingleDatePicker } from 'react-dates';
-import TimePicker from 'rc-time-picker';
+import { connect } from 'react-redux';
+import loadable from '@loadable/component';
 import cx from 'classnames';
 import { Icon, FormFieldWrapper } from '@plone/volto/components';
+import { parseDateTime, toBackendLang } from '@plone/volto/helpers';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+
 import leftKey from '@plone/volto/icons/left-key.svg';
 import rightKey from '@plone/volto/icons/right-key.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
+
 import 'rc-time-picker/assets/index.css';
 import 'react-dates/initialize';
 import 'react-dates/lib/css/_datepicker.css';
+
+const TimePicker = loadable(() => import('rc-time-picker'));
 
 const messages = defineMessages({
   date: {
@@ -73,8 +86,17 @@ const defaultTimeDateOnly = {
  * DatetimeWidget component class
  * @class DatetimeWidget
  * @extends Component
+ *
+ * To use it, in schema properties, declare a field like:
+ *
+ * ```jsx
+ * {
+ *  title: "Publish date",
+ *  type: 'datetime',
+ * }
+ * ```
  */
-class DatetimeWidget extends Component {
+export class DatetimeWidgetComponent extends Component {
   /**
    * Constructor
    * @method constructor
@@ -83,28 +105,32 @@ class DatetimeWidget extends Component {
    */
   constructor(props) {
     super(props);
-    //  Used to set a server timezone or UTC as default
-    moment.defineLocale(
-      this.props.intl.locale,
-      moment.localeData(this.props.intl.locale)._config,
-    ); // copy locale to moment-timezone
-    let datetime = null;
-
-    if (this.props.value) {
-      // check if datetime has timezone, otherwise assumes it's UTC
-      datetime = this.props.value.match(/T(.)*(-|\+|Z)/g)
-        ? // Since we assume UTC everywhere, then transform to local (momentjs default)
-          moment(this.props.value)
-        : // This might happen in old Plone versions dates
-          moment(`${this.props.value}Z`);
-    }
+    this.moment = props.moment.default;
 
     this.state = {
       focused: false,
-      isDefault: datetime?.toISOString() === moment().utc().toISOString(),
-      datetime,
-      dateOnly: this.props.dateOnly || this.props.widget === 'date',
+      // if passed value matches the construction time, we guess it's a default
+      isDefault:
+        parseDateTime(
+          toBackendLang(this.props.lang),
+          this.props.value,
+          undefined,
+          this.moment,
+        )?.toISOString() === this.moment().utc().toISOString(),
     };
+  }
+
+  getInternalValue() {
+    return parseDateTime(
+      toBackendLang(this.props.lang),
+      this.props.value,
+      undefined,
+      this.moment,
+    );
+  }
+
+  getDateOnly() {
+    return this.props.dateOnly || this.props.widget === 'date';
   }
 
   /**
@@ -114,26 +140,21 @@ class DatetimeWidget extends Component {
    * @returns {undefined}
    */
   onDateChange = (date) => {
-    if (date)
-      this.setState(
-        (prevState) => ({
-          datetime: prevState.datetime
-            ? prevState.datetime.set({
-                year: date.year(),
-                month: date.month(),
-                date: date.date(),
-                ...(this.state.dateOnly ? defaultTimeDateOnly : {}),
-              })
-            : moment().set({
-                year: date.year(),
-                month: date.month(),
-                date: date.date(),
-                ...(this.state.dateOnly ? defaultTimeDateOnly : {}),
-              }),
-          isDefault: false,
-        }),
-        () => this.onDateTimeChange(),
-      );
+    if (date) {
+      const moment = this.props.moment.default;
+      const isDateOnly = this.getDateOnly();
+      const base = (this.getInternalValue() || moment()).set({
+        year: date.year(),
+        month: date.month(),
+        date: date.date(),
+        ...(isDateOnly ? defaultTimeDateOnly : {}),
+      });
+      const dateValue = isDateOnly
+        ? base.format('YYYY-MM-DD')
+        : base.toISOString();
+      this.props.onChange(this.props.id, dateValue);
+    }
+    this.setState({ isDefault: false });
   };
 
   /**
@@ -143,45 +164,21 @@ class DatetimeWidget extends Component {
    * @returns {undefined}
    */
   onTimeChange = (time) => {
-    this.setState(
-      (prevState) => ({
-        datetime: prevState.datetime
-          ? prevState.datetime.set({
-              hours: time.hours(),
-              minutes: time.minutes(),
-              seconds: 0,
-            })
-          : moment().set({
-              hours: time.hours(),
-              minutes: time.minutes(),
-              seconds: 0,
-            }),
-        isDefault: false,
-      }),
-      () => this.onDateTimeChange(),
-    );
-  };
-
-  /**
-   * Update date storage
-   * @method onDateTimeChange
-   * @returns {undefined}
-   */
-  onDateTimeChange = () => {
-    const dateValue = this.state.dateOnly
-      ? this.state.datetime.format('YYYY-MM-DD')
-      : this.state.datetime.toISOString();
-    this.props.onChange(this.props.id, dateValue);
+    const moment = this.props.moment.default;
+    if (time) {
+      const base = (this.getInternalValue() || moment()).set({
+        hours: time?.hours() ?? 0,
+        minutes: time?.minutes() ?? 0,
+        seconds: 0,
+      });
+      const dateValue = base.toISOString();
+      this.props.onChange(this.props.id, dateValue);
+    }
   };
 
   onResetDates = () => {
-    this.setState(
-      (prevState) => ({
-        datetime: null,
-        isDefault: false,
-      }),
-      this.props.onChange(this.props.id, null),
-    );
+    this.setState({ isDefault: false });
+    this.props.onChange(this.props.id, null);
   };
 
   /**
@@ -193,27 +190,41 @@ class DatetimeWidget extends Component {
   onFocusChange = ({ focused }) => this.setState({ focused });
 
   render() {
-    const { id, noPastDates, resettable, intl } = this.props;
-    const { datetime, isDefault, focused } = this.state;
+    const {
+      id,
+      resettable,
+      intl,
+      reactDates,
+      widgetOptions,
+      lang,
+    } = this.props;
+    const noPastDates =
+      this.props.noPastDates || widgetOptions?.pattern_options?.noPastDates;
+    const moment = this.props.moment.default;
+    const datetime = this.getInternalValue();
+    const dateOnly = this.getDateOnly();
+    const { SingleDatePicker } = reactDates;
 
     return (
       <FormFieldWrapper {...this.props}>
         <div className="date-time-widget-wrapper">
           <div
             className={cx('ui input date-input', {
-              'default-date': isDefault,
+              'default-date': this.state.isDefault,
             })}
           >
             <SingleDatePicker
               date={datetime}
               disabled={this.props.isDisabled}
               onDateChange={this.onDateChange}
-              focused={focused}
+              focused={this.state.focused}
               numberOfMonths={1}
               {...(noPastDates ? {} : { isOutsideRange: () => false })}
               onFocusChange={this.onFocusChange}
               noBorder
-              displayFormat={moment.localeData(intl.locale).longDateFormat('L')}
+              displayFormat={moment
+                .localeData(toBackendLang(lang))
+                .longDateFormat('L')}
               navPrev={<PrevIcon />}
               navNext={<NextIcon />}
               id={`${id}-date`}
@@ -221,10 +232,10 @@ class DatetimeWidget extends Component {
               openDirection={this.props.openDirection ?? 'down'}
             />
           </div>
-          {!this.state.dateOnly && (
+          {!dateOnly && (
             <div
               className={cx('ui input time-input', {
-                'default-date': isDefault,
+                'default-date': this.state.isDefault,
               })}
             >
               <TimePicker
@@ -234,9 +245,11 @@ class DatetimeWidget extends Component {
                 onChange={this.onTimeChange}
                 allowEmpty={false}
                 showSecond={false}
-                use12Hours={intl.locale === 'en'}
+                use12Hours={lang === 'en'}
                 id={`${id}-time`}
-                format={moment.localeData(intl.locale).longDateFormat('LT')}
+                format={moment
+                  .localeData(toBackendLang(lang))
+                  .longDateFormat('LT')}
                 placeholder={intl.formatMessage(messages.time)}
                 focusOnOpen
                 placement="bottomRight"
@@ -263,7 +276,7 @@ class DatetimeWidget extends Component {
  * @property {Object} propTypes Property types.
  * @static
  */
-DatetimeWidget.propTypes = {
+DatetimeWidgetComponent.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
@@ -283,7 +296,7 @@ DatetimeWidget.propTypes = {
  * @property {Object} defaultProps Default properties.
  * @static
  */
-DatetimeWidget.defaultProps = {
+DatetimeWidgetComponent.defaultProps = {
   description: null,
   required: false,
   error: [],
@@ -294,4 +307,10 @@ DatetimeWidget.defaultProps = {
   openDirection: 'down',
 };
 
-export default injectIntl(DatetimeWidget);
+export default compose(
+  injectLazyLibs(['reactDates', 'moment']),
+  connect((state) => ({
+    lang: state.intl.locale,
+  })),
+  injectIntl,
+)(DatetimeWidgetComponent);


### PR DESCRIPTION
sync the base code from

* https://github.com/plone/volto/blob/16.x.x/src/components/manage/Widgets/DatetimeWidget.jsx
* https://github.com/plone/volto/blob/7ec45f7b4d46233236c651f39a951bad8e389184/src/components/manage/Widgets/DatetimeWidget.jsx

(I don't see changes in code in 17.x)