### PR TITLE
bug 47046 regressione view blocco Search

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,7 @@
 - Alcune icone mancanti nel widget icone fontawesome sono state rese nuovamente visibili
 - Sistemate inconsistenze nella visualizzazione di alcuni tipi di elementi della lista degli allegati in Cartella Modulistica
 - Visualizzazione sidebar in edit del blocco Numeri: sistemato overflowing del testo di aiuto
+- Sistemate le dimensioni dei risultati del blocco search con colonne laterali, rimosso overflow.
 
 ## Versione 8.7.8 (12/10/2023)
 

--- a/src/customizations/volto/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/ListingBody.jsx
@@ -66,7 +66,7 @@ const ListingBody = React.memo(
         const isSearchBlockResults = variation?.['@type'] === 'search';
         const block = isSearchBlockResults ? variation : data;
 
-        if (!block?.show_block_bg) return 'full-width';
+        if (!block?.show_block_bg && !isSearchBlockResults) return 'full-width';
 
         let bg_color = data.bg_color ? `bg-${data.bg_color}` : '';
 


### PR DESCRIPTION
fix: fixed regression for default classes in SearchBlock view that were overflowing content into columns