### PR TITLE
feat: added new AttachmentCardTemplate listing variation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,24 +43,13 @@
 
 ## Versione X.X.X (dd/mm/yyyy)
 
-
 ### Novità
 
 - Aggiunto una nuova variazione del blocco elenco "Allegati" che permette di scaricare oggetti di tipo File o aprire l'anteprima di file PDF
 
-
 ### Migliorie
 
 - Migliorata l'accessibilità del blocco Icone.
-- ...
-
-### Novità
-
-- ...
-
-### Fix
-
-- ...
 
 ## Versione 11.8.0 (19/03/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,15 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+
+### Novità
+
+- Aggiunto una nuova variazione del blocco elenco "Allegati" che permette di scaricare oggetti di tipo File o aprire l'anteprima di file PDF
+
+
+
 ## Versione 11.8.0 (19/03/2024)
 
 ### Migliorie

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -859,6 +859,7 @@ msgstr ""
 msgid "assessore_riferimento"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/View/Commons/Attachment
 # defaultMessage: Allegato
 msgid "attachment"
@@ -2300,8 +2301,9 @@ msgstr ""
 msgid "legend_required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Collegamento
+# defaultMessage: Link
 msgid "link"
 msgstr ""
 
@@ -3597,6 +3599,16 @@ msgstr ""
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
+msgid "show_pdf_desc"
+msgstr ""
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Mostra i PDF in anteprima
+msgid "show_pdf_preview"
 msgstr ""
 
 #: config/Blocks/ListingOptions/simpleListTemplate

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2303,7 +2303,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Link
+# defaultMessage: Collegamento
 msgid "link"
 msgstr ""
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -844,6 +844,7 @@ msgstr "Councilor of"
 msgid "assessore_riferimento"
 msgstr "Reference councilor"
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/View/Commons/Attachment
 # defaultMessage: Allegato
 msgid "attachment"
@@ -2285,8 +2286,9 @@ msgstr "Internal services or offices"
 msgid "legend_required"
 msgstr "Fields marked with (*) are required."
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Collegamento
+# defaultMessage: Link
 msgid "link"
 msgstr "Link"
 
@@ -3583,6 +3585,16 @@ msgstr ""
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
 msgstr ""
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
+msgid "show_pdf_desc"
+msgstr "Allows you to open the preview of all the PDFs in this list in a separate tab otherwise they will be downloaded."
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Mostra i PDF in anteprima
+msgid "show_pdf_preview"
+msgstr "Show PDFs in preview"
 
 #: config/Blocks/ListingOptions/simpleListTemplate
 # defaultMessage: Mostra elenco puntato

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2288,7 +2288,7 @@ msgstr "Fields marked with (*) are required."
 
 #: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Link
+# defaultMessage: Collegamento
 msgid "link"
 msgstr "Link"
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2297,7 +2297,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Link
+# defaultMessage: Collegamento
 msgid "link"
 msgstr "Enlace"
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -853,6 +853,7 @@ msgstr "Concejal de"
 msgid "assessore_riferimento"
 msgstr "Concejal de referencia"
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/View/Commons/Attachment
 # defaultMessage: Allegato
 msgid "attachment"
@@ -2294,8 +2295,9 @@ msgstr "Servicios internos u oficinas"
 msgid "legend_required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Collegamento
+# defaultMessage: Link
 msgid "link"
 msgstr "Enlace"
 
@@ -3592,6 +3594,16 @@ msgstr "Mostrar el mapa en ancho completo"
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
 msgstr "Mostrar la cinta solo en la primera tarjeta"
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
+msgid "show_pdf_desc"
+msgstr "Le permite abrir la vista previa de todos los archivos PDF en esta lista en una pestaña separada, de lo contrario, se descargarán."
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Mostra i PDF in anteprima
+msgid "show_pdf_preview"
+msgstr "Mostrar archivos PDF en vista previa"
 
 #: config/Blocks/ListingOptions/simpleListTemplate
 # defaultMessage: Mostra elenco puntato

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -861,6 +861,7 @@ msgstr "Conseiller de"
 msgid "assessore_riferimento"
 msgstr "Référence du conseiller"
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/View/Commons/Attachment
 # defaultMessage: Allegato
 msgid "attachment"
