### PR TITLE
fix: fixed callout style draftJs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,7 @@
 ### Fix
 
 - Risolto un problema nell'edit della ricorrenza di un evento.
+- Risolto problema con lo stile "callout", icona megafono dell'editor di testo con sfondo bianco e bordo grigio
 
 ## Versione 11.2.0 (11/01/2023)
 
@@ -64,7 +65,6 @@
 - Risolto problema nel funzionamento della toolbar per il blocco HTML.
 - Sistemate spaziature e font su mobile del blocco Card con Immagine e Card Semplice, migliorato il layout di quest'ultimo.
 - È stato migliorato il contrasto minimo necessario tra sfondo e testo nei blocchi numeri, countdown e galleria a griglia.
-- Risolto problema con lo stile "callout", icona megafono dell'editor di testo con sfondo bianco e bordo grigio
 
 ## Versione 11.1.4 (05/01/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 - Risolto problema nel funzionamento della toolbar per il blocco HTML.
 - Sistemate spaziature e font su mobile del blocco Card con Immagine e Card Semplice, migliorato il layout di quest'ultimo.
 - È stato migliorato il contrasto minimo necessario tra sfondo e testo nei blocchi numeri, countdown e galleria a griglia.
+- Risolto problema con lo stile "callout", icona megafono dell'editor di testo con sfondo bianco e bordo grigio
 
 ## Versione 11.1.4 (05/01/2024)
 

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -101,7 +101,10 @@ iframe {
     }
   }
 
-  .callout {
+  p.callout {
+    max-width: none;
+    border-left-width: 0.4rem;
+
     p,
     .public-DraftStyleDefault-block {
       &:last-of-type {

--- a/src/theme/bootstrap-override/bootstrap-italia/_callout.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_callout.scss
@@ -1,8 +1,8 @@
-.callout {
+div.callout {
+  max-width: none;
   padding: 0; //override volto's style
   border: none;
   border-radius: unset;
   margin: 0;
   box-shadow: none;
-  max-width: none;
 }


### PR DESCRIPTION
Lo stile "callout" introdotto con un elemento di bootstrap-Italia entrava in conflitto con quello applicato al testo di draftJs.

![Screenshot 2024-01-11 alle 12 58 18](https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/fe29983b-d422-439e-aefa-099ab0826fc9)

![Screenshot 2024-01-11 alle 13 11 50](https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/583b0d91-edcf-4ec5-960d-8cbff484760f)
