### PR TITLE
fix: removed top spacing from image block in view

### DIFF
--- a/src/theme/ItaliaTheme/Blocks/_imageBlock.scss
+++ b/src/theme/ItaliaTheme/Blocks/_imageBlock.scss
@@ -19,6 +19,8 @@
 
   &.align.left,
   &.align.right {
+    margin-bottom: 0;
+
     img {
       margin-bottom: 0.5rem;
     }


### PR DESCRIPTION
Rimossa la spaziatura superiore tra le immagini e i paragrafi allineati a destra o a sinistra.

<img width="1338" alt="Screenshot 2024-01-31 alle 17 56 41" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/f15d65aa-f81f-4aa6-8114-2a497ff24619">
