### PR TITLE
fix: removed condition from FontAwesomeIcon

### DIFF
--- a/src/components/ItaliaTheme/Icons/FontAwesomeIcon.jsx
+++ b/src/components/ItaliaTheme/Icons/FontAwesomeIcon.jsx
@@ -18,12 +18,7 @@ const FontAwesomeIcon = (props) => {
   };
 
   let prefixKey = prefix;
-  let iconName = getIconAlias(icon, fontAwesomeAliases);
-
-  if (Array.isArray(icon)) {
-    prefixKey = icon[0];
-    iconName = icon[1];
-  }
+  let iconName = getIconAlias(icon[1], fontAwesomeAliases);
 
   const prefixFolder =
     prefixKey === 'fab' ? 'brands' : prefixKey === 'far' ? 'regular' : 'solid';


### PR DESCRIPTION
Set icon[1] for the getIconAlias first parameter.
Removed condition that renames iconName and prefixKey with an array test