### PR TITLE
fix: class no-after added to simple card

### DIFF
--- a/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block.jsx
@@ -52,13 +52,7 @@ const Block = ({
 
   return (
     <div className="simple-text-card-wrapper">
-      <Card
-        color="white"
-        className=" card-bg rounded"
-        noWrapper={false}
-        space
-        tag="div"
-      >
+      <Card color="white" className="no-after card-bg rounded" space tag="div">
         <CardBody>
           <div className={cx('simple-text-card', { 'cms-ui': inEditMode })}>
             {inEditMode ? (


### PR DESCRIPTION
The simple card had a "footer section" created by an `:after.` Used the `.no-after` class from bootstrap-italia to remove that `:after`

![image](https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/bb887e00-0adb-4cac-bced-c5d05d7b2160)