### PR TITLE
fix: view Listing blocks inside Grid block

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 
 ### Fix
 
+- Sistemata la visualizzazione dei blocchi elenco all'interno del blocco griglia
 - L'etichetta della Card con Nastro (Blocco Elenco) non si sovrappone più all'immagine del nastro.
 - Aggiustato il layout della card per il CT persone quando è impostata un'immagine.
 

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -384,6 +384,7 @@ export default function applyConfig(voltoConfig) {
 
   const customBlocks = {
     ...getItaliaBlocks(config),
+
     listing: {
       ...config.blocks.blocksConfig.listing,
       showLinkMore: true,
@@ -451,6 +452,12 @@ export default function applyConfig(voltoConfig) {
     initialBlocks: { ...config.blocks.initialBlocks, ...customInitialBlocks },
     requiredBlocks: [...config.blocks.requiredBlocks, ...customRequiredBlocks],
     showEditBlocksInBabelView: true,
+  };
+
+  //per avere la conf dei blocchi anche nel blocco grid, altrimenti nel blocco grid prende la conf base di volto.
+  config.blocks.blocksConfig.gridBlock = {
+    ...config.blocks.blocksConfig.gridBlock,
+    blocksConfig: config.blocks.blocksConfig,
   };
 
   removeListingVariation(config, 'default'); // removes default volto template, because it will be overrided

--- a/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
+++ b/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
@@ -5,6 +5,56 @@
     height: unset !important;
   }
 
+  .block {
+    .full-width,
+    &.full-width {
+      right: unset;
+      left: unset;
+      width: auto !important;
+      margin-right: unset !important;
+      margin-left: unset !important;
+    }
+
+    .container {
+      width: auto !important;
+    }
+
+    &.listing {
+      &.simpleCard,
+      &.attachmentCardTemplate {
+        .card-teaser-block-3 {
+          > .card-teaser {
+            flex: 0 0 49%; //invece di 3 elementi per riga, ne mostro due perchè c'è poco spazio
+          }
+        }
+      }
+
+      &.cardWithImageTemplate,
+      &.ribbonCardTemplate,
+      &.completeBlockLinksTemplate {
+        .col-lg-4,
+        .col-xl-4,
+        .col-lg-3 {
+          width: 50%; //invece di 3 elementi per riga, ne mostro due perchè c'è poco spazio
+        }
+      }
+
+      &.cardSlideUpTextTemplate,
+      &.quaresImageTemplate {
+        .grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+
+      &.bandiInEvidenceTemplate {
+        .bandi-in-evidence-cards-wrapper {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+    }
+  }
+
+  //in edit (cms-ui)
   .gridBlock-container {
     position: relative;
     max-width: 1320px;
@@ -13,6 +63,11 @@
 
     .toolbar {
       left: 16px !important;
+    }
+
+    .block-editor-listing {
+      padding-right: 0;
+      padding-left: 0;
     }
 
     .block {
@@ -26,6 +81,21 @@
           margin-left: 16px;
           font-size: 14px;
         }
+      }
+    }
+  }
+}
+
+body.cms-ui.has-toolbar.has-sidebar {
+  .block.gridBlock {
+    .public-ui {
+      .container {
+        width: auto !important;
+      }
+
+      .full-width > .px-4.container {
+        padding-right: 24px !important;
+        padding-left: 24px !important;
       }
     }
   }


### PR DESCRIPTION
Sistemata la visualizzazione dei blocchi elenco all'interno del blocco griglia. 

Gli elementi dei blocchi elenco sono stati mostrati in modo che in ogni riga ci stiano al massimo due elementi, in quanto lo spazio di una colonna è ridotto.

<img width="1694" alt="Schermata 2024-03-29 alle 12 36 22" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/5075892c-fece-4090-8240-744971df2128">
