### PR TITLE
fix: tabnav label in Release log

### DIFF
--- a/src/components/ReleaseLog/ReleaseLog.jsx
+++ b/src/components/ReleaseLog/ReleaseLog.jsx
@@ -39,12 +39,12 @@ const ReleaseLog = () => {
   }
 
   const LOGS_TO_VIEW = [
-    { name: 'io-comune', file: ReleaseDCPT },
+    { name: 'io-Comune', file: ReleaseDCPT },
     {
-      name: 'io-cittadino',
+      name: 'io-Cittadino',
       file: ReleaseIoCittadino,
     },
-    { name: 'io-prenoto', file: ReleaseIoPrenoto },
+    { name: 'io-Prenoto', file: ReleaseIoPrenoto },
   ];
 
   const [activeTab, toggleTab] = useState(LOGS_TO_VIEW[0].name);
@@ -110,11 +110,7 @@ const ReleaseLog = () => {
                 active={activeTab === log.name}
                 onClick={() => viewTab(log.name)}
               >
-                <span>
-                  {log.name.substring(0, 3) +
-                    log.name.charAt(3).toUpperCase() +
-                    log.name.substring(4)}
-                </span>
+                <span>{log.name}</span>
               </NavLink>
             </NavItem>
           ))}

--- a/src/components/ReleaseLog/ReleaseLog.jsx
+++ b/src/components/ReleaseLog/ReleaseLog.jsx
@@ -110,7 +110,11 @@ const ReleaseLog = () => {
                 active={activeTab === log.name}
                 onClick={() => viewTab(log.name)}
               >
-                <span>{log.name}</span>
+                <span>
+                  {log.name.substring(0, 3) +
+                    log.name.charAt(3).toUpperCase() +
+                    log.name.substring(4)}
+                </span>
               </NavLink>
             </NavItem>
           ))}


### PR DESCRIPTION
Fixed label for the release-log labels with a capital letter for product names 
io-Comune
io-Prenoto
io-Cittadino

<img width="642" alt="Schermata 2023-10-20 alle 10 04 39" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/aac6dcbd-c02d-4d62-979a-e303d45bf872">
