### PR TITLE
mobile magnifier subsites

### DIFF
--- a/theme/ItaliaTheme/Subsites/templates/_white.scss
+++ b/theme/ItaliaTheme/Subsites/templates/_white.scss
@@ -32,6 +32,11 @@ body.subsite-white {
             a {
               width: 48px;
               height: 48px;
+              &.rounded-icon {
+                svg {
+                  fill: $subsite-white-primary;
+                }
+              }
             }
           }
 

--- a/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
+++ b/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
@@ -12,16 +12,6 @@
           }
         }
       }
-
-      .it-search-wrapper {
-        a.search-link {
-          outline: $header-center-bg-color 1px solid !important;
-
-          &:focus {
-            box-shadow: 0 0 0 5px $focus-outline-color !important;
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Rimosso il bordo e il focus. Su mobile non deve esistere bordo e focus non serve.

<img width="680" alt="Schermata 2024-03-18 alle 11 59 49" src="https://github.com/italia/design-comuni-plone-theme/assets/60133113/5c36eac0-1797-454a-bdaa-5bd2e88ec64e">

Colore dell'icona per il sottosito tema bianco.
