### PR TITLE
fix: fixed a11y of listing block read-more with card-slide-text template

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Sistemata accessibilità del read-more nel blocco elenco con variazione "Card con testo animato" quando si è in un sottosito con uno stile applicato.
+
 ## Versione 10.4.1 (21/11/2023)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -93,16 +93,14 @@ const CardWithSlideUpTextTemplate = (props) => {
                   {show_description && item.description && (
                     <p>{item.description}</p>
                   )}
-                  <div className="read-more">
-                    <CardReadMore
-                      iconName="it-arrow-right"
-                      tag={UniversalLink}
-                      item={!isEditMode ? item : null}
-                      href={isEditMode ? '#' : null}
-                      text={intl.formatMessage(messages.vedi)}
-                      className="justify-content-end"
-                    />
-                  </div>
+                  <CardReadMore
+                    iconName="it-arrow-right"
+                    tag={UniversalLink}
+                    item={!isEditMode ? item : null}
+                    href={isEditMode ? '#' : null}
+                    text={intl.formatMessage(messages.vedi)}
+                    className="justify-content-end"
+                  />
                 </div>
               </UniversalLink>
             );

--- a/src/theme/ItaliaTheme/Blocks/_cardWithSlideUpTextTemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_cardWithSlideUpTextTemplate.scss
@@ -77,8 +77,9 @@
       }
     }
 
-    .read-more a,
-    .read-more a .icon {
+    a.read-more,
+    a.read-more .text + .icon,
+    a.read-more .text {
       color: #fff;
       fill: #fff;
       text-decoration: none;


### PR DESCRIPTION
Bugfix
<img width="1345" alt="Screenshot 2023-11-22 alle 14 29 13" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/61ec432d-1d53-4d8a-b0ba-6cc97d7103cf">

Fix di accessibilità per i link ai read-more nel blocco "Card con test animato" nei sottositi con stile applicato, le regole sono più specifiche per avere i link sempre bianchi su sfondo nero.


