### PR TITLE
feat: new BandoStatus component to manage the current status translations

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1012,9 +1012,8 @@ msgstr ""
 msgid "bandi_search_no_filters"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Scaduto
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: scaduto
 msgid "bando_closed"
 msgstr ""
 
@@ -1039,15 +1038,13 @@ msgstr ""
 msgid "bando_ente"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: In corso
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: in corso
 msgid "bando_inProgress"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Attivo
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: attivo
 msgid "bando_open"
 msgstr ""
 
@@ -1056,9 +1053,8 @@ msgstr ""
 msgid "bando_scadenza"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Programmato
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: programmato
 msgid "bando_scheduled"
 msgstr ""
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1012,7 +1012,7 @@ msgid "bandi_search_no_filters"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: scaduto
+# defaultMessage: Scaduto
 msgid "bando_closed"
 msgstr ""
 
@@ -1038,12 +1038,12 @@ msgid "bando_ente"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: in corso
+# defaultMessage: In corso
 msgid "bando_inProgress"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: attivo
+# defaultMessage: Attivo
 msgid "bando_open"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgid "bando_scadenza"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: programmato
+# defaultMessage: Programmato
 msgid "bando_scheduled"
 msgstr ""
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -997,7 +997,7 @@ msgid "bandi_search_no_filters"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: scaduto
+# defaultMessage: Scaduto
 msgid "bando_closed"
 msgstr "Expired"
 
@@ -1023,12 +1023,12 @@ msgid "bando_ente"
 msgstr "Supplying authority"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: in corso
+# defaultMessage: In corso
 msgid "bando_inProgress"
 msgstr "In progress"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: attivo
+# defaultMessage: Attivo
 msgid "bando_open"
 msgstr "Active"
 
@@ -1038,7 +1038,7 @@ msgid "bando_scadenza"
 msgstr "Expiration date:"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: programmato
+# defaultMessage: Programmato
 msgid "bando_scheduled"
 msgstr "Scheduled"
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -997,9 +997,8 @@ msgstr ""
 msgid "bandi_search_no_filters"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Scaduto
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: scaduto
 msgid "bando_closed"
 msgstr "Expired"
 
@@ -1024,15 +1023,13 @@ msgstr "Publication date"
 msgid "bando_ente"
 msgstr "Supplying authority"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: In corso
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: in corso
 msgid "bando_inProgress"
 msgstr "In progress"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Attivo
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: attivo
 msgid "bando_open"
 msgstr "Active"
 
@@ -1041,9 +1038,8 @@ msgstr "Active"
 msgid "bando_scadenza"
 msgstr "Expiration date:"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Programmato
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: programmato
 msgid "bando_scheduled"
 msgstr "Scheduled"
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1006,9 +1006,8 @@ msgstr "Fondo de bloque"
 msgid "bandi_search_no_filters"
 msgstr "No hay filtros para mostrar. Seleccione yo filtros de búsqueda para mostrar desde la barra lateral."
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Scaduto
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: scaduto
 msgid "bando_closed"
 msgstr "Expirado"
 
@@ -1033,15 +1032,13 @@ msgstr "Fecha de publicación"
 msgid "bando_ente"
 msgstr "Autoridad proveedora"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: In corso
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: in corso
 msgid "bando_inProgress"
 msgstr "En progreso"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Attivo
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: attivo
 msgid "bando_open"
 msgstr "Activar"
 
@@ -1050,9 +1047,8 @@ msgstr "Activar"
 msgid "bando_scadenza"
 msgstr "Fecha de expiración:"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Programmato
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: programmato
 msgid "bando_scheduled"
 msgstr "Programado"
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1006,7 +1006,7 @@ msgid "bandi_search_no_filters"
 msgstr "No hay filtros para mostrar. Seleccione yo filtros de búsqueda para mostrar desde la barra lateral."
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: scaduto
+# defaultMessage: Scaduto
 msgid "bando_closed"
 msgstr "Expirado"
 
@@ -1032,12 +1032,12 @@ msgid "bando_ente"
 msgstr "Autoridad proveedora"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: in corso
+# defaultMessage: In corso
 msgid "bando_inProgress"
 msgstr "En progreso"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: attivo
+# defaultMessage: Attivo
 msgid "bando_open"
 msgstr "Activar"
 
@@ -1047,7 +1047,7 @@ msgid "bando_scadenza"
 msgstr "Fecha de expiración:"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: programmato
+# defaultMessage: Programmato
 msgid "bando_scheduled"
 msgstr "Programado"
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1014,7 +1014,7 @@ msgid "bandi_search_no_filters"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: scaduto
+# defaultMessage: Scaduto
 msgid "bando_closed"
 msgstr "Expiré"
 
@@ -1040,12 +1040,12 @@ msgid "bando_ente"
 msgstr "Autorité fournisseur"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: in corso
+# defaultMessage: In corso
 msgid "bando_inProgress"
 msgstr "En cours"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: attivo
