### PR TITLE
feat: added pre-filters in BandoSearch and updated user selection filters, added parameters in bando listing block

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2899,6 +2899,16 @@ msgid "searchBlock_help"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.
+msgid "searchBlock_help_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Filtri pre-impostati
+msgid "searchBlock_pre_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar
 # defaultMessage: Primario
@@ -3218,6 +3228,11 @@ msgstr ""
 msgid "share"
 msgstr ""
 
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra la data di ultima modifica
+msgid "show_data_ultima_modifica"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Mostra la data
 msgid "show_date"
@@ -3267,6 +3282,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/mapTemplate
 # defaultMessage: Mostra la mappa a tutta larghezza
 msgid "show_map_full_width"
+msgstr ""
+
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra le note anche per i bandi scaduti
+msgid "show_note"
 msgstr ""
 
 #: config/Blocks/ListingOptions/ribbonCardTemplate
@@ -3589,6 +3609,11 @@ msgstr ""
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Ulteriori informazioni
 msgid "ulteriori_informazioni"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+# defaultMessage: Data di ultima modifica
+msgid "ultima_modifica_bando"
 msgstr ""
 
 #: helpers/amministrazioneTrasparenteHelper

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2884,6 +2884,16 @@ msgid "searchBlock_help"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.
+msgid "searchBlock_help_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Filtri pre-impostati
+msgid "searchBlock_pre_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar
 # defaultMessage: Primario
@@ -3203,6 +3213,11 @@ msgstr "Arrange on 4 columns"
 msgid "share"
 msgstr "Share"
 
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra la data di ultima modifica
+msgid "show_data_ultima_modifica"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Mostra la data
 msgid "show_date"
@@ -3252,6 +3267,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/mapTemplate
 # defaultMessage: Mostra la mappa a tutta larghezza
 msgid "show_map_full_width"
+msgstr ""
+
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra le note anche per i bandi scaduti
+msgid "show_note"
 msgstr ""
 
 #: config/Blocks/ListingOptions/ribbonCardTemplate
@@ -3575,6 +3595,11 @@ msgstr "Responsible office"
 # defaultMessage: Ulteriori informazioni
 msgid "ulteriori_informazioni"
 msgstr "Further information"
+
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+# defaultMessage: Data di ultima modifica
+msgid "ultima_modifica_bando"
+msgstr ""
 
 #: helpers/amministrazioneTrasparenteHelper
 # defaultMessage: unità operativa

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2893,6 +2893,16 @@ msgid "searchBlock_help"
 msgstr "Seleccionar filtros de búsqueda para mostrar en bloquear."
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.
+msgid "searchBlock_help_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Filtri pre-impostati
+msgid "searchBlock_pre_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar
 # defaultMessage: Primario
@@ -3212,6 +3222,11 @@ msgstr "Organizar en 4 columnas"
 msgid "share"
 msgstr "Compartir"
 
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra la data di ultima modifica
+msgid "show_data_ultima_modifica"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Mostra la data
 msgid "show_date"
@@ -3262,6 +3277,11 @@ msgstr "Mostrar el título de la imagen."
 # defaultMessage: Mostra la mappa a tutta larghezza
 msgid "show_map_full_width"
 msgstr "Mostrar el mapa en ancho completo"
+
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra le note anche per i bandi scaduti
+msgid "show_note"
+msgstr ""
 
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 # defaultMessage: Mostra il nastro solo sulla prima card
@@ -3584,6 +3604,11 @@ msgstr "Oficina responsable"
 # defaultMessage: Ulteriori informazioni
 msgid "ulteriori_informazioni"
 msgstr "Más información"
+
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+# defaultMessage: Data di ultima modifica
+msgid "ultima_modifica_bando"
+msgstr ""
 
 #: helpers/amministrazioneTrasparenteHelper
 # defaultMessage: unità operativa

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2901,6 +2901,16 @@ msgid "searchBlock_help"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.
+msgid "searchBlock_help_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Filtri pre-impostati
+msgid "searchBlock_pre_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar
 # defaultMessage: Primario
