### PR TITLE
fix: Us45070 info block theme colors

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1241,13 +1241,11 @@ msgid "closeSearch"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Rosso
 msgid "color_danger"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Arancione
 msgid "color_orange"
 msgstr ""
@@ -1266,7 +1264,6 @@ msgid "color_transparent"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Giallo
 msgid "color_warning"
 msgstr ""
@@ -2124,6 +2121,21 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Indice della pagina
 msgid "index"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Primary color
+msgid "info_color_primary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Secondary color
+msgid "info_color_secondary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Tertiary color
+msgid "info_color_tertiary"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Body

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1111,11 +1111,6 @@ msgstr ""
 msgid "block_bg_color"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Colore
-msgid "border_color"
-msgstr ""
-
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Toggle navigation
 msgid "button-toggler-toggle-navigation"
@@ -2121,6 +2116,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Indice della pagina
 msgid "index"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Color
+msgid "info_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1226,13 +1226,11 @@ msgid "closeSearch"
 msgstr "Close search"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Rosso
 msgid "color_danger"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Arancione
 msgid "color_orange"
 msgstr ""
@@ -1251,7 +1249,6 @@ msgid "color_transparent"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Giallo
 msgid "color_warning"
 msgstr ""
@@ -2110,6 +2107,21 @@ msgstr "assignment"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Page index"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Primary color
+msgid "info_color_primary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Secondary color
+msgid "info_color_secondary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Tertiary color
+msgid "info_color_tertiary"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Body
 #: components/ItaliaTheme/Blocks/Calendar/Body

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1096,11 +1096,6 @@ msgstr ""
 msgid "block_bg_color"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Colore
-msgid "border_color"
-msgstr ""
-
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Toggle navigation
 msgid "button-toggler-toggle-navigation"
@@ -2107,6 +2102,11 @@ msgstr "assignment"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Page index"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Color
+msgid "info_color"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Primary color

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1235,13 +1235,11 @@ msgid "closeSearch"
 msgstr "Cerrar búsqueda"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Rosso
 msgid "color_danger"
 msgstr "Rojo"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Arancione
 msgid "color_orange"
 msgstr "Naranja"
@@ -1260,7 +1258,6 @@ msgid "color_transparent"
 msgstr "Transparente"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Giallo
 msgid "color_warning"
 msgstr "Amarillo"
@@ -2119,6 +2116,21 @@ msgstr "Compromiso"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Índice de página"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Primary color
+msgid "info_color_primary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Secondary color
+msgid "info_color_secondary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Tertiary color
+msgid "info_color_tertiary"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Body
 #: components/ItaliaTheme/Blocks/Calendar/Body

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1105,11 +1105,6 @@ msgstr "Bloque de información"
 msgid "block_bg_color"
 msgstr "Color de fondo"
 
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Colore
-msgid "border_color"
-msgstr "Color"
-
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Toggle navigation
 msgid "button-toggler-toggle-navigation"
@@ -2116,6 +2111,11 @@ msgstr "Compromiso"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Índice de página"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Color
+msgid "info_color"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Primary color

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1243,13 +1243,11 @@ msgid "closeSearch"
 msgstr "Fermer la recherche"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Rosso
 msgid "color_danger"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Arancione
 msgid "color_orange"
 msgstr ""
@@ -1268,7 +1266,6 @@ msgid "color_transparent"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Giallo
 msgid "color_warning"
 msgstr ""
@@ -2127,6 +2124,21 @@ msgstr "Engagement"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Index des pages"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Primary color
+msgid "info_color_primary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Secondary color
+msgid "info_color_secondary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Tertiary color
+msgid "info_color_tertiary"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Body
 #: components/ItaliaTheme/Blocks/Calendar/Body

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1113,11 +1113,6 @@ msgstr ""
 msgid "block_bg_color"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Colore
-msgid "border_color"
-msgstr ""
-
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Toggle navigation
 msgid "button-toggler-toggle-navigation"
@@ -2124,6 +2119,11 @@ msgstr "Engagement"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Index des pages"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Color
+msgid "info_color"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Primary color

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1096,11 +1096,6 @@ msgstr "Blocco informazioni"
 msgid "block_bg_color"
 msgstr "Colore di sfondo"
 
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Colore
-msgid "border_color"
-msgstr "Colore"
-
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Toggle navigation
 msgid "button-toggler-toggle-navigation"
