### PR TITLE
Volto querywidget with browser addon

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione x.x.x (x/x/x)
+
+### Novità
+
+- Nel blocco elenco, nel criterio di configurazione 'Posizione', è ora presente uno strumento per facilitare la ricerca dei contenuti nel sito, senza dover scrivere il percorso a mano.
+
 ## Versione 10.4.3 (28/11/2023)
 
 ### Migliorie

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "volto-gdpr-privacy": "2.1.0",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",
+    "volto-querywidget-with-browser": "git+https://gitlab.com/redturtle/volto-querywidget-with-browser.git#v0.4.0",
     "volto-rss-block": "3.0.0",
     "volto-secondarymenu": "4.0.0",
     "volto-social-settings": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "volto-subfooter",
     "volto-gdpr-privacy",
     "volto-data-grid-widget",
+    "volto-querywidget-with-browser",
     "@eeacms/volto-taxonomy",
     "volto-feedback"
   ],

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "volto-gdpr-privacy": "2.1.0",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",
-    "volto-querywidget-with-browser": "git+https://gitlab.com/redturtle/volto-querywidget-with-browser.git#v0.4.0",
+    "volto-querywidget-with-browser": "0.4.0",
     "volto-rss-block": "3.0.0",
     "volto-secondarymenu": "4.0.0",
     "volto-social-settings": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6482,7 +6482,7 @@ __metadata:
     volto-gdpr-privacy: 2.1.0
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
-    volto-querywidget-with-browser: "git+https://gitlab.com/redturtle/volto-querywidget-with-browser.git#v0.4.0"
+    volto-querywidget-with-browser: 0.4.0
     volto-rss-block: 3.0.0
     volto-secondarymenu: 4.0.0
     volto-social-settings: 3.0.0
@@ -14191,12 +14191,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-querywidget-with-browser@git+https://gitlab.com/redturtle/volto-querywidget-with-browser.git#v0.4.0":
+"volto-querywidget-with-browser@npm:0.4.0":
   version: 0.4.0
-  resolution: "volto-querywidget-with-browser@https://gitlab.com/redturtle/volto-querywidget-with-browser.git#commit=8c03431503add4368ad38a5ae281c1ddfb59078b"
+  resolution: "volto-querywidget-with-browser@npm:0.4.0"
   peerDependencies:
     "@plone/volto": ^17.0.0
-  checksum: a3ea58f94c21e5e44deabffab737817358810f5bd39582c8b220cce9d04cf556117abb3405e4a10abea7f0a566f27c4f69c73da1597cce8a90067e6be55509e1
+  checksum: ac57171aa9aa89617afb25814cdcf7e434f3efbeb6e1477db6163aee1b8ec08173e8df86cb2a2ef05d21c9a64b66174e72fd5ba621412a25fb809dc89058b9e9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6482,6 +6482,7 @@ __metadata:
     volto-gdpr-privacy: 2.1.0
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
+    volto-querywidget-with-browser: "git+https://gitlab.com/redturtle/volto-querywidget-with-browser.git#v0.4.0"
     volto-rss-block: 3.0.0
     volto-secondarymenu: 4.0.0
     volto-social-settings: 3.0.0
@@ -14187,6 +14188,15 @@ __metadata:
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
   checksum: 3fa0611e7966ceeb22ea93e361b1811134ce67b5e1487c02a335601c0d77edb5aa9f5989e470a823794d24d70a963adad25f5d6a593354ada544c8d3ccc69a1e
+  languageName: node
+  linkType: hard
+
+"volto-querywidget-with-browser@git+https://gitlab.com/redturtle/volto-querywidget-with-browser.git#v0.4.0":
+  version: 0.4.0
+  resolution: "volto-querywidget-with-browser@https://gitlab.com/redturtle/volto-querywidget-with-browser.git#commit=8c03431503add4368ad38a5ae281c1ddfb59078b"
+  peerDependencies:
+    "@plone/volto": ^17.0.0
+  checksum: a3ea58f94c21e5e44deabffab737817358810f5bd39582c8b220cce9d04cf556117abb3405e4a10abea7f0a566f27c4f69c73da1597cce8a90067e6be55509e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Aggiunto l'addon per fare in modo che nel criterio "posizione" del blocco elenco sia possibile scegliere l'oggetto da linkare con il browser. 
Con questo widget, se si seleziona un oggetto e poi questo oggetto cambia percorso, non è necessario sistemare il blocco elenco. 

https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/7e72f939-5396-4fe2-9ad9-f504bb68cbdd

