### PR TITLE
fix: recurrence string and edit recurrence

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,13 +41,22 @@
 - ...
 -->
 
+## Versione x.x.x (dd/mm/yyyy)
+
+### Migliorie
+
+- Migliorata il testo della ricorrenza di un evento.
+
+### Fix
+
+- Risolto un problema nell'edit della ricorrenza di un evento.
+
 ## Versione 11.2.0 (11/01/2023)
 
 ### Migliorie
 
 - Migliorata l'accessibilità nella pagina di Ricerca.
 - Diminuita la larghezza del testo nelle card che indicano i luoghi.
-- Migliorata il testo della ricorrenza di un evento.
 
 ### Fix
 
@@ -55,7 +64,6 @@
 - Risolto problema nel funzionamento della toolbar per il blocco HTML.
 - Sistemate spaziature e font su mobile del blocco Card con Immagine e Card Semplice, migliorato il layout di quest'ultimo.
 - È stato migliorato il contrasto minimo necessario tra sfondo e testo nei blocchi numeri, countdown e galleria a griglia.
-- Risolto un problema nell'edit della ricorrenza di un evento.
 
 ## Versione 11.1.4 (05/01/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,7 @@
 
 - Migliorata l'accessibilità nella pagina di Ricerca.
 - Diminuita la larghezza del testo nelle card che indicano i luoghi.
+- Migliorata il testo della ricorrenza di un evento.
 
 ### Fix
 
@@ -54,6 +55,7 @@
 - Risolto problema nel funzionamento della toolbar per il blocco HTML.
 - Sistemate spaziature e font su mobile del blocco Card con Immagine e Card Semplice, migliorato il layout di quest'ultimo.
 - È stato migliorato il contrasto minimo necessario tra sfondo e testo nei blocchi numeri, countdown e galleria a griglia.
+- Risolto un problema nell'edit della ricorrenza di un evento.
 
 ## Versione 11.1.4 (05/01/2024)
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2919,6 +2919,36 @@ msgstr ""
 msgid "risultati_indagini_customer_satisfaction"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: il giorno
+msgid "rrule_in"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_nd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: il
+msgid "rrule_on the"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_rd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_st"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_th"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 # defaultMessage: No results from RSS feed.

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2907,32 +2907,32 @@ msgstr "Customer satisfaction survey results"
 #: overrideTranslations
 # defaultMessage: il giorno
 msgid "rrule_in"
-msgstr ""
+msgstr "in"
 
 #: overrideTranslations
 # defaultMessage: _
 msgid "rrule_nd"
-msgstr ""
+msgstr "nd"
 
 #: overrideTranslations
 # defaultMessage: il
 msgid "rrule_on the"
-msgstr ""
+msgstr "on the"
 
 #: overrideTranslations
 # defaultMessage: _
 msgid "rrule_rd"
-msgstr ""
+msgstr "rd"
 
 #: overrideTranslations
 # defaultMessage: _
 msgid "rrule_st"
-msgstr ""
+msgstr "st"
 
 #: overrideTranslations
 # defaultMessage: _
 msgid "rrule_th"
-msgstr ""
+msgstr "th"
 
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2904,6 +2904,36 @@ msgstr "Rights"
 msgid "risultati_indagini_customer_satisfaction"
 msgstr "Customer satisfaction survey results"
 
+#: overrideTranslations
+# defaultMessage: il giorno
+msgid "rrule_in"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_nd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: il
+msgid "rrule_on the"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_rd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_st"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_th"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 # defaultMessage: No results from RSS feed.

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2913,6 +2913,36 @@ msgstr "Derechos"
 msgid "risultati_indagini_customer_satisfaction"
 msgstr "Resultados de la encuesta de satisfacción del cliente"
 
+#: overrideTranslations
+# defaultMessage: il giorno
+msgid "rrule_in"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_nd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: il
+msgid "rrule_on the"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_rd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_st"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_th"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 # defaultMessage: No results from RSS feed.

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2921,6 +2921,36 @@ msgstr "Droits"
 msgid "risultati_indagini_customer_satisfaction"
 msgstr "Résultats des enquêtes de satisfaction clients"
 