@@ -2107,6 +2102,11 @@ msgstr "incarico"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Indice della pagina"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Color
+msgid "info_color"
+msgstr "Colore"
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Primary color

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1226,13 +1226,11 @@ msgid "closeSearch"
 msgstr "Chiudi ricerca"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Rosso
 msgid "color_danger"
 msgstr "Rosso"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Arancione
 msgid "color_orange"
 msgstr "Arancione"
@@ -1251,7 +1249,6 @@ msgid "color_transparent"
 msgstr "Trasparente"
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Giallo
 msgid "color_warning"
 msgstr "Giallo"
@@ -2110,6 +2107,21 @@ msgstr "incarico"
 # defaultMessage: Indice della pagina
 msgid "index"
 msgstr "Indice della pagina"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Primary color
+msgid "info_color_primary"
+msgstr "Colore primario"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Secondary color
+msgid "info_color_secondary"
+msgstr "Colore secondario"
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Tertiary color
+msgid "info_color_tertiary"
+msgstr "Colore terziario"
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Body
 #: components/ItaliaTheme/Blocks/Calendar/Body

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-07-25T10:15:46.866Z\n"
+"POT-Creation-Date: 2023-08-21T09:46:02.852Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1228,13 +1228,11 @@ msgid "closeSearch"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Rosso
 msgid "color_danger"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Arancione
 msgid "color_orange"
 msgstr ""
@@ -1253,7 +1251,6 @@ msgid "color_transparent"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
-#: components/ItaliaTheme/Blocks/Info/Sidebar
 # defaultMessage: Giallo
 msgid "color_warning"
 msgstr ""
@@ -2111,6 +2108,21 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Indice della pagina
 msgid "index"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Primary color
+msgid "info_color_primary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Secondary color
+msgid "info_color_secondary"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Tertiary color
+msgid "info_color_tertiary"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Body

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-08-21T09:46:02.852Z\n"
+"POT-Creation-Date: 2023-08-21T12:28:11.804Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1098,11 +1098,6 @@ msgstr ""
 msgid "block_bg_color"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Info/Sidebar
-# defaultMessage: Colore
-msgid "border_color"
-msgstr ""
-
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Toggle navigation
 msgid "button-toggler-toggle-navigation"
@@ -2108,6 +2103,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Indice della pagina
 msgid "index"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Info/Sidebar
+# defaultMessage: Color
+msgid "info_color"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Info/Sidebar

