### PR TITLE
fix: fix pagination param in site search

### DIFF
--- a/src/components/ItaliaTheme/Search/Search.jsx
+++ b/src/components/ItaliaTheme/Search/Search.jsx
@@ -186,7 +186,11 @@ const Search = () => {
   const [customPath] = useState(qs.parse(location.search)?.custom_path ?? '');
 
   const [sortOn, setSortOn] = useState('relevance');
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(
+    qs.parse(location.search)?.b_start
+      ? qs.parse(location.search).b_start / config.settings.defaultPageSize + 1
+      : 1,
+  );
   const [collapseFilters, _setCollapseFilters] = useState(true);
   const [advFiltersOpen, setAdvFiltersOpen] = useState(false);
 
@@ -313,7 +317,7 @@ const Search = () => {
       options,
       portalTypes,
       searchOrderDict[sortOn] ?? {},
-      (currentPage - 1) * config.settings.defaultPageSize,
+      currentPage,
       customPath,
       subsite,
       intl.locale,
@@ -329,7 +333,7 @@ const Search = () => {
           options,
           {},
           searchOrderDict[sortOn] ?? {},
-          (currentPage - 1) * config.settings.defaultPageSize,
+          currentPage,
           customPath,
           subsite,
           intl.locale,

--- a/src/components/ItaliaTheme/Search/utils.js
+++ b/src/components/ItaliaTheme/Search/utils.js
@@ -179,7 +179,9 @@ const getSearchParamsURL = (
     : config.settings.isMultilingual
     ? '/' + currentLang
     : '';
-
+  const b_start = currentPage
+    ? (currentPage - 1) * config.settings.defaultPageSize
+    : 0;
   const activeSections = Object.keys(sections).reduce((secAcc, secKey) => {
     const sec =
       sections[secKey].items &&
@@ -247,7 +249,7 @@ const getSearchParamsURL = (
       ...sortOn,
       ...portal_type,
       skipNull: true,
-      b_start: currentPage ?? 0,
+      b_start: b_start,
       use_site_search_settings: true,
     };
 
@@ -268,7 +270,7 @@ const getSearchParamsURL = (
       },
       { skipNull: true },
     ) +
-    (currentPage && currentPage > 0 ? `&b_start=${currentPage}` : '')
+    (b_start > 0 ? `&b_start=${b_start}` : '')
   );
 };
 


### PR DESCRIPTION
Sistemato un problema nella paginazione dei risultati della ricerca del sito, per cui se si cliccava su un risultato presente in una pagina che non era la prima (es la pagina 3), quando si faceva back dal browser si ritornava sempre alla prima pagina dei risultati e non alla pagina in cui si era arrivati precendentemente. 