### PR TITLE
fix: number of slides to scroll on mobile set to 1

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -90,6 +90,7 @@ const SliderTemplate = ({
         breakpoint: 980,
         settings: {
           slidesToShow: 1,
+          slidesToScroll: 1,
         },
       },
     ],


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/43237-logo-er-footer-link

slidestoScroll set to 1 on mobile