### PR TITLE
chore: updated volto-form-block

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "volto-dropdownmenu": "4.1.1",
     "volto-editablefooter": "5.1.0",
     "volto-feedback": "0.3.0",
-    "volto-form-block": "3.5.2",
+    "volto-form-block": "3.7.0",
     "volto-gdpr-privacy": "2.1.1",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,7 +6576,7 @@ __metadata:
     volto-dropdownmenu: 4.1.1
     volto-editablefooter: 5.1.0
     volto-feedback: 0.3.0
-    volto-form-block: 3.5.2
+    volto-form-block: 3.7.0
     volto-gdpr-privacy: 2.1.1
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
@@ -14355,9 +14355,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-form-block@npm:3.5.2":
-  version: 3.5.2
-  resolution: "volto-form-block@npm:3.5.2"
+"volto-form-block@npm:3.7.0":
+  version: 3.7.0
+  resolution: "volto-form-block@npm:3.7.0"
   dependencies:
     "@hcaptcha/react-hcaptcha": ^0.3.6
     file-saver: ^2.0.5
@@ -14366,7 +14366,7 @@ __metadata:
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
     volto-subblocks: ^2.0.0
-  checksum: 8154132d440df4cd6d240fb4b913607890ca9128fae7b9efc7d2037bf47fbe0007cab51cc009fca14793db5dc38b18432383e5b491d0d9aeb56ab89cf65942df
+  checksum: c2289a75f34027be1f8fb6f8a69628f9dfc4b773ed757cad83be7a0f42259e3efdac56d5c17dbaca98aff772abc6a1cff8edaef766fe395ad18270cb36f2cf98
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
aggiornato volto-form-block per avere:

- la validazione di default degli indirizzi email inseriti nei campi di configurazione della form 'Mittente di default' e 'Destinatari'

- rimosso il campo 'Obbligatorio' dal tipo di campo 'Testo statico' perchè inutile.