### PR TITLE
fix: listing options order

### DIFF
--- a/src/config/Blocks/ListingOptions/bandiInEvidenceTemplate.js
+++ b/src/config/Blocks/ListingOptions/bandiInEvidenceTemplate.js
@@ -17,7 +17,7 @@ export const addBandiInEvidenceTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
@@ -30,7 +30,7 @@ export const addCardWithImageTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate.js
@@ -9,7 +9,7 @@ export const addCardWithSlideUpTextTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/completeBlockLinksTemplate.js
+++ b/src/config/Blocks/ListingOptions/completeBlockLinksTemplate.js
@@ -9,7 +9,7 @@ export const addCompleteBlockLinksTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/defaultOptions.js
+++ b/src/config/Blocks/ListingOptions/defaultOptions.js
@@ -31,7 +31,7 @@ const messages = defineMessages({
 
 /** DEFAULT **/
 
-const addDefaultOptions = (schema, formData = {}, intl, position = 0) => {
+const addDefaultOptions = (schema, formData = {}, intl, position = 1) => {
   let listing_items_colors =
     config.blocks.blocksConfig.listing?.listing_items_colors || [];
   let listing_bg_colors =

--- a/src/config/Blocks/ListingOptions/inEvidenceTemplate.js
+++ b/src/config/Blocks/ListingOptions/inEvidenceTemplate.js
@@ -18,7 +18,7 @@ export const addInEvidenceTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/mapTemplate.js
+++ b/src/config/Blocks/ListingOptions/mapTemplate.js
@@ -25,7 +25,7 @@ const messages = defineMessages({
   },
 });
 
-export const addMapTemplateOptions = (schema, formData, intl, position = 0) => {
+export const addMapTemplateOptions = (schema, formData, intl, position = 1) => {
   let pos = position;
 
   addSchemaField(

--- a/src/config/Blocks/ListingOptions/photogalleryTemplate.js
+++ b/src/config/Blocks/ListingOptions/photogalleryTemplate.js
@@ -12,7 +12,7 @@ export const addPhotogalleryTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/ribbonCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/ribbonCardTemplate.js
@@ -18,7 +18,7 @@ export const addRibbonCardTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/simpleCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/simpleCardTemplate.js
@@ -36,7 +36,7 @@ export const addSimpleCardTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
   pos = addLighthouseField(schema, intl, pos);

--- a/src/config/Blocks/ListingOptions/simpleListTemplate.js
+++ b/src/config/Blocks/ListingOptions/simpleListTemplate.js
@@ -13,7 +13,7 @@ export const addSimpleListTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/sliderTemplate.js
+++ b/src/config/Blocks/ListingOptions/sliderTemplate.js
@@ -37,7 +37,7 @@ export const addSliderTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/smallBlockLinksTemplate.js
+++ b/src/config/Blocks/ListingOptions/smallBlockLinksTemplate.js
@@ -14,7 +14,7 @@ export const addSmallBlockLinksTemplateOptions = (
   schema,
   formData,
   intl,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 

--- a/src/config/Blocks/ListingOptions/utils.js
+++ b/src/config/Blocks/ListingOptions/utils.js
@@ -67,7 +67,7 @@ export const addSchemaField = (
   title,
   description,
   properties = {},
-  position = 0,
+  position = 1,
   fieldset = 'default',
 ) => {
   let fieldsetIndex = schema.fieldsets.findIndex((x) => x.id === fieldset);
@@ -86,7 +86,7 @@ export const templatesOptions = (
   intl,
   fields,
   fieldsConfig,
-  position = 0,
+  position = 1,
 ) => {
   let pos = position;
 
@@ -151,7 +151,7 @@ export const templatesOptions = (
   return pos;
 };
 
-export const addLighthouseField = (schema, intl, position = 0) => {
+export const addLighthouseField = (schema, intl, position = 1) => {
   let pos = position;
   const fieldset =
     schema.id === 'search' ? 'listingTemplateOptions' : undefined;


### PR DESCRIPTION
Sistemato l'ordinamento delle option nella sidebar del blocco elenco, per fare in modo che il primo campo sia sempre la scelta del template. Probabilmente con l'ultimo aggiornamento di Volto si era scombianto qualcosa. 

Come era: 
<img width="385" alt="Schermata 2023-12-22 alle 13 15 41" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/98d61ba8-6c67-43f8-91e6-6f951dfc5c13">

Come è ora con questo fix: 
<img width="374" alt="Schermata 2023-12-22 alle 13 14 28" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/bd78e944-8c73-4c45-994e-bd644c9d16bd">


