### PR TITLE
fix: added arrow icon to links in footerNavigation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,7 @@
 - Sistemato il flag Mostra tipologia bandi nel blocco elenco con variazione Bandi in Evidenza
 - Tradotto il messaggio per Screen Reader del bottone per aprire e chiudere il menu in mobile.
 - Menu dropdown si chiude correttamente quando il percorso è un sottosito con un menu diverso rispetto al sito principale
+- Migliorata l'accessibilità dei link nel footer.
 
 ## Versione 7.25.3 (07/03/2024)
 

--- a/src/components/ItaliaTheme/Footer/FooterNavigation.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterNavigation.jsx
@@ -19,6 +19,7 @@ import {
   LinkListItem,
 } from 'design-react-kit/dist/design-react-kit';
 import { SectionIcon } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
@@ -73,6 +74,7 @@ const FooterNavigation = () => {
                   }
                 >
                   {item.title}
+                  <Icon icon="it-arrow-right" color="white" />
                 </Link>
               </h4>
               {!config.settings.isFooterCollapsed && item.items && (


### PR DESCRIPTION
@Wagner3UB

Le WCAG non parlano espressamente di icone ma di non-color designators, ma si limitano a listare caratteristiche e stili di font come boldness, italics, etc.
Facendo qualche ricerca, sembra che le icone possano essere usate come "non-color designators" per link. Reference:
https://www.freecodecamp.org/news/link-accessibility-colors-are-not-enough/ (punto 3, icons)
https://usability.yale.edu/web-accessibility/articles/links#:~:text=The%20easiest%20way%20to%20provide,option%20includes%20having%20an%20icon