+# defaultMessage: Attivo
 msgid "bando_open"
 msgstr "Actif"
 
@@ -1055,7 +1055,7 @@ msgid "bando_scadenza"
 msgstr "Date d'expiration"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: programmato
+# defaultMessage: Programmato
 msgid "bando_scheduled"
 msgstr ""
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1014,9 +1014,8 @@ msgstr ""
 msgid "bandi_search_no_filters"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Scaduto
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: scaduto
 msgid "bando_closed"
 msgstr "Expiré"
 
@@ -1041,15 +1040,13 @@ msgstr "Date de publication"
 msgid "bando_ente"
 msgstr "Autorité fournisseur"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: In corso
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: in corso
 msgid "bando_inProgress"
 msgstr "En cours"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Attivo
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: attivo
 msgid "bando_open"
 msgstr "Actif"
 
@@ -1058,9 +1055,8 @@ msgstr "Actif"
 msgid "bando_scadenza"
 msgstr "Date d'expiration"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Programmato
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: programmato
 msgid "bando_scheduled"
 msgstr ""
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -997,7 +997,7 @@ msgid "bandi_search_no_filters"
 msgstr "Nessun filtro da mostrare. Seleziona i filtri di ricerca da mostrare dalla sidebar laterale."
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: scaduto
+# defaultMessage: Scaduto
 msgid "bando_closed"
 msgstr "Scaduto"
 
@@ -1023,12 +1023,12 @@ msgid "bando_ente"
 msgstr "Ente erogatore"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: in corso
+# defaultMessage: In corso
 msgid "bando_inProgress"
 msgstr "In corso"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: attivo
+# defaultMessage: Attivo
 msgid "bando_open"
 msgstr "Attivo"
 
@@ -1038,7 +1038,7 @@ msgid "bando_scadenza"
 msgstr "Scadenza partecipazione"
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: programmato
+# defaultMessage: Programmato
 msgid "bando_scheduled"
 msgstr "Programmato"
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -997,9 +997,8 @@ msgstr "Sfondo del blocco"
 msgid "bandi_search_no_filters"
 msgstr "Nessun filtro da mostrare. Seleziona i filtri di ricerca da mostrare dalla sidebar laterale."
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Scaduto
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: scaduto
 msgid "bando_closed"
 msgstr "Scaduto"
 
@@ -1024,15 +1023,13 @@ msgstr "Data di pubblicazione"
 msgid "bando_ente"
 msgstr "Ente erogatore"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: In corso
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: in corso
 msgid "bando_inProgress"
 msgstr "In corso"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Attivo
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: attivo
 msgid "bando_open"
 msgstr "Attivo"
 
@@ -1041,9 +1038,8 @@ msgstr "Attivo"
 msgid "bando_scadenza"
 msgstr "Scadenza partecipazione"
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Programmato
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: programmato
 msgid "bando_scheduled"
 msgstr "Programmato"
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-11-07T08:43:23.182Z\n"
+"POT-Creation-Date: 2023-11-07T09:01:50.705Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -999,7 +999,7 @@ msgid "bandi_search_no_filters"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: scaduto
+# defaultMessage: Scaduto
 msgid "bando_closed"
 msgstr ""
 
@@ -1025,12 +1025,12 @@ msgid "bando_ente"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: in corso
+# defaultMessage: In corso
 msgid "bando_inProgress"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: attivo
+# defaultMessage: Attivo
 msgid "bando_open"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgid "bando_scadenza"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/BandoStatus
-# defaultMessage: programmato
+# defaultMessage: Programmato
 msgid "bando_scheduled"
 msgstr ""
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-11-06T09:06:10.531Z\n"
+"POT-Creation-Date: 2023-11-07T08:43:23.182Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -999,9 +999,8 @@ msgstr ""
 msgid "bandi_search_no_filters"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Scaduto
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: scaduto
 msgid "bando_closed"
 msgstr ""
 
@@ -1026,15 +1025,13 @@ msgstr ""
 msgid "bando_ente"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: In corso
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: in corso
 msgid "bando_inProgress"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Attivo
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: attivo
 msgid "bando_open"
 msgstr ""
 
@@ -1043,9 +1040,8 @@ msgstr ""
 msgid "bando_scadenza"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando
