### PR TITLE
feat: Us 46339 link esterni smalllinksblock

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,3 +29,9 @@
 ### Fix
 - ...
 -->
+
+## Versione 8.6.x
+
+### Migliorie
+
+- Fissato il layout del template Blocco link solo immagini con link esterni, icona accessibilità per link esterni ora è disattivabile attraverso opzione del template, posizionata invece in overlay se presente

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2633,6 +2633,11 @@ msgstr ""
 msgid "other_info"
 msgstr ""
 
+#: config/Blocks/ListingOptions/smallBlockLinksTemplate
+# defaultMessage: Non mostrare l'icona di accessibilità per i link a siti esterni
+msgid "override_links_accessibility_marker"
+msgstr "Barrierefreiheitssymbol nicht für Links anzeigen, die auf externe Websites oder Ressourcen verweisen"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Pagamenti previsti e modalità
 msgid "pagamenti"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2618,6 +2618,11 @@ msgstr "Ohter topics"
 msgid "other_info"
 msgstr "Further information"
 
+#: config/Blocks/ListingOptions/smallBlockLinksTemplate
+# defaultMessage: Non mostrare l'icona di accessibilità per i link a siti esterni
+msgid "override_links_accessibility_marker"
+msgstr "Do not show accessibility icon for links pointing to external websites or resources"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Pagamenti previsti e modalità
 msgid "pagamenti"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2627,6 +2627,11 @@ msgstr "Otros temas"
 msgid "other_info"
 msgstr "Más información"
 
+#: config/Blocks/ListingOptions/smallBlockLinksTemplate
+# defaultMessage: Non mostrare l'icona di accessibilità per i link a siti esterni
+msgid "override_links_accessibility_marker"
+msgstr "No mostrar el ícono de accesibilidad para enlaces que apuntan a sitios web o recursos externos"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Pagamenti previsti e modalità
 msgid "pagamenti"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2635,6 +2635,11 @@ msgstr "Autres sujets"
 msgid "other_info"
 msgstr "Informations complémentaires"
 
+#: config/Blocks/ListingOptions/smallBlockLinksTemplate
+# defaultMessage: Non mostrare l'icona di accessibilità per i link a siti esterni
+msgid "override_links_accessibility_marker"
+msgstr "Ne pas afficher l'icône d'accessibilité pour les liens pointant vers des sites Web ou des ressources externes"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Pagamenti previsti e modalità
 msgid "pagamenti"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2618,6 +2618,11 @@ msgstr "Altri argomenti"
 msgid "other_info"
 msgstr "Ulteriori informazioni"
 
+#: config/Blocks/ListingOptions/smallBlockLinksTemplate
+# defaultMessage: Non mostrare l'icona di accessibilità per i link a siti esterni
+msgid "override_links_accessibility_marker"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Pagamenti previsti e modalità
 msgid "pagamenti"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-08-28T07:32:02.134Z\n"
+"POT-Creation-Date: 2023-09-18T12:53:30.989Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2618,6 +2618,11 @@ msgstr ""
 #: components/ItaliaTheme/View/UOView/UOMoreInfos
 # defaultMessage: Ulteriori informazioni
 msgid "other_info"
+msgstr ""
+
+#: config/Blocks/ListingOptions/smallBlockLinksTemplate
+# defaultMessage: Non mostrare l'icona di accessibilità per i link a siti esterni
+msgid "override_links_accessibility_marker"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields

