### PR TITLE
fix: i link in modulistica devono far vedere la remoteUrl e non il link (v2)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,12 @@
 
 ### Migliorie
 
-Aggiunto limite di caratteri agli input della descrizione
+- Aggiunto limite di caratteri agli input della descrizione
+
+### Fix
+
+- Sistemato il problema per cui nell'area modulistica eventuali link che puntano
+  a file non aprivano il file ma una pagina bianca del sito
 
 <!--- -->
 

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
@@ -34,7 +34,7 @@ const Downloads = ({ item, titleDoc }) => {
     </React.Fragment>
   ) : (
     <UniversalLink
-      href={flattenToAppURL(item['@id'])}
+      href={item.remoteUrl || flattenToAppURL(item['@id'])}
       title={item.title}
       className="modulistica-link"
     >
@@ -77,7 +77,7 @@ const DocRow = ({ doc, items }) => {
       key={doc['@id']}
     >
       {/*Only title and/or description, no files */}
-      {(!items || items.length == 0) && (
+      {(!items || items.length === 0) && (
         <div className="doc">{titleWrapper}</div>
       )}
 

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
@@ -59,7 +59,7 @@ const DocRow = ({ doc, items }) => {
       })}
     >
       <div id={`title-${doc.id}`} className="title">
-        <UniversalLink href={flattenToAppURL(doc['@id'])}>
+        <UniversalLink href={doc.remoteUrl || flattenToAppURL(doc['@id'])}>
           {doc.title}
         </UniversalLink>
         {doc?.description && (


### PR DESCRIPTION
Il problema è che volto non segue correttamente i redirect e se viene linkato un file con @@download ... non si apre correttamente, ma si vede una pagina bianca.

