### PR TITLE
fix: bug when importing svg icons without viewBox

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ... [`Istruzioni`](url della documentazione relativa alla novità)
+
+### Fix
+
+- Risolto un problema di visualizzazione di alcune icone social.
+
 ## Versione 11.3.0 (16/01/2024)
 
 ### Novità

--- a/razzle.extend.js
+++ b/razzle.extend.js
@@ -63,6 +63,7 @@ const modify = (webpackConfig, { target, dev }, webpackObject) => {
               params: { removeUselessStrokeAndFill: true },
             },
             { name: 'removeViewBox', params: { removeViewBox: false } },
+            'removeDimensions',
           ],
         },
       },

--- a/src/components/ItaliaTheme/Icons/DesignIcon.jsx
+++ b/src/components/ItaliaTheme/Icons/DesignIcon.jsx
@@ -41,8 +41,10 @@ const Icon = ({ icon, title, className, size }) => {
     const { current: name } = ImportedIconRef;
     return (
       <svg
-        xmlns={name.attributes && name.attributes.xmlns}
-        viewBox={name.attributes && name.attributes.viewBox}
+        xmlns={name.attributes?.xmlns}
+        viewBox={name.attributes?.viewBox}
+        width={name.attributes?.width}
+        height={name.attributes?.height}
         style={{ height: size, width: 'auto' }}
         className={className}
         aria-hidden="true"


### PR DESCRIPTION
Ho aggiunto gli attributi width e height nel componente dell'icona per totale sicurezza, ma in realtà non dovrebbero mai essere usati perché a monte nell'import degli svg di bootstrap-italia ho aggiunto un plugin di svgo che converte width e height in viewBox, che è migliore perché così l'icona è scalabile infinitamente, mentre senza viewBox non lo è.