### PR TITLE
fix: fix height of icons in Icons Block

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -137,6 +137,7 @@ const BandiInEvidenceTemplate = ({
                     )}
 
                     {/* Tipologia */}
+
                     {show_tipologia && item.tipologia_bando?.title?.length > 0 && (
                       <span className="d-flex flex-wrap align-items-baseline bando-dati-info">
                         <div className="bando-dati-label me-2">
@@ -206,10 +207,12 @@ const BandiInEvidenceTemplate = ({
                             className={cx('bando-state', {
                               open: item.bando_state?.includes('open'),
                               closed: item.bando_state?.includes('closed'),
-                              scheduled:
-                                item.bando_state?.includes('scheduled'),
-                              'in-progress':
-                                item.bando_state?.includes('inProgress'),
+                              scheduled: item.bando_state?.includes(
+                                'scheduled',
+                              ),
+                              'in-progress': item.bando_state?.includes(
+                                'inProgress',
+                              ),
                             })}
                           >
                             {intl.formatMessage(messages[item.bando_state[0]])}

--- a/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -167,8 +167,8 @@
       }
 
       .icon {
-        width: 3.35rem;
-        height: auto;
+        width: auto;
+        height: 4rem;
         color: $tertiary;
       }
     }


### PR DESCRIPTION
Fissato un problema di disallineamento verticale delle icone nel blocco Icone.
Come si vedeva prima:
<img width="1301" alt="Schermata 2023-09-14 alle 15 26 57" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/716ea562-902b-4d1f-a19b-8f19596a2db3">

come si vede ora:
<img width="1415" alt="Schermata 2023-09-14 alle 15 26 32" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/92aa998a-6f8d-49cf-8308-58bad231f4fd">