-# defaultMessage: Programmato
+#: components/ItaliaTheme/View/Commons/BandoStatus
+# defaultMessage: programmato
 msgid "bando_scheduled"
 msgstr ""
 

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -19,6 +19,8 @@ import {
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import { viewDate } from 'design-comuni-plone-theme/helpers';
 
+import { BandoStatus } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
+
 const messages = defineMessages({
   vedi: {
     id: 'bando_vedi',
@@ -39,22 +41,6 @@ const messages = defineMessages({
   stato: {
     id: 'bando_stato',
     defaultMessage: 'Stato:',
-  },
-  open: {
-    id: 'bando_open',
-    defaultMessage: 'Attivo',
-  },
-  scheduled: {
-    id: 'bando_scheduled',
-    defaultMessage: 'Programmato',
-  },
-  closed: {
-    id: 'bando_closed',
-    defaultMessage: 'Scaduto',
-  },
-  inProgress: {
-    id: 'bando_inProgress',
-    defaultMessage: 'In corso',
   },
   ente: {
     id: 'bando_ente',
@@ -215,7 +201,7 @@ const BandiInEvidenceTemplate = ({
                               ),
                             })}
                           >
-                            {intl.formatMessage(messages[item.bando_state[0]])}
+                            <BandoStatus content={item} />
                           </div>
                         </span>
                       </span>

--- a/src/components/ItaliaTheme/View/Commons/BandoStatus.jsx
+++ b/src/components/ItaliaTheme/View/Commons/BandoStatus.jsx
@@ -1,0 +1,38 @@
+/**
+ * Importante: (06/11/2023)
+ * Component creato per essere possibile customizzare in modo più efficiente le traduzioni per lo status dei bandi.
+ * Deve essere cancellato dopo l'aggiornamento di Volto
+ */
+
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  open: {
+    id: 'bando_open',
+    defaultMessage: 'attivo',
+  },
+  closed: {
+    id: 'bando_closed',
+    defaultMessage: 'scaduto',
+  },
+  inProgress: {
+    id: 'bando_inProgress',
+    defaultMessage: 'in corso',
+  },
+  scheduled: {
+    id: 'bando_scheduled',
+    defaultMessage: 'programmato',
+  },
+});
+
+/**
+ * BandoStatus view component class.
+ * @function BandoStatus
+ */
+
+const BandoStatus = ({ content }) => {
+  const intl = useIntl();
+  return <>{intl.formatMessage(messages[content.bando_state[0]])}</>;
+};
+
+export default BandoStatus;

--- a/src/components/ItaliaTheme/View/Commons/BandoStatus.jsx
+++ b/src/components/ItaliaTheme/View/Commons/BandoStatus.jsx
@@ -9,19 +9,19 @@ import { defineMessages, useIntl } from 'react-intl';
 const messages = defineMessages({
   open: {
     id: 'bando_open',
-    defaultMessage: 'attivo',
+    defaultMessage: 'Attivo',
   },
   closed: {
     id: 'bando_closed',
-    defaultMessage: 'scaduto',
+    defaultMessage: 'Scaduto',
   },
   inProgress: {
     id: 'bando_inProgress',
-    defaultMessage: 'in corso',
+    defaultMessage: 'In corso',
   },
   scheduled: {
     id: 'bando_scheduled',
-    defaultMessage: 'programmato',
+    defaultMessage: 'Programmato',
   },
 });
 

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando.jsx
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
+import { BandoStatus } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
+
 /**
  * PageHeaderBando view component class.
  * @function PageHeaderBando
@@ -64,7 +66,7 @@ const PageHeaderBando = ({ content }) => {
                 size=""
               />
               {intl.formatMessage(messages.bando)}{' '}
-              {intl.formatMessage(messages[content.bando_state[0]])}
+              <BandoStatus content={content} />
             </div>
           </div>
         </div>

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando.jsx
@@ -19,22 +19,6 @@ const messages = defineMessages({
     id: 'Bando',
     defaultMessage: 'Bando',
   },
-  open: {
-    id: 'bando_open',
-    defaultMessage: 'attivo',
-  },
-  closed: {
-    id: 'bando_closed',
-    defaultMessage: 'scaduto',
-  },
-  inProgress: {
-    id: 'bando_inProgress',
-    defaultMessage: 'in corso',
-  },
-  scheduled: {
-    id: 'bando_scheduled',
-    defaultMessage: 'programmato',
-  },
 });
 
 const PageHeaderBando = ({ content }) => {

--- a/src/components/ItaliaTheme/View/index.js
+++ b/src/components/ItaliaTheme/View/index.js
@@ -73,6 +73,7 @@ export Sponsors from 'design-comuni-plone-theme/components/ItaliaTheme/View/Comm
 export RelatedItems from 'design-comuni-plone-theme/components/ItaliaTheme/View/Commons/RelatedItems';
 export RelatedItemInEvidence from 'design-comuni-plone-theme/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/RelatedItemInEvidence';
 export DownloadFileFormat from 'design-comuni-plone-theme/components/ItaliaTheme/View/Commons/DownloadFileFormat';
+export BandoStatus from 'design-comuni-plone-theme/components/ItaliaTheme/View/Commons/BandoStatus';
 export BandoDates from 'design-comuni-plone-theme/components/ItaliaTheme/View/Commons/BandoDates';
 
 /* --- View --- */


### PR DESCRIPTION
Important
Component created to make possible to customize Bando status translations more efficiently.
It should be deleted after the Volto update.