### PR TITLE
chore: margin-bottom for left and right positions for image equal zero

### DIFF
--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -357,6 +357,14 @@ body.cms-ui {
         z-index: 0;
       }
     }
+    &.image {
+      .block.align {
+        &.left,
+        &.right {
+          z-index: 0;
+        }
+      }
+    }
   }
 
   a {


### PR DESCRIPTION
Add css to correct slate problem with z-index inside the image block