### PR TITLE
feat: added image size and colorListWidget in Alert block

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Novità
+
+- Aggiunta la possibilità di selezionare la dimensione dell'immagine nel blocco Alert, inoltre è stato aggiornato anche il widget per la selezione del colore di sfondo.
+
 ## Versione 10.3.0 (08/11/2023)
 
 ### Fix

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -86,6 +86,7 @@ msgstr ""
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
@@ -131,21 +132,6 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -1217,6 +1203,16 @@ msgstr ""
 msgid "codice_ipa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
@@ -1226,6 +1222,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/IncaricoView/IncaricoView

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -71,6 +71,7 @@ msgstr "Show"
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
@@ -116,21 +117,6 @@ msgstr "Click here to replace file"
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -1202,6 +1188,16 @@ msgstr "Close search"
 msgid "codice_ipa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
@@ -1211,6 +1207,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/IncaricoView/IncaricoView

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -80,6 +80,7 @@ msgstr "Ver"
 msgid "CardImageRight"
 msgstr "Alinear imagen a la derecha"
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
@@ -126,21 +127,6 @@ msgstr "Haga clic aquí para reemplazar el archivo"
 # defaultMessage: Colore
 msgid "Color"
 msgstr "Color"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
-msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
 # defaultMessage: Contatti
@@ -1211,6 +1197,16 @@ msgstr "Cerrar búsqueda"
 msgid "codice_ipa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
@@ -1221,6 +1217,11 @@ msgstr "Primario"
 # defaultMessage: Trasparente
 msgid "color_transparent"
 msgstr "Transparente"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
+msgstr ""
 
 #: components/ItaliaTheme/View/IncaricoView/IncaricoView
 #: components/ItaliaTheme/View/PersonaView/PersonaDocumenti

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -88,6 +88,7 @@ msgstr "Voir"
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
@@ -133,21 +134,6 @@ msgstr "Cliquez ici pour remplacer le fichier"
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -1219,6 +1205,16 @@ msgstr "Fermer la recherche"
 msgid "codice_ipa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
@@ -1228,6 +1224,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/IncaricoView/IncaricoView

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -71,6 +71,7 @@ msgstr "Vedi"
 msgid "CardImageRight"
 msgstr "Allinea immagine a destra"
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
@@ -117,21 +118,6 @@ msgstr "Clicca qui per sostituire il file"
 # defaultMessage: Colore
 msgid "Color"
 msgstr "Colore"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr "Rosso"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr "Giallo"
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
-msgstr "Arancione"
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
 # defaultMessage: Contatti
@@ -1202,6 +1188,16 @@ msgstr "Chiudi ricerca"
 msgid "codice_ipa"
 msgstr "Codice dell'ente erogatore (ipa)"
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
@@ -1212,6 +1208,11 @@ msgstr "Colore primario"
 # defaultMessage: Trasparente
 msgid "color_transparent"
 msgstr "Trasparente"
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
+msgstr ""
 
 #: components/ItaliaTheme/View/IncaricoView/IncaricoView
 #: components/ItaliaTheme/View/PersonaView/PersonaDocumenti

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-11-07T09:01:50.705Z\n"
+"POT-Creation-Date: 2023-11-08T17:11:37.097Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -73,6 +73,7 @@ msgstr ""
 msgid "CardImageRight"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Dimensione immagine
 msgid "CardImageSize"
@@ -118,21 +119,6 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/ColorListWidget
 # defaultMessage: Colore
 msgid "Color"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Rosso
-msgid "Color_danger"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Giallo
-msgid "Color_warning"
-msgstr ""
-
-#: components/ItaliaTheme/Blocks/Alert/Sidebar
-# defaultMessage: Arancione
-msgid "Color_warning_orange"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoContatti
@@ -1204,6 +1190,16 @@ msgstr ""
 msgid "codice_ipa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Rosso
+msgid "color_danger"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Arancione
+msgid "color_orange"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
@@ -1213,6 +1209,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Alert/Sidebar
+# defaultMessage: Giallo
+msgid "color_warning"
 msgstr ""
 
 #: components/ItaliaTheme/View/IncaricoView/IncaricoView

