### PR TITLE
chore: hidden pagination size field from calendar block props

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,6 +43,10 @@
 
 ## Versione X.X.X (dd/mm/yyyy)
 
+### Migliorie
+
+- Rimosso il campo "Risultati per pagina" che non agiva sulle impostazioni del blocco Calendario.
+
 ### Fix
 
 - Risolto un problema riguardante la visualizzazione delle date nelle card che rappresentano uun CT Evento nei vari listati nel caso in cui l'evento si sviluppi su anni diversi

--- a/src/components/ItaliaTheme/Blocks/Calendar/ListingSidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Calendar/ListingSidebar.jsx
@@ -127,7 +127,10 @@ const ListingSidebar = (props) => {
             <Icon name={downSVG} size="20px" />
           )}
         </Accordion.Title>
-        <Accordion.Content active={activeAccIndex === 1}>
+        <Accordion.Content
+          active={activeAccIndex === 1}
+          className="listing-calendar-props"
+        >
           <ListingData
             blocksConfig={{ listing: config.blocks.blocksConfig.listing }}
             {...props}

--- a/src/theme/ItaliaTheme/Blocks/_calendar.scss
+++ b/src/theme/ItaliaTheme/Blocks/_calendar.scss
@@ -200,3 +200,8 @@
     }
   }
 }
+
+/* Hidden pagination size from calendar props */
+.listing-calendar-props [class*='field-wrapper-b_size'] {
+  display: none;
+}


### PR DESCRIPTION
Nascosto il campo "Risultati per pagina" nel blocco Calendario.

<img width="1821" alt="Screenshot 2024-02-12 alle 10 42 42 copia" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/228de1e5-5cc1-4676-a132-1942bde79ecf">
