### PR TITLE
fix: footer logo responsive height

### DIFF
--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -345,7 +345,7 @@ iframe {
 
   .block.image img {
     width: auto;
-    height: 75px;
+    max-height: 75px;
   }
 
   .block.gridBlock {


### PR DESCRIPTION
su mobile, se il logo era molto largo, veniva tagliato