### PR TITLE
fix: backwards compatibility for background color var of Alert block

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Alert/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/Edit.jsx
@@ -60,7 +60,7 @@ class Edit extends Component {
   constructor(props) {
     super(props);
     if (!this.props.data.bg_color) {
-      this.props.data.bg_color = 'warning';
+      this.props.data.bg_color = this.props.data.color ?? 'warning'; // backwards compatibility with previous background-color variable name 'color'
     }
     this.blockNode = React.createRef();
   }

--- a/src/components/ItaliaTheme/Blocks/Alert/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/Alert/View.jsx
@@ -27,9 +27,11 @@ const View = ({ data, pathname }) => {
       )
     : '';
 
+  const background_color = data.bg_color ?? data.color; // backwards compatibility with previous background-color variable name 'color'
+
   return (
     <section role="alert" className="block alertblock">
-      <div className={cx('full-width', 'bg-alert-' + data.bg_color)}>
+      <div className={cx('full-width', 'bg-alert-' + background_color)}>
         <Container className="p-4 pt-5 pb-5">
           <Row className="align-items-start">
             {data.image?.data && (


### PR DESCRIPTION
Per un qualche motivo è stato cambiato il nome della prop in cui viene salvato il colore del blocco alert, e quindi i blocchi esistenti avevano perso il colore.
ora viene testato sia il vecchio nome del campo (color) che il nuovo nome del campo (bg_color), e quando si entra in edit viene impostato come valore di default il valore di 'color' se esisteva, oppure il colore arancione (warning).

E' un fix temporaneo in attesa di capire come muoversi, ed eventualmente pensare ad un upgradestep