### PR TITLE
chore: updated volto-querywidget-with-browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "volto-gdpr-privacy": "2.1.1",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",
-    "volto-querywidget-with-browser": "0.4.0",
+    "volto-querywidget-with-browser": "0.4.1",
     "volto-rss-block": "3.0.0",
     "volto-secondarymenu": "4.0.0",
     "volto-social-settings": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6580,7 +6580,7 @@ __metadata:
     volto-gdpr-privacy: 2.1.1
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
-    volto-querywidget-with-browser: 0.4.0
+    volto-querywidget-with-browser: 0.4.1
     volto-rss-block: 3.0.0
     volto-secondarymenu: 4.0.0
     volto-social-settings: 3.0.0
@@ -14401,12 +14401,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-querywidget-with-browser@npm:0.4.0":
-  version: 0.4.0
-  resolution: "volto-querywidget-with-browser@npm:0.4.0"
+"volto-querywidget-with-browser@npm:0.4.1":
+  version: 0.4.1
+  resolution: "volto-querywidget-with-browser@npm:0.4.1"
   peerDependencies:
     "@plone/volto": ^17.0.0
-  checksum: ac57171aa9aa89617afb25814cdcf7e434f3efbeb6e1477db6163aee1b8ec08173e8df86cb2a2ef05d21c9a64b66174e72fd5ba621412a25fb809dc89058b9e9
+  checksum: a01eacb7fa67561066f288c7ba18f5af177a88deca142f57c33638eb63bc1894d46ac66f01c6d2e3ea4e4f43479b762a63246a08f6600d665174d55d2a49c207
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fissato un problema nel widget di selezione del path del blocco elenco, per il quale se si inserivano due condizioni per 'Percorso' non manteneva i diversi valori delle condizioni per percorso, ma le eguagliava all'ultimo percorso selezionato