### PR TITLE
fix: fixed load of locations data in LocationsMap

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/LocationsMap.jsx
+++ b/src/components/ItaliaTheme/View/Commons/LocationsMap.jsx
@@ -43,12 +43,7 @@ const LocationsMap = ({ center, locations }) => {
 
   useEffect(() => {
     venues.forEach((loc) => {
-      if (
-        !fetchedLocations?.[loc.key]?.loading &&
-        !fetchedLocations?.[loc.key]?.loaded
-      ) {
-        dispatch(getContent(loc.url, null, loc.key));
-      }
+      dispatch(getContent(loc.url, null, loc.key));
     });
 
     return () =>


### PR DESCRIPTION
Fix per quei casi dove la mappa di un ct UO interno ad un'altra UO non veniva visualizzata.
Ticket [#45604](https://redturtle.tpondemand.com/entity/45604-alcune-volte-le-mappe-non-sono)

Da replicare probabilmente anche su v3.