### PR TITLE
fix: fixed listing block card-slide-text-template read-more alignment

### DIFF
--- a/src/theme/ItaliaTheme/Blocks/_cardWithSlideUpTextTemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_cardWithSlideUpTextTemplate.scss
@@ -104,6 +104,7 @@
       position: relative;
       z-index: 2;
       overflow: hidden;
+      width: 100%;
       height: auto;
       max-height: 0;
       -webkit-transition: all 0.35s linear;


### PR DESCRIPTION
Bugfix
<img width="1321" alt="Screenshot 2023-11-22 alle 16 34 15" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/ed15ea4f-cc8a-4c81-9025-b87fc8f89327">

Con il nuovo aggiornamento a volto-17 è stata introdotta una regola alla classe listing-item che sovrascrive l'allineamento del read-more a destra
<img width="637" alt="Screenshot 2023-11-22 alle 16 36 42" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/3ae4b56d-2b62-445f-85c1-3cc3405e1dad">

Il fix è stato aggiunto ad un div figlio `.box-slide-up`
