### PR TITLE
fix: added condition to SimpleCardTemplate for the creation/modified dates

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -189,6 +189,7 @@ const SimpleCardTemplateDefault = (props) => {
           ) : null;
           const category = getCategory(item, show_type, show_section, props);
           const type = item['@type'];
+
           return (
             <Card
               className={`align-items-top rounded shadow ${getItemClass(item)}`}
@@ -225,16 +226,16 @@ const SimpleCardTemplateDefault = (props) => {
                     {(type === 'Modulo' || type === 'Documento') &&
                       !hide_dates && (
                         <div className="document-date mt-3">
-                          {item?.CreationDate && (
+                          {item?.effective && (
                             <p className="mb-0">
                               <strong>
                                 {intl.formatMessage(messages.publication_date)}:{' '}
                               </strong>
-                              {moment(item.CreationDate).format('DD-MM-YYYY')}
+                              {moment(item.effective).format('DD-MM-YYYY')}
                             </p>
                           )}
                           {item?.modified && (
-                            <p>
+                            <p className="mb-0">
                               <strong>
                                 {intl.formatMessage(messages.update_date)}:{' '}
                               </strong>

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -222,19 +222,27 @@ const SimpleCardTemplateDefault = (props) => {
                 {listingText && (
                   <CardText className={cx('', { 'mb-5': eventRecurrenceMore })}>
                     {listingText}
-                    {(type === 'Modulo' || type === 'Documento') && (
-                      <div className="document-date mt-3">
-                        <strong>
-                          {intl.formatMessage(messages.publication_date)}:{' '}
-                        </strong>
-                        {moment(item.CreationDate).format('DD-MM-YYYY')}
-                        <br />
-                        <strong>
-                          {intl.formatMessage(messages.update_date)}:{' '}
-                        </strong>
-                        {moment(item.modified).format('DD-MM-YYYY')}
-                      </div>
-                    )}
+                    {(type === 'Modulo' || type === 'Documento') &&
+                      !hide_dates && (
+                        <div className="document-date mt-3">
+                          {item?.CreationDate && (
+                            <p className="mb-0">
+                              <strong>
+                                {intl.formatMessage(messages.publication_date)}:{' '}
+                              </strong>
+                              {moment(item.CreationDate).format('DD-MM-YYYY')}
+                            </p>
+                          )}
+                          {item?.modified && (
+                            <p>
+                              <strong>
+                                {intl.formatMessage(messages.update_date)}:{' '}
+                              </strong>
+                              {moment(item.modified).format('DD-MM-YYYY')}
+                            </p>
+                          )}
+                        </div>
+                      )}
                   </CardText>
                 )}
                 {eventRecurrenceMore}


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/44453-errore-visualizzazione-date

It's a little hard to explain... This is where we found the bug: https://www.comune.modena.it/documenti-e-dati/bandi-e-avvisi/bandi-di-concorso/bandi-e-avvisi-di-selezione

Listing block -> no filters -> only documents inside the folder -> The cards inside will be all type "document" even with no filters set. Those cards show creation and modified date (show the current day for both entries), but they shouldn't even appear, only if a filter with "tipo contenuto | documento" was set.

Checkbox "nascondi le date" doesn't work