### PR TITLE
fix: rss card date

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,12 @@
 - ...
 -->
 
+## Versione 7.22.2 (11/10/2023)
+
+### Fix
+
+- Sistemato il template degli Rss Card con immagine per mostrare la data corretta
+
 ## Versione 7.22.1 (27/09/2023)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -76,7 +76,9 @@ const CardWithImageRssTemplate = ({
                           <span className="mx-1">&mdash;</span>
                         </>
                       )}
-                      <span>{getViewDate(item.pubDate, intl.locale)}</span>{' '}
+                      <span>
+                        {getViewDate(item.pubDate || item.date, intl.locale)}
+                      </span>{' '}
                     </div>
                     <CardTitle className="big-heading" tag="h6">
                       {item.title}


### PR DESCRIPTION
Now the cards have the correct date, not the current day

<img width="1203" alt="Schermata 2023-10-11 alle 14 48 52" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/f9f925ae-9c21-45a1-9869-5786ee71ea17">
