### PR TITLE
set height for DocumentBody images

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/WideImage.jsx
+++ b/src/components/ItaliaTheme/View/Commons/WideImage.jsx
@@ -31,6 +31,7 @@ const WideImage = ({
             critical
             loading="eager"
             sizes={sizes}
+            responsive={!fullWidth}
           />
         )}
         {caption && (

--- a/src/theme/ItaliaTheme/Views/_common.scss
+++ b/src/theme/ItaliaTheme/Views/_common.scss
@@ -272,6 +272,7 @@ div.sticky-wrapper {
 .wide-image:not(.row-full-width) {
   img {
     max-width: 100%;
+    height: auto;
   }
 }
 

--- a/src/theme/ItaliaTheme/Views/_common.scss
+++ b/src/theme/ItaliaTheme/Views/_common.scss
@@ -269,13 +269,6 @@ div.sticky-wrapper {
   }
 }
 
-.wide-image:not(.row-full-width) {
-  img {
-    max-width: 100%;
-    height: auto;
-  }
-}
-
 .content-image {
   figure {
     width: 100%;


### PR DESCRIPTION
height: auto

- The new Image component no longer uses the <picture> element as it did before. This change has led to a height issue when the imagePosition variables are set to DocumentBody within the config file.

<img width="1385" alt="Screenshot 2024-01-31 at 11 27 00" src="https://github.com/italia/design-comuni-plone-theme/assets/60133113/51a937c5-5bd2-4040-b579-7247c87bf074">

Result:
<img width="1378" alt="Screenshot 2024-01-31 at 11 29 25" src="https://github.com/italia/design-comuni-plone-theme/assets/60133113/0199b956-fbed-4732-972c-f7059560f7d7">
