### PR TITLE
chore: updated twitter icon

### DIFF
--- a/src/components/ItaliaTheme/Icons/Icon.jsx
+++ b/src/components/ItaliaTheme/Icons/Icon.jsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 
 import DesignIcon from './DesignIcon';
 import TelegramSVG from './svg/TelegramSVG';
+import XTwitterSVG from './svg/XTwitterSVG';
 import { FontAwesomeIcon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
 const Icon = (props) => {
@@ -25,10 +26,13 @@ const Icon = (props) => {
 
     const parts = icon.split(' ');
 
-    if (icon.indexOf('it-') === 0) {
+    // TO DO: rimuovere le condizioni dell'icona di twitter quando verrà aggiornato Bootstrap Italia
+    if (icon.indexOf('it-') === 0 && icon !== 'it-twitter') {
       return <DesignIcon {...props} className={classes} {...rest} />;
     } else if (icon === 'telegram') {
       return <TelegramSVG className={classes} {...rest} />;
+    } else if (icon === 'it-twitter') {
+      return <XTwitterSVG className={classes} {...rest} />;
     } else if (parts.length > 1) {
       return (
         <FontAwesomeIcon icon={parts} className={`fal ${classes}`} {...rest} />

--- a/src/components/ItaliaTheme/Icons/svg/XTwitterSVG.jsx
+++ b/src/components/ItaliaTheme/Icons/svg/XTwitterSVG.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+const XTwitterSVG = (props) => (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    data-prefix="fab"
+    data-icon="x-twitter"
+    {...props}
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 496 512"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z" />
+  </svg>
+);
+
+export default XTwitterSVG;

--- a/src/theme/ItaliaTheme/Components/_sharing.scss
+++ b/src/theme/ItaliaTheme/Components/_sharing.scss
@@ -3,6 +3,7 @@
   .btn.dropdown-toggle {
     text-decoration: underline;
   }
+
   .link-list-wrapper {
     ul {
       li {
@@ -10,7 +11,10 @@
         button.btn-link {
           display: flex;
           align-items: center;
+
           .icon {
+            height: 28px;
+            width: 28px;
             margin-right: 0.5em;
           }
         }


### PR DESCRIPTION
Cambiata temporaneamente la nuova icona di Twitter, in attesa dell'aggiornamento di Bootstrap Italia

[Header]
<img width="1136" alt="Screenshot 2023-10-11 alle 18 18 31" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/8429c686-ebfe-4c58-9418-2020e6600214">

[Share]
<img width="1108" alt="Screenshot 2023-10-11 alle 18 17 49" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/b953279c-3bb6-4fe8-a0e9-50104d29dd24">

[Footer]
<img width="1136" alt="Screenshot 2023-10-11 alle 18 18 45" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/5e5f9afc-dc87-4074-b271-b61088d4e38e">
