### PR TITLE
Megamenu subsite

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@
 - Sistemato layout del menu laterale sinistro nella vista del Bando
 - Sistemato il flag Mostra tipologia bandi nel blocco elenco con variazione Bandi in Evidenza
 - Tradotto il messaggio per Screen Reader del bottone per aprire e chiudere il menu in mobile.
+- Menu dropdown si chiude correttamente quando il percorso è un sottosito con un menu diverso rispetto al sito principale
 
 ## Versione 7.25.3 (07/03/2024)
 

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -70,7 +70,7 @@ const isChildActive = (itemUrl, pathname) => {
   return pathname.indexOf(itemUrl) > -1;
 };
 
-const MegaMenu = ({ item, pathname }) => {
+const MegaMenu = ({ item, pathname, closeMenu }) => {
   const intl = useIntl();
   const blocksFieldname = getBlocksFieldname(item);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(item);
@@ -317,7 +317,10 @@ const MegaMenu = ({ item, pathname }) => {
                                   title={child.title}
                                   condition={!!child['@id']}
                                   key={child['@id']}
-                                  onClick={() => setMenuStatus(false)}
+                                  onClick={() => {
+                                    setMenuStatus(false);
+                                    closeMenu();
+                                  }}
                                   className={cx('list-item', {
                                     active: isChildActive(
                                       flattenToAppURL(child['@id']),

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -140,6 +140,9 @@ const Navigation = ({ pathname }) => {
                         item={item}
                         pathname={pathname}
                         key={index + 'mm'}
+                        closeMenu={() => {
+                          setCollapseOpen(false);
+                        }}
                       />
                     ))}
                 </Nav>


### PR DESCRIPTION
Menu dropdown si chiude correttamente quando il percorso è un sottosito con un menu diverso rispetto al sito principale