### PR TITLE
Backport white header preset from child themes and fix header mobile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,21 @@
 - ...
 -->
 
+## Versione 8.7.11 (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Migliorata icona del menù mobile
+- Sistemata dimensione logo e bottone di ricerca su mobile
+
 ## Versione 8.7.10 (19/10/2023)
 
 ## Fix

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -55,10 +55,6 @@ a {
   color: $secondary-text !important;
 }
 
-button.custom-navbar-toggler svg.icon {
-  fill: $secondary-text;
-}
-
 ::selection {
   background-color: default;
 }

--- a/src/theme/ItaliaTheme/_white-header.scss
+++ b/src/theme/ItaliaTheme/_white-header.scss
@@ -1,0 +1,62 @@
+@if ($enable-header-white-background) {
+  .it-header-wrapper {
+    .it-header-center-wrapper {
+      .it-header-center-content-wrapper {
+        .it-brand-wrapper {
+          .it-brand-text,
+          .it-brand-text h2,
+          .it-brand-text h3 {
+            color: $text-color;
+            font-weight: 700;
+          }
+        }
+
+        .it-right-zone {
+          color: $text-color;
+
+          .it-socials {
+            ul {
+              .icon {
+                color: $primary;
+                fill: $primary;
+              }
+
+              a:hover svg {
+                fill: darken($primary, 10%);
+              }
+            }
+          }
+
+          .it-search-wrapper a.rounded-icon {
+            background-color: $primary;
+            color: white;
+
+            &:hover {
+              background-color: darken($primary, 10%);
+            }
+          }
+        }
+      }
+    }
+
+    .it-header-navbar-wrapper {
+      background-color: $primary;
+    }
+
+    .navbar .navbar-collapsable {
+      .menu-wrapper .it-brand-wrapper {
+        .it-brand-text,
+        .it-brand-text h2,
+        .it-brand-text h3 {
+          color: $text-color;
+          font-weight: 700;
+        }
+      }
+    }
+    @media (max-width: map-get($map: $grid-breakpoints, $key: 'lg') - 1px) {
+      button.custom-navbar-toggler svg.icon {
+        fill: $primary;
+      }
+    }
+  }
+}

--- a/src/theme/_site-variables.scss
+++ b/src/theme/_site-variables.scss
@@ -19,6 +19,12 @@ $tertiary-text: #fff !default;
 $highlight-search: #ff0 !default;
 $font-family-monospace-light: Roboto Mono Light !default;
 
+// Per abilitare l'header bianco impostare a true
+// e impostare "$header-center-bg-color: white" come qui sotto
+$enable-header-white-background: false;
+// $header-center-bg-color: white;
+// $header-slim-bg-color: #3f3f3f;
+
 // GDPR-BANNER RELATED
 $gdpr-accept-all: #005700 !default;
 $gdpr-toggle-checked: #005700 !default;

--- a/src/theme/bootstrap-override/_bootstrap-italia-site.scss
+++ b/src/theme/bootstrap-override/_bootstrap-italia-site.scss
@@ -188,6 +188,7 @@
   @import 'bootstrap-italia/src/scss/custom/headernavbar';
   @import 'bootstrap-italia/src/scss/custom/headernavbartheme';
   @import 'bootstrap-italia/src/scss/custom/header';
+  @import './bootstrap-italia/header';
 
   // footer
   @import 'bootstrap-italia/src/scss/custom/footer';

--- a/src/theme/bootstrap-override/bootstrap-italia/_header.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_header.scss
@@ -1,0 +1,19 @@
+.it-header-wrapper {
+  @media (max-width: map-get($map: $grid-breakpoints, $key: 'lg') - 1px) {
+    .it-header-navbar-wrapper {
+      background-color: transparent;
+
+      > .container {
+        padding: 0;
+      }
+    }
+
+    .it-nav-wrapper .it-header-navbar-wrapper nav {
+      padding-right: 0;
+    }
+
+    .it-nav-wrapper .it-header-navbar-wrapper {
+      margin-top: -20px;
+    }
+  }
+}

--- a/src/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
@@ -24,4 +24,23 @@
       }
     }
   }
+
+  @media (max-width: map-get($map: $grid-breakpoints, $key: 'lg') - 1px) {
+    .it-header-center-content-wrapper {
+      .it-brand-wrapper {
+        .header-logo {
+          img {
+            width: 30px;
+            height: 30px;
+          }
+        }
+      }
+
+      .it-right-zone .it-search-wrapper a.rounded-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+      }
+    }
+  }
 }

--- a/src/theme/site.scss
+++ b/src/theme/site.scss
@@ -21,6 +21,7 @@
 @import 'ItaliaTheme/css_variables';
 @import 'ItaliaTheme/common';
 @import 'ItaliaTheme/main';
+@import 'ItaliaTheme/white-header';
 @import 'ItaliaTheme/ar';
 @import 'ItaliaTheme/home';
 @import 'ItaliaTheme/sitemap';


### PR DESCRIPTION
Con questa modifica è possibile fare un sito con header bianco solo cambiando due variabili. Inoltre ci sono alcuni fix per l'aspetto di un sito mobile (logo e bottone ricerca)

Normale

<img width="375" alt="image" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/14176608/5f4d1a04-32b6-4cfd-909d-dfaf810c6efa">

Bianco (il logo è bianco ma c'è, non l'ho cambiato per questa prova)

<img width="375" alt="Screenshot 2023-10-26 alle 17 45 39" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/14176608/120cc5c2-3260-4ca1-9130-05530d98f521">
