### PR TITLE
fix: default value for show_type in card-with-image-template

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -50,7 +50,7 @@ const CardWithImageTemplate = (props) => {
     show_block_bg = false,
     always_show_image = false,
     set_four_columns = false,
-    show_type = true,
+    show_type = false,
     show_section,
     show_icon = true,
     show_description = true,


### PR DESCRIPTION
Di default nella sidebar, l'opzione 'mostra il tipo' è disabilitata per il template del blocco elenco 'Card con immagine',
mentre nel template, il suo default è stato messo a true.

Questo crea problemi di visualizzazioni sui contenuti migrati.
Ho impostato il default della variabile nel template uguale al valore di default della checkbox corrispondente nella sidebar.