### PR TITLE
feat: enable dynamic footer generation from control panel

### DIFF
--- a/src/components/ItaliaTheme/Footer/FooterNavigation.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterNavigation.jsx
@@ -23,6 +23,9 @@ const messages = defineMessages({
 const FooterNavigation = () => {
   const intl = useIntl();
   const items = useSelector((state) => state.navigation.items, isEqual);
+  const show_navigation = useSelector(
+    (state) => state.navigation.show_in_footer,
+  );
 
   // DEPRECATED: isFooterCollapsed to be removed in version 12
   if (config.settings.isFooterCollapsed) {
@@ -32,7 +35,7 @@ const FooterNavigation = () => {
     );
   }
 
-  return (
+  return show_navigation ? (
     <>
       {items && (
         <Row tag="div">
@@ -87,6 +90,8 @@ const FooterNavigation = () => {
         </Row>
       )}
     </>
+  ) : (
+    <></>
   );
 };
 

--- a/src/customizations/volto/reducers/navigation/navigation.js
+++ b/src/customizations/volto/reducers/navigation/navigation.js
@@ -69,6 +69,8 @@ export default function navigation(state = initialState, action = {}) {
         return {
           ...state,
           error: null,
+          show_in_footer:
+            action.result['@components'].navigation.show_in_footer,
           items: getRecursiveItems(
             action.result['@components'].navigation.items,
           ),
@@ -86,6 +88,8 @@ export default function navigation(state = initialState, action = {}) {
         return {
           ...state,
           error: null,
+          show_in_footer:
+            action.result['@components'].navigation.show_in_footer,
           items: getRecursiveItems(action.result.items),
           loaded: true,
           loading: false,
@@ -97,6 +101,7 @@ export default function navigation(state = initialState, action = {}) {
         ...state,
         error: action.error,
         items: [],
+        show_in_footer: null,
         loaded: false,
         loading: false,
       };


### PR DESCRIPTION
per per il backend qui https://github.com/RedTurtle/design.plone.contenttypes/pull/238/files

Introdotta la possibilità di mostrare o meno nel footer le colonne autogenerate con i contenuti del sito, tramite un flag nel pannello di controllo