@@ -2302,8 +2303,9 @@ msgstr ""
 msgid "legend_required"
 msgstr "Les champs marqués d'une (*) sont obligatoires."
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Collegamento
+# defaultMessage: Link
 msgid "link"
 msgstr ""
 
@@ -3600,6 +3602,16 @@ msgstr ""
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
 msgstr ""
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
+msgid "show_pdf_desc"
+msgstr "Permet d'ouvrir l'aperçu de tous les PDF de cette liste dans un onglet séparé sinon ils seront téléchargés."
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Mostra i PDF in anteprima
+msgid "show_pdf_preview"
+msgstr "Afficher les PDF en aperçu"
 
 #: config/Blocks/ListingOptions/simpleListTemplate
 # defaultMessage: Mostra elenco puntato

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2305,7 +2305,7 @@ msgstr "Les champs marqués d'une (*) sont obligatoires."
 
 #: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Link
+# defaultMessage: Collegamento
 msgid "link"
 msgstr ""
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2288,7 +2288,7 @@ msgstr "I campi contrassegnati da (*) sono obbligatori."
 
 #: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Link
+# defaultMessage: Collegamento
 msgid "link"
 msgstr "Collegamento"
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -844,6 +844,7 @@ msgstr "Assessore di"
 msgid "assessore_riferimento"
 msgstr "Assessore di riferimento"
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/View/Commons/Attachment
 # defaultMessage: Allegato
 msgid "attachment"
@@ -2285,8 +2286,9 @@ msgstr "Servizi o uffici interni"
 msgid "legend_required"
 msgstr "I campi contrassegnati da (*) sono obbligatori."
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Collegamento
+# defaultMessage: Link
 msgid "link"
 msgstr "Collegamento"
 
@@ -3583,6 +3585,16 @@ msgstr "Mostra la mappa a tutta larghezza"
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
 msgstr "Mostra il nastro solo sulla prima card"
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
+msgid "show_pdf_desc"
+msgstr "Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati."
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Mostra i PDF in anteprima
+msgid "show_pdf_preview"
+msgstr "Mostra i PDF in anteprima"
 
 #: config/Blocks/ListingOptions/simpleListTemplate
 # defaultMessage: Mostra elenco puntato

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-03-07T15:23:38.346Z\n"
+"POT-Creation-Date: 2024-03-20T16:10:46.827Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -846,6 +846,7 @@ msgstr ""
 msgid "assessore_riferimento"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/View/Commons/Attachment
 # defaultMessage: Allegato
 msgid "attachment"
@@ -2287,8 +2288,9 @@ msgstr ""
 msgid "legend_required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Collegamento
+# defaultMessage: Link
 msgid "link"
 msgstr ""
 
@@ -3584,6 +3586,16 @@ msgstr ""
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
+msgid "show_pdf_desc"
+msgstr ""
+
+#: config/Blocks/ListingOptions/attachmentCardTemplate
+# defaultMessage: Mostra i PDF in anteprima
+msgid "show_pdf_preview"
 msgstr ""
 
 #: config/Blocks/ListingOptions/simpleListTemplate

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-03-20T16:10:46.827Z\n"
+"POT-Creation-Date: 2024-03-27T08:54:22.652Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2290,7 +2290,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
-# defaultMessage: Link
+# defaultMessage: Collegamento
 msgid "link"
 msgstr ""
 

