### PR TITLE
fix: query for listing path filters

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,8 @@
 
 - Risolto un problema riguardante la visualizzazione delle date nelle card che rappresentano uun CT Evento nei vari listati nel caso in cui l'evento si sviluppi su anni diversi
 
+- Nel blocco elenco, sono stati sistemati i filtri per percorso quando si clicca sul bottone configurato.
+
 ## Versione 11.4.1 (08/02/2024)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -163,7 +163,7 @@ const SimpleCardTemplateDefault = (props) => {
                     tag="button"
                     className="ms-3"
                     onClick={(e) => {
-                      addPathFilter(button.path['@id']);
+                      addPathFilter(button.path['UID']);
                     }}
                   >
                     {button.label}


### PR DESCRIPTION
Risolve questo problema:
nel blocco elenco, quando si impostano i filtri per percorso, se poi si clicca sul bottone configurato, non si vede nessun risultato. 

Il motivo era che veniva passata alla query il valore sbagliato del path su cui filtrare. 