--- a/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
@@ -6,9 +6,9 @@ import { ColorListWidget } from 'design-comuni-plone-theme/components/ItaliaThem
 import { CheckboxWidget } from '@plone/volto/components';
 
 const messages = defineMessages({
-  border_color: {
-    id: 'border_color',
-    defaultMessage: 'Colore',
+  info_color: {
+    id: 'info_color',
+    defaultMessage: 'Color',
   },
   info_color_primary: {
     id: 'info_color_primary',
@@ -51,6 +51,7 @@ class Sidebar extends Component {
         label: this.props.intl.formatMessage(messages.info_color_tertiary),
       },
     ];
+
     return (
       <Segment.Group raised>
         <header className="header pulled">
@@ -65,8 +66,8 @@ class Sidebar extends Component {
         <Segment className="form">
           <ColorListWidget
             id="color"
-            title={this.props.intl.formatMessage(messages.border_color)}
-            value={this.props.data.border_color}
+            title={this.props.intl.formatMessage(messages.info_color)}
+            value={this.props.data.color}
             onChange={(id, value) => {
               this.props.onChangeBlock(this.props.block, {
                 ...this.props.data,
@@ -75,6 +76,7 @@ class Sidebar extends Component {
             }}
             colors={bg_colors}
           />
+
           <CheckboxWidget
             id="bg_color"
             title={this.props.intl.formatMessage(messages.bg_color)}

--- a/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Info/Sidebar.jsx
@@ -10,17 +10,17 @@ const messages = defineMessages({
     id: 'border_color',
     defaultMessage: 'Colore',
   },
-  color_warning: {
-    id: 'color_warning',
-    defaultMessage: 'Giallo',
+  info_color_primary: {
+    id: 'info_color_primary',
+    defaultMessage: 'Primary color',
   },
-  color_orange: {
-    id: 'color_orange',
-    defaultMessage: 'Arancione',
+  info_color_secondary: {
+    id: 'info_color_secondary',
+    defaultMessage: 'Secondary color',
   },
-  color_danger: {
-    id: 'color_danger',
-    defaultMessage: 'Rosso',
+  info_color_tertiary: {
+    id: 'info_color_tertiary',
+    defaultMessage: 'Tertiary color',
   },
   bg_color: {
     id: 'bg_color',
@@ -39,16 +39,16 @@ class Sidebar extends Component {
   render() {
     const bg_colors = [
       {
-        name: 'warning',
-        label: this.props.intl.formatMessage(messages.color_warning),
+        name: 'primary',
+        label: this.props.intl.formatMessage(messages.info_color_primary),
       },
       {
-        name: 'warning-orange',
-        label: this.props.intl.formatMessage(messages.color_orange),
+        name: 'secondary',
+        label: this.props.intl.formatMessage(messages.info_color_secondary),
       },
       {
-        name: 'danger',
-        label: this.props.intl.formatMessage(messages.color_danger),
+        name: 'tertiary',
+        label: this.props.intl.formatMessage(messages.info_color_tertiary),
       },
     ];
     return (

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -1,16 +1,16 @@
 //Variables for future customization
-$primary-color: $primary;
-$primary-font-color: $text-color;
-$primary-font-color-with-bg: $primary-text;
+$info-block-primary-color: $primary;
+$info-block-primary-font-color: $text-color;
+$info-block-primary-font-color-with-bg: $primary-text;
 
-$secondary-color: $secondary;
-$secondary-font-color: $text-color;
-$secondary-font-color-with-bg: $primary-text;
+$info-block-secondary-color: $secondary;
+$info-block-secondary-font-color: $text-color;
+$info-block-secondary-font-color-with-bg: $primary-text;
 
 //fixed, doesn't change with the theme
-$tertiary-color: $gray-border;
-$tertiary-font-color: $black;
-$tertiary-font-color-with-bg: $black;
+$info-block-tertiary-color: $gray-border;
+$info-block-tertiary-font-color: $black;
+$info-block-tertiary-font-color-with-bg: $black;
 
 .public-ui {
   .infoblock {
@@ -35,19 +35,19 @@ $tertiary-font-color-with-bg: $black;
     }
 
     .bg-alert-primary {
-      color: $primary-font-color;
-      border-color: $primary-color;
+      color: $info-block-primary-font-color;
+      border-color: $info-block-primary-color;
       .draftjs-buttons a {
-        background-color: $primary-color;
+        background-color: $info-block-primary-color;
         &:hover {
-          background-color: darken($primary-color, 10%);
+          background-color: darken($info-block-primary-color, 10%);
         }
       }
       svg.icon {
-        fill: $primary-color;
+        fill: $info-block-primary-color;
       }
       &.bg-color-true {
-        background-color: $primary-color;
+        background-color: $info-block-primary-color;
       }
       h1,
       h2,
@@ -60,7 +60,7 @@ $tertiary-font-color-with-bg: $black;
         color: #fff;
       }
       &.bg-color-true {
-        color: $primary-font-color-with-bg;
+        color: $info-block-primary-font-color-with-bg;
         h1,
         h2,
         h3,
@@ -69,30 +69,30 @@ $tertiary-font-color-with-bg: $black;
         h6,
         a,
         .public-DraftEditorPlaceholder-inner {
-          color: $primary-font-color-with-bg;
+          color: $info-block-primary-font-color-with-bg;
         }
         svg.icon,
         .public-DraftEditorPlaceholder-inner {
-          fill: $primary-font-color-with-bg;
-          color: $primary-font-color-with-bg;
+          fill: $info-block-primary-font-color-with-bg;
+          color: $info-block-primary-font-color-with-bg;
         }
       }
     }
 
     .bg-alert-secondary {
-      color: $secondary-font-color;
-      border-color: $secondary-color;
+      color: $info-block-secondary-font-color;
+      border-color: $info-block-secondary-color;
       .draftjs-buttons a {
-        background-color: $secondary-color;
+        background-color: $info-block-secondary-color;
         &:hover {
-          background-color: darken($secondary-color, 10%);
+          background-color: darken($info-block-secondary-color, 10%);
         }
       }
       svg.icon {
-        fill: $secondary-color;
+        fill: $info-block-secondary-color;
       }
       &.bg-color-true {
-        background-color: $secondary-color;
+        background-color: $info-block-secondary-color;
       }
       h1,
       h2,
@@ -105,7 +105,7 @@ $tertiary-font-color-with-bg: $black;
         color: #fff;
       }
       &.bg-color-true {
-        color: $secondary-font-color-with-bg;
+        color: $info-block-secondary-font-color-with-bg;
         h1,
         h2,
         h3,
@@ -114,32 +114,32 @@ $tertiary-font-color-with-bg: $black;
         h6,
         a,
         .public-DraftEditorPlaceholder-inner {
-          color: $secondary-font-color-with-bg;
+          color: $info-block-secondary-font-color-with-bg;
         }
         svg.icon,
         .public-DraftEditorPlaceholder-inner {
-          fill: $secondary-font-color-with-bg;
-          color: $secondary-font-color-with-bg;
+          fill: $info-block-secondary-font-color-with-bg;
+          color: $info-block-secondary-font-color-with-bg;
         }
       }
     }
 
     .bg-alert-tertiary {
-      border-color: $tertiary-color;
-      color: $tertiary-font-color;
+      border-color: $info-block-tertiary-color;
+      color: $info-block-tertiary-font-color;
       .draftjs-buttons a {
-        background-color: $tertiary-color;
-        color: $tertiary-font-color;
+        background-color: $info-block-tertiary-color;
+        color: $info-block-tertiary-font-color;
         &:hover {
-          background-color: darken($tertiary-color, 10%);
+          background-color: darken($info-block-tertiary-color, 10%);
         }
       }
       svg.icon {
-        fill: $tertiary-font-color;
+        fill: $info-block-tertiary-font-color;
       }
       &.bg-color-true {
-        background-color: $tertiary-color;
-        color: $tertiary-font-color;
+        background-color: $info-block-tertiary-color;
+        color: $info-block-tertiary-font-color;
         svg.icon,
         .public-DraftEditorPlaceholder-inner,
         h1,
@@ -149,8 +149,8 @@ $tertiary-font-color-with-bg: $black;
         h5,
         h6,
         a {
-          color: $tertiary-font-color;
-          fill: $tertiary-font-color;
+          color: $info-block-tertiary-font-color;
+          fill: $info-block-tertiary-font-color;
         }
       }
     }

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -8,7 +8,7 @@ $secondary-color-font: $text-color;
 $secondary-color-font-with-bg: $primary-text;
 
 //fixed, doesn't change with the theme
-$terciary-color: $gray-border;
+$tertiary-color: $gray-border;
 $tertiary-color-font: $black;
 $tertiary-color-font-with-bg: $black;
 
@@ -125,20 +125,20 @@ $tertiary-color-font-with-bg: $black;
     }
 
     .bg-alert-tertiary {
-      border-color: $terciary-color;
+      border-color: $tertiary-color;
       color: $tertiary-color-font;
       .draftjs-buttons a {
-        background-color: $terciary-color;
+        background-color: $tertiary-color;
         color: $tertiary-color-font;
         &:hover {
-          background-color: darken($terciary-color, 10%);
+          background-color: darken($tertiary-color, 10%);
         }
       }
       svg.icon {
         fill: $tertiary-color-font;
       }
       &.bg-color-true {
-        background-color: $terciary-color;
+        background-color: $tertiary-color;
         color: $tertiary-color-font;
         svg.icon,
         .public-DraftEditorPlaceholder-inner,

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -1,16 +1,16 @@
 //Variables for future customization
 $primary-color: $primary;
-$primary-color-font: $text-color;
-$primary-color-font-with-bg: $primary-text;
+$primary-font-color: $text-color;
+$primary-font-color-with-bg: $primary-text;
 
 $secondary-color: $secondary;
-$secondary-color-font: $text-color;
-$secondary-color-font-with-bg: $primary-text;
+$secondary-font-color: $text-color;
+$secondary-font-color-with-bg: $primary-text;
 
 //fixed, doesn't change with the theme
 $tertiary-color: $gray-border;
-$tertiary-color-font: $black;
-$tertiary-color-font-with-bg: $black;
+$tertiary-font-color: $black;
+$tertiary-font-color-with-bg: $black;
 
 .public-ui {
   .infoblock {
@@ -35,7 +35,7 @@ $tertiary-color-font-with-bg: $black;
     }
 
     .bg-alert-primary {
-      color: $primary-color-font;
+      color: $primary-font-color;
       border-color: $primary-color;
       .draftjs-buttons a {
         background-color: $primary-color;
@@ -60,7 +60,7 @@ $tertiary-color-font-with-bg: $black;
         color: #fff;
       }
       &.bg-color-true {
-        color: $primary-color-font-with-bg;
+        color: $primary-font-color-with-bg;
         h1,
         h2,
         h3,
@@ -69,18 +69,18 @@ $tertiary-color-font-with-bg: $black;
         h6,
         a,
         .public-DraftEditorPlaceholder-inner {
-          color: $primary-color-font-with-bg;
+          color: $primary-font-color-with-bg;
         }
         svg.icon,
         .public-DraftEditorPlaceholder-inner {
-          fill: $primary-color-font-with-bg;
-          color: $primary-color-font-with-bg;
+          fill: $primary-font-color-with-bg;
+          color: $primary-font-color-with-bg;
         }
       }
     }
 
     .bg-alert-secondary {
-      color: $secondary-color-font;
+      color: $secondary-font-color;
       border-color: $secondary-color;
       .draftjs-buttons a {
         background-color: $secondary-color;
@@ -105,7 +105,7 @@ $tertiary-color-font-with-bg: $black;
         color: #fff;
       }
       &.bg-color-true {
-        color: $secondary-color-font-with-bg;
+        color: $secondary-font-color-with-bg;
         h1,
         h2,
         h3,
@@ -114,32 +114,32 @@ $tertiary-color-font-with-bg: $black;
         h6,
         a,
         .public-DraftEditorPlaceholder-inner {
-          color: $secondary-color-font-with-bg;
+          color: $secondary-font-color-with-bg;
         }
         svg.icon,
         .public-DraftEditorPlaceholder-inner {
-          fill: $secondary-color-font-with-bg;
-          color: $secondary-color-font-with-bg;
+          fill: $secondary-font-color-with-bg;
+          color: $secondary-font-color-with-bg;
         }
       }
     }
 
     .bg-alert-tertiary {
       border-color: $tertiary-color;
-      color: $tertiary-color-font;
+      color: $tertiary-font-color;
       .draftjs-buttons a {
         background-color: $tertiary-color;
-        color: $tertiary-color-font;
+        color: $tertiary-font-color;
         &:hover {
           background-color: darken($tertiary-color, 10%);
         }
       }
       svg.icon {
-        fill: $tertiary-color-font;
+        fill: $tertiary-font-color;
       }
       &.bg-color-true {
         background-color: $tertiary-color;
-        color: $tertiary-color-font;
+        color: $tertiary-font-color;
         svg.icon,
         .public-DraftEditorPlaceholder-inner,
         h1,
@@ -149,8 +149,8 @@ $tertiary-color-font-with-bg: $black;
         h5,
         h6,
         a {
-          color: $tertiary-color-font;
-          fill: $tertiary-color-font;
+          color: $tertiary-font-color;
+          fill: $tertiary-font-color;
         }
       }
     }

--- a/theme/ItaliaTheme/Blocks/_info.scss
+++ b/theme/ItaliaTheme/Blocks/_info.scss
@@ -1,17 +1,31 @@
+//Variables for future customization
+$primary-color: $primary;
+$primary-color-font: $text-color;
+$primary-color-font-with-bg: $primary-text;
+
+$secondary-color: $secondary;
+$secondary-color-font: $text-color;
+$secondary-color-font-with-bg: $primary-text;
+
+//fixed, doesn't change with the theme
+$terciary-color: $gray-border;
+$tertiary-color-font: $black;
+$tertiary-color-font-with-bg: $black;
+
 .public-ui {
   .infoblock {
-    .bg-alert-warning-orange,
-    .bg-alert-warning,
-    .bg-alert-danger {
+    .bg-alert-primary,
+    .bg-alert-secondary,
+    .bg-alert-tertiary {
       border-style: solid;
       border-width: 2px 2px 2px 10px;
       .draftjs-buttons a {
-        color: $body-color;
+        color: #fff;
       }
       &.bg-color-true {
         .draftjs-buttons a {
           background-color: #fff;
-          color: $body-color;
+          color: $text-color;
           &:hover {
             background-color: #000;
             color: #fff;
@@ -20,9 +34,21 @@
       }
     }
 
-    .bg-alert-warning-orange,
-    .bg-alert-warning {
-      color: $black;
+    .bg-alert-primary {
+      color: $primary-color-font;
+      border-color: $primary-color;
+      .draftjs-buttons a {
+        background-color: $primary-color;
+        &:hover {
+          background-color: darken($primary-color, 10%);
+        }
+      }
+      svg.icon {
+        fill: $primary-color;
+      }
+      &.bg-color-true {
+        background-color: $primary-color;
+      }
       h1,
       h2,
       h3,
@@ -31,33 +57,89 @@
       h6,
       a,
       .public-DraftEditorPlaceholder-inner {
-        color: $black;
+        color: #fff;
       }
       &.bg-color-true {
+        color: $primary-color-font-with-bg;
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        a,
+        .public-DraftEditorPlaceholder-inner {
+          color: $primary-color-font-with-bg;
+        }
         svg.icon,
         .public-DraftEditorPlaceholder-inner {
-          fill: $black;
-          color: $black;
+          fill: $primary-color-font-with-bg;
+          color: $primary-color-font-with-bg;
         }
       }
     }
 
-    .bg-alert-danger {
-      border-color: #a32219;
-      color: $black;
+    .bg-alert-secondary {
+      color: $secondary-color-font;
+      border-color: $secondary-color;
       .draftjs-buttons a {
-        background-color: #a32219;
-        color: #fff;
+        background-color: $secondary-color;
         &:hover {
-          background-color: darken(#a32219, 10%);
+          background-color: darken($secondary-color, 10%);
         }
       }
       svg.icon {
-        fill: #a32219;
+        fill: $secondary-color;
       }
       &.bg-color-true {
-        background-color: #a32219;
+        background-color: $secondary-color;
+      }
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      a,
+      .public-DraftEditorPlaceholder-inner {
         color: #fff;
+      }
+      &.bg-color-true {
+        color: $secondary-color-font-with-bg;
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        a,
+        .public-DraftEditorPlaceholder-inner {
+          color: $secondary-color-font-with-bg;
+        }
+        svg.icon,
+        .public-DraftEditorPlaceholder-inner {
+          fill: $secondary-color-font-with-bg;
+          color: $secondary-color-font-with-bg;
+        }
+      }
+    }
+
+    .bg-alert-tertiary {
+      border-color: $terciary-color;
+      color: $tertiary-color-font;
+      .draftjs-buttons a {
+        background-color: $terciary-color;
+        color: $tertiary-color-font;
+        &:hover {
+          background-color: darken($terciary-color, 10%);
+        }
+      }
+      svg.icon {
+        fill: $tertiary-color-font;
+      }
+      &.bg-color-true {
+        background-color: $terciary-color;
+        color: $tertiary-color-font;
         svg.icon,
         .public-DraftEditorPlaceholder-inner,
         h1,
@@ -67,41 +149,9 @@
         h5,
         h6,
         a {
-          color: #fff;
-          fill: #fff;
+          color: $tertiary-color-font;
+          fill: $tertiary-color-font;
         }
-      }
-    }
-
-    .bg-alert-warning-orange {
-      border-color: #eb973f;
-      .draftjs-buttons a {
-        background-color: #eb973f;
-        &:hover {
-          background-color: darken(#eb973f, 10%);
-        }
-      }
-      svg.icon {
-        fill: #eb973f;
-      }
-      &.bg-color-true {
-        background-color: #eb973f;
-      }
-    }
-
-    .bg-alert-warning {
-      border-color: #f0c250;
-      .draftjs-buttons a {
-        background-color: #f0c250;
-        &:hover {
-          background-color: darken(#f0c250, 10%);
-        }
-      }
-      svg.icon {
-        fill: #f0c250;
-      }
-      &.bg-color-true {
-        background-color: #f0c250;
       }
     }
 


### PR DESCRIPTION
Block info - Color pallet options

Default: Primary, secondary and light gray

Variables created to make easy set up the colors when needed (theme custom)

<img width="1555" alt="Schermata 2023-08-21 alle 14 41 11" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/535012c3-ca94-4da6-994b-d3424c149a7b">
