### PR TITLE
Bug 51205 visualizzazione cartella modulistica

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,13 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Sistemato il layout e la visualizzazione della vista del CT Cartella Modulistica per gestire al meglio gli elementi
+  titolo, titolo del modulo e link al download in caso di testi lunghi, specialmente su mobile
+
 ## Versione 11.3.2 (19/01/2023)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Views/_cartellaModulistica.scss
+++ b/src/theme/ItaliaTheme/Views/_cartellaModulistica.scss
@@ -48,7 +48,9 @@ $docs-section-margin: 3em;
           justify-content: space-between;
           padding: 0.4em 0;
           gap: 4rem;
-
+          .title {
+            flex: 1;
+          }
           .title-wrap {
             flex: 1;
 
@@ -182,6 +184,14 @@ $docs-section-margin: 3em;
       .documents-section,
       .document-row-section {
         .doc-row {
+          .doc:not(.modulo) {
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: center;
+            .downloads {
+              width: 100%;
+            }
+          }
           .doc {
             flex-wrap: wrap;
             align-items: center;
@@ -211,6 +221,7 @@ $docs-section-margin: 3em;
 
             &.modulo {
               justify-content: space-between;
+              flex-wrap: nowrap;
 
               .title,
               .downloads {


### PR DESCRIPTION
fix: ct Cartella Modulistica layout fixes, handle long text and fix mobile layout

Prima
<img width="591" alt="image" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/41484878/8737855b-bab3-4f13-a460-2ac0a54d4a2b">

Dopo
![image](https://github.com/RedTurtle/design-comuni-plone-theme/assets/41484878/cce38fcd-a2af-453f-8b93-ca811db500f6)
