### PR TITLE
fix: changed dependencies for rerender of setFirstLoading

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Listing/withQuerystringResults.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/withQuerystringResults.jsx
@@ -6,6 +6,7 @@ CUSTOMIZATIONS:
 - added additional fields to pass to @querystring-search (config.settings.querystringAdditionalFields)
 - used [subrequestID] instead [subrequestID] of block, as id of subrequest to avoid block unload on duplicate contents with blocks with same id's
 */
+
 import React, { createRef, useEffect } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { getContent, getQueryStringResults } from '@plone/volto/actions';
@@ -77,6 +78,8 @@ export default function withQuerystringResults(WrappedComponent) {
     const querystringResults = useSelector(
       (state) => state.querystringsearch.subrequests,
     );
+
+    const subrequestResult = querystringResults[subrequestID];
 
     const dispatch = useDispatch();
     const listingRef = createRef();
@@ -163,11 +166,14 @@ export default function withQuerystringResults(WrappedComponent) {
         );
       }
 
-      if (firstLoading && querystringResults[subrequestID] && !loadingQuery) {
-        setFirstLoading(false);
-      }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+      if (firstLoading && subrequestResult && !loadingQuery) {
+        setFirstLoading(false);
+      }
+    }, [firstLoading, loadingQuery, subrequestResult]);
 
     useDeepCompareEffect(() => {
       if (


### PR DESCRIPTION
setFirstLoading non veniva impostato a false perchè querystringResult risultava sempre undefined al primo render.
Spostato setFirstLoading(false) in nuovo useEffect con set di dipendenze nuove per triggerare re-render quando la query è conclusa e querystringResult non è più undefined.