+#: overrideTranslations
+# defaultMessage: il giorno
+msgid "rrule_in"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_nd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: il
+msgid "rrule_on the"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_rd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_st"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_th"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 # defaultMessage: No results from RSS feed.

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2904,6 +2904,36 @@ msgstr "Diritti"
 msgid "risultati_indagini_customer_satisfaction"
 msgstr "Risultati indagini di customer satisfaction"
 
+#: overrideTranslations
+# defaultMessage: il giorno
+msgid "rrule_in"
+msgstr "il giorno"
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_nd"
+msgstr " "
+
+#: overrideTranslations
+# defaultMessage: il
+msgid "rrule_on the"
+msgstr "il giorno"
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_rd"
+msgstr " "
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_st"
+msgstr " "
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_th"
+msgstr " "
+
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 # defaultMessage: No results from RSS feed.

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-01-11T11:04:31.849Z\n"
+"POT-Creation-Date: 2024-01-11T13:44:40.490Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2904,6 +2904,36 @@ msgstr ""
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Risultati indagini di customer satisfaction
 msgid "risultati_indagini_customer_satisfaction"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: il giorno
+msgid "rrule_in"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_nd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: il
+msgid "rrule_on the"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_rd"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_st"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: _
+msgid "rrule_th"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -37,7 +37,6 @@ import {
   FREQUENCES,
   WEEKLY_DAYS,
   MONDAYFRIDAY_DAYS,
-  toISOString,
   rrulei18n,
 } from '@plone/volto/components/manage/Widgets/RecurrenceWidget/Utils';
 
@@ -437,17 +436,17 @@ class RecurrenceWidget extends Component {
         case 'until':
           let mDate = null;
           if (value) {
-            mDate = this.moment(new Date(value));
+            mDate = moment(new Date(value));
             if (typeof value === 'string') {
-              mDate = this.moment(new Date(value));
+              mDate = moment(new Date(value));
             } else {
               //object-->Date()
-              mDate = this.moment(value);
+              mDate = moment(value);
             }
 
             if (this.props.formData.end) {
               //set time from formData.end
-              const mEnd = this.moment(new Date(this.props.formData.end));
+              const mEnd = moment(new Date(this.props.formData.end));
               mDate.set('hour', mEnd.get('hour'));
               mDate.set('minute', mEnd.get('minute'));
             }
@@ -476,8 +475,8 @@ class RecurrenceWidget extends Component {
       field === 'dtstart'
         ? value
         : rruleSet.dtstart()
-        ? rruleSet.dtstart()
-        : new Date();
+          ? rruleSet.dtstart()
+          : new Date();
     var exdates =
       field === 'exdates' ? value : Object.assign([], rruleSet.exdates());
 

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -1,0 +1,28 @@
+import { defineMessages } from 'react-intl';
+
+defineMessages({
+  rrule_st: {
+    id: 'rrule_st',
+    defaultMessage: '_', //in italiano non si traduce
+  },
+  rrule_nd: {
+    id: 'rrule_nd',
+    defaultMessage: '_', //in italiano non si traduce
+  },
+  rrule_rd: {
+    id: 'rrule_rd',
+    defaultMessage: '_', //in italiano non si traduce
+  },
+  rrule_th: {
+    id: 'rrule_th',
+    defaultMessage: '_', //in italiano non si traduce
+  },
+  rrule_in: {
+    id: 'rrule_in',
+    defaultMessage: 'il giorno',
+  },
+  rrule_on_the: {
+    id: 'rrule_on the',
+    defaultMessage: 'il',
+  },
+});


### PR DESCRIPTION
Sistemato l'edit della ricorrenza: si rompeva quando si provava ad editare una ricorrenza.
Sistemata la stringa della ricorrenza nel caso vengano selezionati giorni del mese come 1, 21, 31:

Come era: 
 
<img width="806" alt="Schermata 2024-01-11 alle 14 42 13" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/7d144204-9b52-4bcd-9e3b-ff2c6149d47a">

Com
<img width="971" alt="Schermata 2024-01-11 alle 15 06 21" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/0378ba23-d7f5-477d-a1de-73a2822a07d1">
e è ora:
