### PR TITLE
chore: updated bando_state from backend string label

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -228,7 +228,7 @@ const BandiInEvidenceTemplate = ({
                                 item.bando_state?.includes('inProgress'),
                             })}
                           >
-                            {intl.formatMessage(messages[item.bando_state[0]])}
+                            {item.bando_state[1]}
                           </div>
                         </span>
                       </span>

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderBando.jsx
@@ -64,7 +64,7 @@ const PageHeaderBando = ({ content }) => {
                 size=""
               />
               {intl.formatMessage(messages.bando)}{' '}
-              {intl.formatMessage(messages[content.bando_state[0]])}
+              {content.bando_state[1]}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Lo stato del bando ora viene letto dall'etichetta passata a backend, richiesto BE aggiornato all'ultima versione