### PR TITLE
feat: the default maximum b_size allowed in redturtle.volto is 500

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/Attachments.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Attachments.jsx
@@ -54,7 +54,8 @@ const Attachments = ({
             sort_on: 'getObjPositionInParent',
             metadata_fields: '_all',
             fullobjects: 1,
-            b_size: 900,
+            // the default maximum b_size allowed in redturtle.volto is 500
+            b_size: 499,
           },
           key,
         ),


### PR DESCRIPTION
This fix remove annoying log warning