### PR TITLE
fix: collapse button alignment for filters in Search page

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Migliorato l'allineamento dei filtri nella pagina di Ricerca.
+
 ## Versione 7.25.3 (07/03/2024)
 
 ### Migliorie

--- a/theme/ItaliaTheme/Components/_search.scss
+++ b/theme/ItaliaTheme/Components/_search.scss
@@ -1,3 +1,10 @@
-.search-results-wrapper .ordering-widget .react-select__option--is-focused {
-  background-color: $primary;
+.section-search {
+  .search-results-wrapper .ordering-widget .react-select__option--is-focused {
+    background-color: $primary;
+  }
+
+  #categoryCollapse .form-checck .group-col .form-check .float-right {
+    position: absolute;
+    right: 0px;
+  }
 }


### PR DESCRIPTION
![image](https://github.com/RedTurtle/design-comuni-plone-theme/assets/116291154/534cf4bb-7c75-47bf-92d5-46e56ab99004)

Allineato il bottoncino