### PR TITLE
feat: added z-index 0 to the floating images inside the block image

### DIFF
--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -417,6 +417,14 @@ body.cms-ui {
         z-index: 0;
       }
     }
+    &.image {
+      .block.align {
+        &.left,
+        &.right {
+          z-index: 0;
+        }
+      }
+    }
   }
 
   a {


### PR DESCRIPTION
Add css to correct slate problem with z-index inside the image block