### PR TITLE
table mobile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,7 @@
 - Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito
 - Migliorato l'HTML semantico per le card del blocco rss per migliorare l'esperienza d'uso con Screen Reader
 - Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
+- Visualizzazione mobile per il blocco tabela sistemata.
 
 ## Versione 7.24.2 (11/01/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,14 +32,6 @@
 
 ## Versione X.X.X (dd/mm/yyyy)
 
-### Migliorie
-
-- ...
-
-### Novità
-
-- ... [`Istruzioni`](url della documentazione relativa alla novità)
-
 ### Fix
 
 - Visualizzazione mobile per il blocco tabella sistemata.
@@ -60,10 +52,6 @@
 
 - Sono stati apportati alcuni aggiustamenti ai sottositi con l'intento di migliorare l'esperienza e aumentare l'accessibilità. In particolare le modifiche riguardano colori, visualizzazione della ricerca, blocchi info, blocco contenuto in primo piano e blocco icone e pulsanti.
 - Sono stati corretti alcuni errori nel menu mobile per i sottositi. Ora la lente di ingrandimento è visibile nei sottositi con colori scuri e la freccia nei pulsanti "link ad altro" è del colore del sottosito.
-- Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"
-- Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito
-- Migliorato l'HTML semantico per le card del blocco rss per migliorare l'esperienza d'uso con Screen Reader
-- Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - I link dei Social sono stati resi "parlanti" per motivi di accessibilità, ora viene riportato "Seguici su nome_del_social".
 - Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito.
 - Migliorato l'HTML semantico per le card del blocco RSS per migliorare l'esperienza d'uso con Screen Reader.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,9 +30,24 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ... [`Istruzioni`](url della documentazione relativa alla novità)
+
+### Fix
+
+- Visualizzazione mobile per il blocco tabella sistemata.
+
 ## Versione 7.25.0 (20/02/2024)
 
 ### Novità
+
 - Sono state aggiunte delle nuove proprietà nel blocco elenco con variazione Bandi in Evidenza per mostrare le Note di aggiornamento anche per i bandi scaduti e la Data di ultima modifica per tutti i bandi.
 - Nella ricerca per Bandi sono stati implementati dei pre-filtri non visibili dall'utente configurabili dalla sidebar laterale per rendere la ricerca più specifica all'utente.
 
@@ -49,7 +64,6 @@
 - Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito
 - Migliorato l'HTML semantico per le card del blocco rss per migliorare l'esperienza d'uso con Screen Reader
 - Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
-- Visualizzazione mobile per il blocco tabela sistemata.
 - I link dei Social sono stati resi "parlanti" per motivi di accessibilità, ora viene riportato "Seguici su nome_del_social".
 - Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito.
 - Migliorato l'HTML semantico per le card del blocco RSS per migliorare l'esperienza d'uso con Screen Reader.

--- a/theme/ItaliaTheme/_main.scss
+++ b/theme/ItaliaTheme/_main.scss
@@ -264,7 +264,6 @@ iframe {
 //table overflow mobile
 @media (max-width: #{map-get($grid-breakpoints, lg)}) {
   .public-ui table.ui.table {
-    display: block;
     overflow: auto;
     th {
       white-space: nowrap;


### PR DESCRIPTION
Il display block su blocco con le tabelle generava un spazio a destra sulla versione mobile. Togliendo il display non ho avuto ulteriori problemi e il problema è sparito.

<img width="558" alt="Screenshot 2024-02-16 at 09 51 32" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/7c6dbfce-a39e-4a64-949d-e8d818d7d212">

https://redturtle.tpondemand.com/entity/51937-errata-visualizzazione
