### PR TITLE
fix: z-index moved to a generic block

### DIFF
--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -346,7 +346,12 @@ body.cms-ui {
       .public-DraftStyleDefault-block {
         margin-bottom: unset;
       }
-      // z-index necessario su Volto 17 finché non passiamo ad usare slate
+    }
+  }
+
+  // z-index necessario su Volto 17 finché non passiamo ad usare slate
+  .block {
+    .DraftEditor-root {
       .DraftEditor-editorContainer,
       .public-DraftEditorPlaceholder-root {
         z-index: 0;


### PR DESCRIPTION
Used only .block insted .block.text to render effective the z-index 0 for all blocks