@@ -3220,6 +3230,11 @@ msgstr "Disposer sur 4 colonnes"
 msgid "share"
 msgstr "Partager"
 
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra la data di ultima modifica
+msgid "show_data_ultima_modifica"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Mostra la data
 msgid "show_date"
@@ -3269,6 +3284,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/mapTemplate
 # defaultMessage: Mostra la mappa a tutta larghezza
 msgid "show_map_full_width"
+msgstr ""
+
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra le note anche per i bandi scaduti
+msgid "show_note"
 msgstr ""
 
 #: config/Blocks/ListingOptions/ribbonCardTemplate
@@ -3592,6 +3612,11 @@ msgstr "Bureau responsable"
 # defaultMessage: Ulteriori informazioni
 msgid "ulteriori_informazioni"
 msgstr "Informations complémentaires"
+
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+# defaultMessage: Data di ultima modifica
+msgid "ultima_modifica_bando"
+msgstr ""
 
 #: helpers/amministrazioneTrasparenteHelper
 # defaultMessage: unità operativa

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2884,6 +2884,16 @@ msgid "searchBlock_help"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.
+msgid "searchBlock_help_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Filtri pre-impostati
+msgid "searchBlock_pre_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar
 # defaultMessage: Primario
@@ -3203,6 +3213,11 @@ msgstr "Disponi su 4 colonne"
 msgid "share"
 msgstr "Condividi"
 
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra la data di ultima modifica
+msgid "show_data_ultima_modifica"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Mostra la data
 msgid "show_date"
@@ -3253,6 +3268,11 @@ msgstr ""
 # defaultMessage: Mostra la mappa a tutta larghezza
 msgid "show_map_full_width"
 msgstr "Mostra la mappa a tutta larghezza"
+
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra le note anche per i bandi scaduti
+msgid "show_note"
+msgstr ""
 
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 # defaultMessage: Mostra il nastro solo sulla prima card
@@ -3575,6 +3595,11 @@ msgstr "Ufficio responsabile"
 # defaultMessage: Ulteriori informazioni
 msgid "ulteriori_informazioni"
 msgstr "Ulteriori informazioni"
+
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+# defaultMessage: Data di ultima modifica
+msgid "ultima_modifica_bando"
+msgstr ""
 
 #: helpers/amministrazioneTrasparenteHelper
 # defaultMessage: unità operativa

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-01-16T14:29:53.874Z\n"
+"POT-Creation-Date: 2024-02-07T17:28:21.593Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2886,6 +2886,16 @@ msgid "searchBlock_help"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.
+msgid "searchBlock_help_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
+# defaultMessage: Filtri pre-impostati
+msgid "searchBlock_pre_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar
 # defaultMessage: Primario
@@ -3205,6 +3215,11 @@ msgstr ""
 msgid "share"
 msgstr ""
 
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra la data di ultima modifica
+msgid "show_data_ultima_modifica"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Mostra la data
 msgid "show_date"
@@ -3254,6 +3269,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/mapTemplate
 # defaultMessage: Mostra la mappa a tutta larghezza
 msgid "show_map_full_width"
+msgstr ""
+
+#: config/Blocks/ListingOptions/bandiInEvidenceTemplate
+# defaultMessage: Mostra le note anche per i bandi scaduti
+msgid "show_note"
 msgstr ""
 
 #: config/Blocks/ListingOptions/ribbonCardTemplate
@@ -3576,6 +3596,11 @@ msgstr ""
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Ulteriori informazioni
 msgid "ulteriori_informazioni"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+# defaultMessage: Data di ultima modifica
+msgid "ultima_modifica_bando"
 msgstr ""
 
 #: helpers/amministrazioneTrasparenteHelper

--- a/src/actions/getSearchBandiFilters.js
+++ b/src/actions/getSearchBandiFilters.js
@@ -1,17 +1,25 @@
 export const GET_SEARCH_BANDI_FILTERS = 'GET_SEARCH_BANDI_FILTERS';
