### PR TITLE
scale for index 3

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
@@ -62,7 +62,7 @@ const GridGalleryTemplate = ({
             });
 
             let scale = null;
-            if (index % 7 === 0 || index % 7 === 6) {
+            if (index % 7 === 0 || index % 7 === 6 || index % 7 === 3) {
               scale = 'great';
             }
             if (index % 7 === 1 || index % 7 === 5) {
@@ -71,7 +71,6 @@ const GridGalleryTemplate = ({
             if (index % 7 === 2 || index % 7 === 4) {
               scale = 'large';
             }
-
             if (scale && item?.image?.scales?.[scale]) {
               image = (
                 <picture className="volto-image responsive">


### PR DESCRIPTION
The condition for `index % 7 === 3` was missing, and this creates a wrong layout for a card with the class item-3

<img width="629" alt="Screenshot 2024-01-24 at 16 19 43" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/7867e708-c8b0-458f-b8d5-eef9ce38b49b">
