### PR TITLE
fix: fix LinkEntity error on create link in WysWidget and in edit

### DIFF
--- a/src/config/RichTextEditor/LinkEntity.jsx
+++ b/src/config/RichTextEditor/LinkEntity.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
+import { IntlProvider } from 'react-intl';
 
 const LinkEntity = connect((state) => ({
   token: state.userSession.token,
@@ -10,14 +11,16 @@ const LinkEntity = connect((state) => ({
   const to = token ? url : targetUrl || url;
 
   return (
-    <UniversalLink
-      href={to}
-      openLinkInNewTab={target === '_blank' || undefined}
-      download={download}
-      data-element={dataElement || props['data-element'] || null}
-    >
-      {children}
-    </UniversalLink>
+    <IntlProvider>
+      <UniversalLink
+        href={to}
+        openLinkInNewTab={target === '_blank' || undefined}
+        download={download}
+        data-element={dataElement || props['data-element'] || null}
+      >
+        {children}
+      </UniversalLink>
+    </IntlProvider>
   );
 });
 


### PR DESCRIPTION
Ad esempio, se in un sottosito mettevi del testo con link nel campo 'Testo per l'header del sito', quando inserivi il link dava errore, e se invece il link era presente, quando andavi in edit si spaccava la vista