+import { expandToBackendURL } from '@plone/volto/helpers';
 
 /**
  * Get search bandi filters.
  * @function getSearchBandiFilters
- * @returns {Object} Get search bandi filters action.
- */
+ * @returns {Object} Get search bandi filters action:
+ * {
+ *  offices: [],
+ *  subjects: [],
+ *  tipologie: [],
+ * }
+*/
+
 export function getSearchBandiFilters(path = '') {
-  let p = path === '/' ? '' : path;
+  // let p = path === '/' ? '' : path;
+  const pathSearchFilters = `${path === '/' ? '' : expandToBackendURL(path)}/@bandi-search-filters`;
   return {
     type: GET_SEARCH_BANDI_FILTERS,
     request: {
       op: 'get',
-      path: p + '/@bandi-search-filters',
+      path: pathSearchFilters,
     },
   };
 }

--- a/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
@@ -78,6 +78,10 @@ const Body = ({ data, inEditMode, path, onChangeBlock }) => {
       }
     });
 
+    if (data.defaultQuerystring) {
+      query.push(...data.defaultQuerystring.filter(el => el.i !== 'portal_type'));
+    }
+
     if (data.location && data.location[0]) {
       query.push({
         i: 'path',
@@ -125,7 +129,8 @@ const Body = ({ data, inEditMode, path, onChangeBlock }) => {
     return newState;
   };
 
-  const filtersConfig = FiltersConfig(null);
+  const pathSearch = data?.location?.length > 0 ? data.location[0]['@id'] : '/';
+  const filtersConfig = FiltersConfig(null, pathSearch);
   const getInitialState = () => {
     return {
       filterOne: filtersConfig[data?.filter_one],

--- a/src/components/ItaliaTheme/Blocks/BandiSearch/DefaultFilters.js
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/DefaultFilters.js
@@ -65,7 +65,7 @@ const messages = defineMessages({
   },
 });
 
-const DefaultFilters = () => {
+const DefaultFilters = (pathSearch) => {
   const intl = useIntl();
   moment.locale(intl.locale);
   const subsite = useSelector((state) => state.subsite?.data);
@@ -99,7 +99,14 @@ const DefaultFilters = () => {
         props: {
           value: null,
           options: {
-            vocabulary: 'redturtle.bandi.tipologia.vocabulary',
+            // vocabulary: 'redturtle.bandi.tipologia.vocabulary',
+            // placeholder: intl.formatMessage(messages.tipologia),
+            dispatch: {
+              action: getSearchBandiFilters,
+              path: subsite ? flattenToAppURL(subsite['@id']) : pathSearch || '/',
+              stateSelector: 'searchBandiFilters',
+              resultProp: 'tipologie',
+            },
             placeholder: intl.formatMessage(messages.tipologia),
           },
         },
@@ -147,7 +154,7 @@ const DefaultFilters = () => {
           options: {
             dispatch: {
               action: getSearchBandiFilters,
-              path: subsite ? flattenToAppURL(subsite['@id']) : '/',
+              path: subsite ? flattenToAppURL(subsite['@id']) : pathSearch || '/',
               stateSelector: 'searchBandiFilters',
               resultProp: 'offices',
             },
@@ -175,7 +182,7 @@ const DefaultFilters = () => {
           options: {
             dispatch: {
               action: getSearchBandiFilters,
-              path: subsite ? flattenToAppURL(subsite['@id']) : '/',
+              path: subsite ? flattenToAppURL(subsite['@id']) : pathSearch || '/',
               stateSelector: 'searchBandiFilters',
               resultProp: 'subjects',
             },
@@ -201,10 +208,10 @@ const DefaultFilters = () => {
       widget: {
         component: DateFilter,
         props: {
-          value: {
-            startDate: moment().startOf('day'),
-            endDate: moment().endOf('day'),
-          },
+          // value: {
+          //   startDate: moment().startOf('day'),
+          //   endDate: moment().endOf('day'),
+          // },
           showClearDates: true,
           // defaultStart: moment().startOf('day'),
           // defaultEnd: moment().endOf('day'),

--- a/src/components/ItaliaTheme/Blocks/BandiSearch/FiltersConfig.js
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/FiltersConfig.js
@@ -6,9 +6,9 @@ import DefaultFilters from 'design-comuni-plone-theme/components/ItaliaTheme/Blo
   componente da customizzare nel proprio sito per modificare/aggiungere tipologie di Filtri
   ***
  */
-const FiltersConfig = (dispatchFilter) => {
+const FiltersConfig = (dispatchFilter, path) => {
   // const subsite = useSelector((state) => state.subsite?.data);
-  const defaultFilters = DefaultFilters();
+  const defaultFilters = DefaultFilters(path);
 
   return {
     ...defaultFilters,

--- a/src/components/ItaliaTheme/Blocks/BandiSearch/Sidebar.jsx
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/Sidebar.jsx
@@ -8,6 +8,7 @@ import {
   ObjectBrowserWidget,
   CheckboxWidget,
 } from '@plone/volto/components';
+import QueryWidget from '@plone/volto/components/manage/Widgets/QueryWidget';
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
 import FiltersConfig from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/BandiSearch/FiltersConfig';
@@ -57,6 +58,14 @@ const messages = defineMessages({
     id: 'searchBlock_style',
     defaultMessage: 'Aspetto',
   },
+  pre_filters: {
+    id: 'searchBlock_pre_filters',
+    defaultMessage: 'Filtri pre-impostati',
+  },
+  help_filters: {
+    id: 'searchBlock_help_filters',
+    defaultMessage: "Questi filtri non verranno visualizzati dall'utente ma consentono di pre filtrare i bandi secondo alcuni criteri.",
+  },
   text_filter: {
     id: 'searchBlock_text_filter',
     defaultMessage: 'Filtro di testo',
@@ -101,16 +110,12 @@ const messages = defineMessages({
 
 const Sidebar = ({ block, data, onChangeBlock, required }) => {
   const intl = useIntl();
-  const [activeAccIndex, setActiveAccIndex] = useState(1);
 
-  function handleAccClick(e, titleProps) {
-    const { index } = titleProps;
-    const newIndex = activeAccIndex === index ? -1 : index;
+  /* Accordions active */
+  const [activeAccLayout, setActiveAccLayout] = useState(true);
+  const [activeAccFilters, setActiveAccFilters] = useState(true);
 
-    setActiveAccIndex(newIndex);
-  }
-
-  let filtersConfig = FiltersConfig(null);
+  let filtersConfig = FiltersConfig(null, null);
 
   const filters = Object.keys(filtersConfig).map((k) => [
     k,
@@ -219,18 +224,43 @@ const Sidebar = ({ block, data, onChangeBlock, required }) => {
       </Segment>
       <Accordion fluid styled className="form">
         <Accordion.Title
-          active={activeAccIndex === 1}
+          active={activeAccFilters}
           index={1}
-          onClick={handleAccClick}
+          onClick={() => setActiveAccFilters(!activeAccFilters)}
         >
-          {intl.formatMessage(messages.styles)}
-          {activeAccIndex === 1 ? (
+          {intl.formatMessage(messages.pre_filters)}
+          {activeAccFilters ? (
             <Icon name={upSVG} size="20px" />
           ) : (
             <Icon name={downSVG} size="20px" />
           )}
         </Accordion.Title>
-        <Accordion.Content active={activeAccIndex === 1}>
+        <Accordion.Content active={activeAccFilters}>
+          <Segment padded>
+            <p className="help">{intl.formatMessage(messages.help_filters)}</p>
+            <QueryWidget block={block} onChange={(id, value)=> {
+              onChangeBlock(block, {
+                ...data,
+                [id]: value,
+              });
+            }} id='defaultQuerystring' value={data.defaultQuerystring} />
+          </Segment>
+        </Accordion.Content>
+      </Accordion>
+      <Accordion fluid styled className="form">
+        <Accordion.Title
+          active={setActiveAccLayout}
+          index={1}
+          onClick={() => setActiveAccLayout(!activeAccLayout)}
+        >
+          {intl.formatMessage(messages.styles)}
+          {activeAccLayout ? (
+            <Icon name={upSVG} size="20px" />
+          ) : (
+            <Icon name={downSVG} size="20px" />
+          )}
+        </Accordion.Title>
+        <Accordion.Content active={activeAccLayout}>
           <SelectWidget
             id="bg_color"
             title={intl.formatMessage(messages.bg_color)}

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -36,6 +36,10 @@ const messages = defineMessages({
     id: 'chiusura_procedimento_bando',
     defaultMessage: 'Chiusura del procedimento',
   },
+  ultima_modifica: {
+    id: 'ultima_modifica_bando',
+    defaultMessage: 'Data di ultima modifica',
+  },
   stato: {
     id: 'bando_stato',
     defaultMessage: 'Stato:',
@@ -74,6 +78,8 @@ const BandiInEvidenceTemplate = ({
   show_ente,
   show_tipologia,
   show_description,
+  show_data_ultima_modifica,
+  show_note,
   linkTitle,
   linkHref,
   center_cards,
@@ -142,6 +148,18 @@ const BandiInEvidenceTemplate = ({
                         </div>
                         <span className="bando-dati-date">
                           {item.tipologia_bando?.title}
+                        </span>
+                      </span>
+                    )}
+
+                    {/* Data di ultima modifica */}
+                    {show_data_ultima_modifica && item.modified && (
+                      <span className="d-flex flex-wrap align-items-baseline bando-dati-info">
+                        <div className="bando-dati-label mr-2">
+                          {intl.formatMessage(messages.ultima_modifica)}:
+                        </div>
+                        <span className="bando-dati-date">
+                          {viewDate(intl.locale, item.modified, 'DD-MM-YYYY')}
                         </span>
                       </span>
                     )}
@@ -218,7 +236,8 @@ const BandiInEvidenceTemplate = ({
 
                     {/* Note aggiornamenti */}
                     {item.update_note &&
-                      (item.bando_state?.includes('open') ||
+                      ((show_note && item.bando_state?.includes('closed')) ||
+                        item.bando_state?.includes('open') ||
                         item.bando_state?.includes('inProgress')) && (
                         <span className="d-flex bando-note">
                           <strong>{item.update_note}</strong>

--- a/src/config/Blocks/ListingOptions/bandiInEvidenceTemplate.js
+++ b/src/config/Blocks/ListingOptions/bandiInEvidenceTemplate.js
@@ -11,6 +11,14 @@ const messages = defineMessages({
     id: 'show_tipologia',
     defaultMessage: 'Mostra la tipologia',
   },
+  show_data_ultima_modifica: {
+    id: 'show_data_ultima_modifica',
+    defaultMessage: 'Mostra la data di ultima modifica',
+  },
+  show_note: {
+    id: 'show_note',
+    defaultMessage: 'Mostra le note anche per i bandi scaduti',
+  },
 });
 
 export const addBandiInEvidenceTemplateOptions = (
@@ -25,7 +33,7 @@ export const addBandiInEvidenceTemplateOptions = (
     schema,
     formData,
     intl,
-    ['show_description', 'show_ente', 'show_tipologia'],
+    ['show_description', 'show_ente', 'show_tipologia', 'show_data_ultima_modifica', 'show_note'],
     {
       show_ente: {
         default: false,
@@ -34,6 +42,14 @@ export const addBandiInEvidenceTemplateOptions = (
       show_tipologia: {
         default: false,
         label: intl.formatMessage(messages.show_tipologia),
+      },
+      show_data_ultima_modifica: {
+        default: false,
+        label: intl.formatMessage(messages.show_data_ultima_modifica),
+      },
+      show_note: {
+        default: false,
+        label: intl.formatMessage(messages.show_note),
       },
     },
     pos,


### PR DESCRIPTION
Modifiche per questa [US51827](https://redturtle.tpondemand.com/entity/51827-modifica-oggetto-bando/comments/109996)

In particolare nel blocco elenco con variazione Bandi in evidenza
- sono stati aggiunte le proprietà per mostrare le Note di aggiornamento anche per i bandi scaduti e per mostrare la Data di ultima modifica

Nella ricerca Bandi
- I campi di tipo Tipologia/Categoria/Ufficio visibili all'utente vengono valorizzati a partire dai bandi specificati nella "Posizione in cui cercare" e non prendono più i valori dal vocabolario,
- sono stati implementati i pre-filtri non visibili dall'utente
- sono stati azzerati i filtri Data quando si atterra in pagina