--- a/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
@@ -19,6 +19,7 @@ const SmallBlockLinksTemplate = ({
   linkHref,
   titleLine,
   linkmore_id_lighthouse,
+  override_links_accessibility_marker,
 }) => {
   return (
     <div className="small-block-links">
@@ -48,6 +49,9 @@ const SmallBlockLinksTemplate = ({
                       item={!isEditMode ? item : null}
                       href={isEditMode ? '#' : ''}
                       className="img-link"
+                      overrideMarkSpecialLinks={
+                        override_links_accessibility_marker
+                      }
                     >
                       {image}
                     </UniversalLink>

--- a/src/config/Blocks/ListingOptions/index.js
+++ b/src/config/Blocks/ListingOptions/index.js
@@ -21,3 +21,4 @@ export { addSliderTemplateOptions } from 'design-comuni-plone-theme/config/Block
 export { addSimpleListTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/simpleListTemplate';
 export { addCardWithSlideUpTextTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate';
 export { addPhotogalleryTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/photogalleryTemplate';
+export { addSmallBlockLinksTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/smallBlockLinksTemplate';

--- a/src/config/Blocks/ListingOptions/smallBlockLinksTemplate.js
+++ b/src/config/Blocks/ListingOptions/smallBlockLinksTemplate.js
@@ -1,0 +1,32 @@
+import { defineMessages } from 'react-intl';
+
+import { addSchemaField } from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
+
+const messages = defineMessages({
+  override_links_accessibility_marker: {
+    id: 'override_links_accessibility_marker',
+    defaultMessage:
+      "Non mostrare l'icona di accessibilità per i link a siti esterni",
+  },
+});
+
+export const addSmallBlockLinksTemplateOptions = (
+  schema,
+  formData,
+  intl,
+  position = 0,
+) => {
+  let pos = position;
+
+  addSchemaField(
+    schema,
+    'override_links_accessibility_marker',
+    intl.formatMessage(messages.override_links_accessibility_marker),
+    null,
+    { type: 'boolean' },
+    pos,
+  );
+  pos++;
+
+  return pos;
+};

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -59,6 +59,7 @@ import {
   addCardWithSlideUpTextTemplateOptions,
   addPhotogalleryTemplateOptions,
   addLinkMoreOptions,
+  addSmallBlockLinksTemplateOptions,
   cloneBlock,
 } from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
 
@@ -178,7 +179,8 @@ const italiaListingVariations = [
     template: SmallBlockLinksTemplate,
     skeleton: SmallBlockLinksTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      /*let pos = */ addDefaultOptions(schema, formData, intl);
+      let pos = addDefaultOptions(schema, formData, intl);
+      addSmallBlockLinksTemplateOptions(schema, formData, intl, pos);
       addLinkMoreOptions(schema, formData, intl);
       return schema;
     },

--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -30,6 +30,7 @@ const UniversalLink = ({
   children,
   className = null,
   title = null,
+  overrideMarkSpecialLinks = false,
   ...props
 }) => {
   const intl = useIntl();
@@ -116,14 +117,15 @@ const UniversalLink = ({
         {...props}
       >
         {children}
-        {config.settings.siteProperties.markSpecialLinks && (
-          <Icon
-            icon="it-external-link"
-            title={title}
-            size="xs"
-            className="align-top ms-1 external-link"
-          />
-        )}
+        {!overrideMarkSpecialLinks &&
+          config.settings.siteProperties.markSpecialLinks && (
+            <Icon
+              icon="it-external-link"
+              title={title}
+              size="xs"
+              className="align-top ms-1 external-link"
+            />
+          )}
       </a>
     );
   } else if (isDownload) {

--- a/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
@@ -15,13 +15,20 @@
     border: 8px solid $white;
     background: $white;
     box-shadow: 0 2px 20px 0 rgba(0, 0, 0, 0.1);
+    position: relative;
+
+    .img-link svg {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      z-index: 2;
+    }
 
     .volto-image.responsive img,
     .img-skeleton {
       width: auto;
       max-width: 100%;
       object-fit: contain;
-
     }
 
     .img-skeleton {


### PR DESCRIPTION
Risolve questo problema mettendo in absolute l'icona a11y per il link esterno e prevedendo un impostazione aggiuntiva nel template del blocco per nascondere le icone accessibilita' per i link esterni
![image](https://github.com/RedTurtle/design-comuni-plone-theme/assets/41484878/87193cd9-2eb0-4e41-a512-df54b9da1f76)
