### PR TITLE
fix: removed style that hides modal close icon

### DIFF
--- a/src/theme/extras/_modals.scss
+++ b/src/theme/extras/_modals.scss
@@ -35,20 +35,3 @@
     cursor: pointer;
   }
 }
-
-.modal-dialog {
-  .modal-header {
-    align-items: flex-start;
-
-    button.btn-close {
-      display: flex;
-      width: fit-content;
-      align-items: center;
-      background: none;
-
-      span {
-        font-size: 50px;
-      }
-    }
-  }
-}


### PR DESCRIPTION
Fix per l'icona di chiusura modale
![Screenshot 2023-12-27 alle 17 15 32](https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/f53e5369-31f9-4201-8dee-ce6adb3107bb)