--- a/src/components/ItaliaTheme/Blocks/Alert/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Edit.jsx
@@ -59,8 +59,8 @@ class Edit extends Component {
 
   constructor(props) {
     super(props);
-    if (!this.props.data.color) {
-      this.props.data.color = 'warning';
+    if (!this.props.data.bg_color) {
+      this.props.data.bg_color = 'warning';
     }
     this.blockNode = React.createRef();
   }
@@ -78,8 +78,8 @@ class Edit extends Component {
         >
           <Row
             className={cx(
-              'row-full-width p-5',
-              'bg-alert-' + this.props.data.color,
+              'full-width p-5',
+              'bg-alert-' + this.props.data.bg_color,
             )}
           >
             <Container className="ui">
@@ -89,7 +89,11 @@ class Edit extends Component {
                     <img
                       src={`data:${this.props.data.image['content-type']};${this.props.data.image.encoding},${this.props.data.image.data}`}
                       alt=""
-                      className="left-image"
+                      className={cx('left-image', [
+                        this.props.data.sizeImage
+                          ? 'size-' + this.props.data.sizeImage
+                          : 'size-l',
+                      ])}
                     />
                   </Col>
                 )}

--- a/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Sidebar.jsx
@@ -1,30 +1,35 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Form } from 'semantic-ui-react';
-import { Button, Grid, Segment } from 'semantic-ui-react';
+import { Segment } from 'semantic-ui-react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { FileWidget } from '@plone/volto/components';
+import { ColorListWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import ImageSizeWidget from '@plone/volto/components/manage/Widgets/ImageSizeWidget';
 
 const messages = defineMessages({
   Color: {
     id: 'Color',
     defaultMessage: 'Colore',
   },
-  Color_warning: {
-    id: 'Color_warning',
+  color_warning: {
+    id: 'color_warning',
     defaultMessage: 'Giallo',
   },
-  Color_warning_orange: {
-    id: 'Color_warning_orange',
+  color_orange: {
+    id: 'color_orange',
     defaultMessage: 'Arancione',
   },
-  Color_danger: {
-    id: 'Color_danger',
+  color_danger: {
+    id: 'color_danger',
     defaultMessage: 'Rosso',
   },
   Image: {
     id: 'Image',
     defaultMessage: 'Immagine',
+  },
+  CardImageSize: {
+    id: 'CardImageSize',
+    defaultMessage: 'Dimensione immagine',
   },
 });
 
@@ -37,6 +42,21 @@ class Sidebar extends Component {
   };
 
   render() {
+    const bg_colors = [
+      {
+        name: 'info',
+        label: this.props.intl.formatMessage(messages.color_warning),
+      },
+      {
+        name: 'warning',
+        label: this.props.intl.formatMessage(messages.color_orange),
+      },
+      {
+        name: 'danger',
+        label: this.props.intl.formatMessage(messages.color_danger),
+      },
+    ];
+
     return (
       <Segment.Group raised>
         <header className="header pulled">
@@ -46,74 +66,18 @@ class Sidebar extends Component {
         </header>
 
         <Segment className="form">
-          <Form.Field inline required={this.props.required}>
-            <Grid>
-              <Grid.Row>
-                <Grid.Column width="4">
-                  <div className="wrapper">
-                    <label htmlFor="field-align">
-                      {this.props.intl.formatMessage(messages.Color)}
-                    </label>
-                  </div>
-                </Grid.Column>
-                <Grid.Column
-                  width="8"
-                  verticalAlign="middle"
-                  className="color-chooser"
-                >
-                  <Button.Group vertical compact>
-                    <Button
-                      icon
-                      basic={this.props.data.color !== 'warning'}
-                      color="yellow"
-                      onClick={(name, value) => {
-                        this.props.onChangeBlock(this.props.block, {
-                          ...this.props.data,
-                          color: 'warning',
-                        });
-                      }}
-                      active={this.props.data.color === 'warning'}
-                      content={this.props.intl.formatMessage(
-                        messages.Color_warning,
-                      )}
-                    />
-
-                    <Button
-                      icon
-                      basic={this.props.data.color !== 'warning-orange'}
-                      color="orange"
-                      onClick={(name, value) => {
-                        this.props.onChangeBlock(this.props.block, {
-                          ...this.props.data,
-                          color: 'warning-orange',
-                        });
-                      }}
-                      active={this.props.data.color === 'warning-orange'}
-                      content={this.props.intl.formatMessage(
-                        messages.Color_warning_orange,
-                      )}
-                    />
-
-                    <Button
-                      icon
-                      basic={this.props.data.color !== 'danger'}
-                      color="red"
-                      onClick={(name, value) => {
-                        this.props.onChangeBlock(this.props.block, {
-                          ...this.props.data,
-                          color: 'danger',
-                        });
-                      }}
-                      active={this.props.data.color === 'danger'}
-                      content={this.props.intl.formatMessage(
-                        messages.Color_danger,
-                      )}
-                    />
-                  </Button.Group>
-                </Grid.Column>
-              </Grid.Row>
-            </Grid>
-          </Form.Field>
+          <ColorListWidget
+            id="bg_color"
+            title={this.props.intl.formatMessage(messages.Color)}
+            value={this.props.data.bg_color}
+            onChange={(id, value) => {
+              this.props.onChangeBlock(this.props.block, {
+                ...this.props.data,
+                [id]: value,
+              });
+            }}
+            colors={bg_colors}
+          />
           <FileWidget
             id="image"
             title={this.props.intl.formatMessage(messages.Image)}
@@ -124,6 +88,17 @@ class Sidebar extends Component {
                 image: value,
               });
             }}
+          />
+          <ImageSizeWidget
+            id="sizeImage"
+            title={this.props.intl.formatMessage(messages.CardImageSize)}
+            onChange={(name, value) => {
+              this.props.onChangeBlock(this.props.block, {
+                ...this.props.data,
+                sizeImage: value,
+              });
+            }}
+            value={this.props.data.sizeImage}
           />
         </Segment>
       </Segment.Group>

--- a/src/components/ItaliaTheme/Blocks/Alert/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/View.jsx
@@ -29,7 +29,7 @@ const View = ({ data, pathname }) => {
 
   return (
     <section role="alert" className="block alertblock">
-      <div className={cx('full-width', 'bg-alert-' + data.color)}>
+      <div className={cx('full-width', 'bg-alert-' + data.bg_color)}>
         <Container className="p-4 pt-5 pb-5">
           <Row className="align-items-start">
             {data.image?.data && (
@@ -38,7 +38,9 @@ const View = ({ data, pathname }) => {
                   src={`data:${data.image['content-type']};${data.image.encoding},${data.image.data}`}
                   alt=""
                   aria-hidden="true"
-                  className="left-image"
+                  className={cx('left-image', [
+                    data.sizeImage ? 'size-' + data.sizeImage : 'size-l',
+                  ])}
                   loading="lazy"
                 />
               </Col>

--- a/src/components/ItaliaTheme/Blocks/__tests__/Alert.test.jsx
+++ b/src/components/ItaliaTheme/Blocks/__tests__/Alert.test.jsx
@@ -11,7 +11,7 @@ const mockStore = configureStore(middlewares);
 
 const mock_fields = {
   '@type': 'alert',
-  color: 'warning',
+  bg_color: 'warning',
   image: {
     'content-type': 'image/jpeg',
     data:

--- a/src/theme/ItaliaTheme/Blocks/_alert.scss
+++ b/src/theme/ItaliaTheme/Blocks/_alert.scss
@@ -5,69 +5,38 @@
       height: auto;
     }
 
-    .bg-alert-danger {
-      background-color: #a32219;
-      color: $white;
+    .draftjs-buttons a {
+      background-color: $white;
+      color: $body-color;
 
-      .public-DraftEditorPlaceholder-inner {
-        color: $white;
-      }
-
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        color: $white;
-      }
-
-      a {
+      &:hover {
+        background-color: $black;
         color: $white;
       }
     }
 
-    .bg-alert-warning-orange {
-      background-color: #eb973f;
-      color: $black;
-
-      .public-DraftEditorPlaceholder-inner {
-        color: $black;
-      }
-
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        color: $black;
-      }
+    .bg-alert-danger {
+      background-color: $alert-danger;
+      color: $white;
 
       a {
-        color: $black;
+        color: $white;
       }
     }
 
     .bg-alert-warning {
-      background-color: #f0c250;
-      color: $black;
-
-      .public-DraftEditorPlaceholder-inner {
-        color: $black;
-      }
-
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        color: $black;
-      }
+      background-color: $alert-warning;
 
       a {
-        color: $black;
+        color: $body-color;
+      }
+    }
+
+    .bg-alert-info {
+      background-color: $alert-info;
+
+      a {
+        color: $body-color;
       }
     }
 
@@ -81,35 +50,27 @@
       }
     }
 
-    .DraftEditor-root {
-      background: none;
-    }
-
     p {
       margin: 0;
     }
 
     img.left-image {
-      max-width: 80%;
       object-fit: unset;
+      max-width: 80%;
+
+      &.size {
+        &-m {
+          max-width: 50%;
+        }
+
+        &-s {
+          max-width: 30%;
+        }
+      }
     }
 
     .image-col {
       text-align: center;
-    }
-
-    div + h3,
-    p + h3,
-    h3 + div,
-    h3 + p {
-      margin-top: 1.33rem;
-    }
-
-    div + h2,
-    p + h2,
-    h2 + div,
-    h2 + p {
-      margin-top: 1rem;
     }
   }
 }

--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -367,6 +367,20 @@ body.cms-ui {
     .button.tertiary.active {
       background-color: $tertiary;
     }
+
+    // Alert block
+    .button.info,
+    .button.info.active {
+      background-color: $alert-info;
+    }
+    .button.warning,
+    .button.warning.active {
+      background-color: $alert-warning;
+    }
+    .button.danger,
+    .button.danger.active {
+      background-color: $alert-danger;
+    }
   }
 
   .path-filter-widget {

--- a/src/theme/_site-variables.scss
+++ b/src/theme/_site-variables.scss
@@ -39,6 +39,11 @@ $caption-text: #455b71 !default;
 
 $primary-a0: hsl($primary-h, 62%, 97%) !default;
 
+// ALERT-BLOCK CUSTOM COLORS
+$alert-danger: #a32219;
+$alert-warning: #eb973f;
+$alert-info: #f0c250;
+
 $argument-icon-color: $tertiary !default;
 $argument-icon-bg: #f5f6f7 !default;
 $external-link-fill-buttons: $tertiary-text !default;


### PR DESCRIPTION
<img width="1923" alt="Screenshot 2023-11-08 alle 17 53 11" src="https://github.com/italia/design-comuni-plone-theme/assets/43245702/2238445d-4ac8-4472-963a-f3f9283e2094">


Oltre ad aggiungere la dimensione dell'immagine e ad aver sistemato il widget per il colore, è stata fatta della pulizia nel scss che mi sembrava non applicasse effettivamente stili al componente.