### PR TITLE
fix: fix cContacts block horizontal alignment

### DIFF
--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/ViewBlock.jsx
@@ -20,7 +20,7 @@ import { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers';
 const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
   return (
     <Card
-      className="card-bg rounded subblock-view"
+      className="card-bg rounded subblock-view "
       noWrapper={false}
       space
       tag="div"

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
@@ -106,7 +106,7 @@ class Edit extends SubblocksEdit {
             </div>
 
             <SubblocksWrapper node={this.node}>
-              <Row>
+              <Row className="justify-content-center">
                 {this.state.subblocks.map((subblock, subindex) => (
                   <Col lg="4" key={subblock.id}>
                     <EditBlock
@@ -120,7 +120,7 @@ class Edit extends SubblocksEdit {
                 ))}
 
                 {this.props.selected && (
-                  <Col lg={4}>
+                  <Col lg={12} className="text-center pb-3">
                     {this.renderAddBlockButton(
                       this.props.intl.formatMessage(messages.addItem),
                     )}

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
@@ -42,9 +42,9 @@ const AccordionView = ({ data, block }) => {
                 )}
               </div>
             </div>
-            <Row>
+            <Row className="justify-content-center">
               {data.subblocks.map((subblock, index) => (
-                <Col lg="4" key={subblock.id}>
+                <Col lg="4" key={subblock.id} className="pb-3">
                   <ViewBlock
                     data={subblock}
                     key={index}


### PR DESCRIPTION
E' stato sistemato l'allineamento orrizzontale del blocco Contatti, in modo che i contatti siano centrati orizzontalmente.
Se infatti c'era un solo contatto, questo rimaneva allineato a sinistra.
Come era prima:
<img width="466" alt="Schermata 2023-09-14 alle 14 54 21" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/23ac588e-ea24-4b3c-9629-64a88204cbb4">

come è stato sistemato:
<img width="723" alt="Schermata 2023-09-14 alle 14 58 18" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/635bfc70-1bac-4378-8148-a5f88119e367">
