### PR TITLE
fix: fixed btn-primary icon with focus-visible

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,6 +63,7 @@
 - La tendina delle select nel blocco Form non si sovrappone più ai campi sottostanti.
 - Sistemato alert di errore nel blocco Form che nascondeva il form quando un campo non era valido, ora continua a visualizzarsi anche la form.
 - Migliorato il testo alternativo per il logo NextGenerationEU nel footer.
+- Sistemato il contrasto delle icone nei pulsanti "primary" quando si attiva il focus col tab da tastiera
 
 ## Versione 11.5.1 (19/02/2024)
 

--- a/src/theme/bootstrap-override/_bootstrap-italia-site.scss
+++ b/src/theme/bootstrap-override/_bootstrap-italia-site.scss
@@ -100,6 +100,7 @@
   @import 'bootstrap-italia/src/scss/custom/calendar';
   @import 'bootstrap-italia/src/scss/custom/alert';
   @import 'bootstrap-italia/src/scss/custom/buttons';
+  @import './bootstrap-italia/buttons';
   @import 'bootstrap-italia/src/scss/custom/font';
   @import 'bootstrap-italia/src/scss/custom/forms';
   @import 'bootstrap-italia/src/scss/custom/form-input-file';

--- a/src/theme/bootstrap-override/bootstrap-italia/_buttons.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_buttons.scss
@@ -1,0 +1,8 @@
+button.btn.btn-primary:focus-visible,
+.btn.btn-primary:focus-visible {
+  &:not(:hover) {
+    svg.icon {
+      fill: var(--bs-btn-hover-color);
+    }
+  }
+}


### PR DESCRIPTION
US [51943](https://redturtle.tpondemand.com/entity/51943-a11y-widget-calendario)
Con il focus-visible attivo sui button primary non si vedevano le icone

<img width="1313" alt="Screenshot 2024-03-04 alle 15 20 39" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/673a47e9-51a0-45ec-be56-642cd2b0799a">

<img width="1313" alt="Screenshot 2024-03-04 alle 15 20 21" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/0757fe3b-35ad-4b23-9f7a-460481479d4e">
