### PR TITLE
callout bg

### DIFF
--- a/theme/ItaliaTheme/_main.scss
+++ b/theme/ItaliaTheme/_main.scss
@@ -83,7 +83,7 @@ iframe {
 
   .callout {
     padding: 1.25rem;
-    border: 1px solid $neutral-1-a2;
+    border: 1px solid $neutral-1-a1;
     border-left-width: 0.4rem;
     margin: 1.25rem 0;
     border-radius: 0.25rem;
@@ -99,7 +99,7 @@ iframe {
   .callout-bg {
     padding: 1.25rem;
     margin: 1.25rem 0;
-    background-color: $primary-c1;
+    background-color: $neutral-1-a1;
 
     p,
     .public-DraftStyleDefault-block {


### PR DESCRIPTION
Serve a standardizzare il colore su draftjs del pulsante callout con il blocco info (AUSL PC REQUEST)

![image](https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/c0d904c1-db36-4f1e-8a0f-f670a7b0678a)

<img width="1264" alt="Schermata 2024-02-20 alle 16 51 09" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/60133113/d4f3ace2-0b47-47bf-9060-a226ab387f9f">