--- a/src/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { defineMessages, useIntl } from 'react-intl';
+import { UniversalLink } from '@plone/volto/components';
+import {
+  Container,
+  Card,
+  CardBody,
+  CardTitle,
+  Row,
+  Col,
+} from 'design-react-kit';
+import {
+  Icon,
+  ListingLinkMore,
+} from 'design-comuni-plone-theme/components/ItaliaTheme';
+
+const messages = defineMessages({
+  link: {
+    id: 'link',
+    defaultMessage: 'Link',
+  },
+  attachment: {
+    id: 'attachment',
+    defaultMessage: 'Allegato',
+  },
+});
+
+const AttachmentCardTemplate = ({
+  items,
+  isEditMode,
+  linkTitle,
+  linkHref,
+  show_pdf_preview,
+  show_block_bg,
+  title,
+  id_lighthouse,
+  linkAlign,
+  titleLine,
+  linkmore_id_lighthouse,
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Container className="px-4">
+      <div className="simple-card-compact-template">
+        {title && (
+          <Row>
+            <Col>
+              <h2
+                className={cx('mb-4', {
+                  'mt-5': !show_block_bg,
+                  'title-bottom-line': titleLine,
+                })}
+              >
+                {title}
+              </h2>
+            </Col>
+          </Row>
+        )}
+        <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3 mb-3">
+          {items.map((item, index) => {
+            let itemUrl = { ...item };
+            if (item['@type'] === 'File') {
+              itemUrl = {
+                ...item,
+                file: item,
+                '@id':
+                  show_pdf_preview && item?.mime_type === 'application/pdf'
+                    ? item?.['@id'] + '/@@display-file/file'
+                    : item?.['@id'] + '/@@download/file',
+              };
+            }
+
+            return (
+              <Card
+                className="card card-teaser shadow p-4 mt-3 rounded attachment"
+                noWrapper={true}
+                tag="div"
+              >
+                {item['@type'] === 'File' ? (
+                  <Icon
+                    icon="it-clip"
+                    alt={intl.formatMessage(messages.attachment)}
+                    title={intl.formatMessage(messages.attachment)}
+                  />
+                ) : (
+                  <Icon
+                    icon="it-link"
+                    alt={intl.formatMessage(messages.link)}
+                    title={intl.formatMessage(messages.link)}
+                  />
+                )}
+                <CardBody tag="div">
+                  <CardTitle tag="h5" className="mb-0">
+                    <UniversalLink
+                      item={!isEditMode ? itemUrl : null}
+                      href={isEditMode ? '#' : null}
+                      data-element={id_lighthouse}
+                    >
+                      {item.title || item.id}
+                    </UniversalLink>
+                  </CardTitle>
+                </CardBody>
+              </Card>
+            );
+          })}
+        </div>
+
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          linkAlign={linkAlign}
+          linkmoreIdLighthouse={linkmore_id_lighthouse}
+        />
+      </div>
+    </Container>
+  );
+};
+
+AttachmentCardTemplate.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.any).isRequired,
+  isEditMode: PropTypes.bool,
+  linkTitle: PropTypes.any,
+};
+
+export default AttachmentCardTemplate;

--- a/src/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate.jsx
@@ -3,14 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { defineMessages, useIntl } from 'react-intl';
 import { UniversalLink } from '@plone/volto/components';
