### PR TITLE
fix: fixed documentFirstHeading in subsites without style

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,6 +52,7 @@
 ### Fix
 
 - Sistemata la visualizzazione della tipologia del bando nel template del blocco elenco 'Bandi'
+- Rimosso titolo della pagina nei sottositi senza nessuno stile applicato
 
 ## Versione 10.2.0 (06/11/2023)
 

--- a/src/theme/ItaliaTheme/Subsites/_common.scss
+++ b/src/theme/ItaliaTheme/Subsites/_common.scss
@@ -10,4 +10,3 @@
 @import '~bootstrap/scss/mixins';
 
 @import 'mixin';
-@import 'homepage';

--- a/src/theme/ItaliaTheme/Subsites/_homepage.scss
+++ b/src/theme/ItaliaTheme/Subsites/_homepage.scss
@@ -1,9 +1,0 @@
-body.subsite.subsite-root {
-  &,
-  .public-ui {
-    .documentFirstHeading,
-    #briciole {
-      display: none;
-    }
-  }
-}

--- a/src/theme/ItaliaTheme/_home.scss
+++ b/src/theme/ItaliaTheme/_home.scss
@@ -9,3 +9,13 @@ body.public-ui.contenttype-lrf {
 .sidebar-container-enter-done {
   z-index: 150000 !important;
 }
+
+body.subsite.subsite-root {
+  &,
+  .public-ui {
+    .documentFirstHeading,
+    #briciole {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Nei sottositi senza nessuno stile applicato si vedeva il titolo della pagina: 

<img width="1423" alt="Screenshot 2023-11-10 alle 15 03 10" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/e0aead96-a1a2-4937-9050-634e4159eccd">

questo perché lo stile della home era applicato solo ai vari template dei sottositi, è stato quindi spostato nel file generale `_home.scss` di io-comune