-import {
-  Container,
-  Card,
-  CardBody,
-  CardTitle,
-  Row,
-  Col,
-} from 'design-react-kit';
+import { Container, Card, CardBody, CardTitle } from 'design-react-kit';
 import {
   Icon,
   ListingLinkMore,
@@ -19,7 +12,7 @@ import {
 const messages = defineMessages({
   link: {
     id: 'link',
-    defaultMessage: 'Link',
+    defaultMessage: 'Collegamento',
   },
   attachment: {
     id: 'attachment',
@@ -46,18 +39,14 @@ const AttachmentCardTemplate = ({
     <Container className="px-4">
       <div className="simple-card-compact-template">
         {title && (
-          <Row>
-            <Col>
-              <h2
-                className={cx('mb-4', {
-                  'mt-5': !show_block_bg,
-                  'title-bottom-line': titleLine,
-                })}
-              >
-                {title}
-              </h2>
-            </Col>
-          </Row>
+          <h2
+            className={cx('mb-4', {
+              'mt-5': !show_block_bg,
+              'title-bottom-line': titleLine,
+            })}
+          >
+            {title}
+          </h2>
         )}
         <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3 mb-3">
           {items.map((item, index) => {
@@ -83,13 +72,11 @@ const AttachmentCardTemplate = ({
                   <Icon
                     icon="it-clip"
                     alt={intl.formatMessage(messages.attachment)}
-                    title={intl.formatMessage(messages.attachment)}
                   />
                 ) : (
                   <Icon
                     icon="it-link"
                     alt={intl.formatMessage(messages.link)}
-                    title={intl.formatMessage(messages.link)}
                   />
                 )}
                 <CardBody tag="div">

--- a/src/config/Blocks/ListingOptions/attachmentCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/attachmentCardTemplate.js
@@ -1,0 +1,40 @@
+import { defineMessages } from 'react-intl';
+
+import { templatesOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
+
+const messages = defineMessages({
+  show_pdf_preview: {
+    id: 'show_pdf_preview',
+    defaultMessage: 'Mostra i PDF in anteprima',
+  },
+  show_pdf_desc: {
+    id: 'show_pdf_desc',
+    defaultMessage:
+      "Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.",
+  },
+});
+
+export const addAttachmentCardTemplateOptions = (
+  schema,
+  formData,
+  intl,
+  position = 1,
+) => {
+  let pos = position;
+
+  pos = templatesOptions(
+    schema,
+    formData,
+    intl,
+    ['show_pdf_preview'],
+    {
+      show_pdf_preview: {
+        default: false,
+        label: intl.formatMessage(messages.show_pdf_preview),
+        description: intl.formatMessage(messages.show_pdf_desc),
+      },
+    },
+    pos,
+  );
+  return pos;
+};

--- a/src/config/Blocks/ListingOptions/index.js
+++ b/src/config/Blocks/ListingOptions/index.js
@@ -22,3 +22,4 @@ export { addSimpleListTemplateOptions } from 'design-comuni-plone-theme/config/B
 export { addCardWithSlideUpTextTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate';
 export { addPhotogalleryTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/photogalleryTemplate';
 export { addSmallBlockLinksTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/smallBlockLinksTemplate';
+export { addAttachmentCardTemplateOptions } from 'design-comuni-plone-theme/config/Blocks/ListingOptions/attachmentCardTemplate';

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -42,6 +42,8 @@ import SimpleListTemplateSkeleton from 'design-comuni-plone-theme/components/Ita
 import CardWithSlideUpTextTemplate from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate';
 import CardWithSlideUpTextTemplateSkeleton from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Listing/TemplatesSkeletons/CardWithSlideUpTextTemplateSkeleton';
 
+import AttachmentCardTemplate from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate';
+
 // import AmministrazioneTrasparenteTablesTemplate from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate';
 // import AmministrazioneTrasparenteTablesTemplateSkeleton from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Listing/TemplatesSkeletons/AmministrazioneTrasparenteTablesTemplateSkeleton';
 
@@ -60,6 +62,7 @@ import {
   addPhotogalleryTemplateOptions,
   addLinkMoreOptions,
   addSmallBlockLinksTemplateOptions,
+  addAttachmentCardTemplateOptions,
   cloneBlock,
 } from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
 
@@ -263,6 +266,20 @@ const italiaListingVariations = [
     schemaEnhancer: ({ schema, formData, intl }) => {
       let pos = addDefaultOptions(schema, formData, intl);
       addSimpleListTemplateOptions(schema, formData, intl, pos);
+      addLinkMoreOptions(schema, formData, intl);
+      return schema;
+    },
+    cloneData: cloneBlock,
+  },
+  {
+    id: 'attachmentCardTemplate',
+    isDefault: false,
+    title: 'Allegati',
+    template: AttachmentCardTemplate,
+    // used default skeleton
+    schemaEnhancer: ({ schema, formData, intl }) => {
+      let pos = addDefaultOptions(schema, formData, intl);
+      addAttachmentCardTemplateOptions(schema, formData, intl, pos);
       addLinkMoreOptions(schema, formData, intl);
       return schema;
     },


### PR DESCRIPTION
US [50351](https://redturtle.tpondemand.com/entity/50351-blocco-elenco-nuova-variazione-allegati)
Nuova variazione del blocco elenco "Allegati", attraverso l'opzione "Mostra i PDF in anteprima" diamo la possibilità di aprire gli oggetti di tipo file PDF in anteprima in una nuova tab oppure per ogni oggetto di tipo File è possibile scaricarlo.

<img width="1670" alt="Screenshot 2024-03-20 alle 17 02 55" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/a990f7fa-4e24-4753-831c-0d390ace8afe">

Per tutti gli altri tipi di oggetto rimane un semplice collegamento

<img width="1670" alt="Screenshot 2024-03-20 alle 17 01 33" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/c830908b-2a2e-4afb-8dc9-6a89c7c5f294">

Da mergiare anche sul branch di Slate, dove viene mostrato anche l'info della dimensione e del mime-type

<img width="1669" alt="Screenshot 2024-03-20 alle 16 47 18" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/43245702/a57dbfc4-502f-4bd3-b737-8fbaa557bb03">
