### PR TITLE
feat: use config.settings.openExternalLinkInNewTab

### DIFF
--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -66,8 +66,8 @@ import { schemaListing } from 'design-comuni-plone-theme/components/ItaliaTheme/
 
 import reducers from 'design-comuni-plone-theme/reducers';
 
-const ReleaseLog = loadable(
-  () => import('design-comuni-plone-theme/components/ReleaseLog/ReleaseLog'),
+const ReleaseLog = loadable(() =>
+  import('design-comuni-plone-theme/components/ReleaseLog/ReleaseLog'),
 );
 
 const messages = defineMessages({
@@ -87,6 +87,7 @@ export default function applyConfig(voltoConfig) {
 
   config.settings = {
     ...config.settings,
+    openExternalLinkInNewTab: true,
     sentryOptions: (libraries) => ({
       ...voltoSentryOptions(libraries),
       ignoreErrors: [

--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -86,6 +86,7 @@ const UniversalLink = ({
 
   const checkedURL = URLUtils.checkAndNormalizeUrl(url);
   url = checkedURL.url;
+
   let tag = (
     <Link
       to={flattenToAppURL(url)}
@@ -101,7 +102,10 @@ const UniversalLink = ({
 
   if (isExternal) {
     const openInNewTab =
-      openLinkInNewTab === null ? openExternalLinkInNewTab : openLinkInNewTab;
+      openLinkInNewTab === null || openLinkInNewTab === undefined
+        ? openExternalLinkInNewTab
+        : openLinkInNewTab;
+
     tag = (
       <a
         href={url}

--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -35,6 +35,7 @@ const UniversalLink = ({
 }) => {
   const intl = useIntl();
   const token = useSelector((state) => state.userSession?.token);
+  const { openExternalLinkInNewTab } = config.settings;
 
   let url = href;
   if (!href && item) {
@@ -99,6 +100,8 @@ const UniversalLink = ({
   );
 
   if (isExternal) {
+    const openInNewTab =
+      openLinkInNewTab === null ? openExternalLinkInNewTab : openLinkInNewTab;
     tag = (
       <a
         href={url}
@@ -106,9 +109,7 @@ const UniversalLink = ({
           id: 'opensInNewTab',
         })}`}
         target={
-          !checkedURL.isMail &&
-          !checkedURL.isTelephone &&
-          !(openLinkInNewTab === false)
+          !checkedURL.isMail && !checkedURL.isTelephone && openInNewTab
             ? '_blank'
             : null
         }


### PR DESCRIPTION
now UniversalLink opens external links in new tab by default if 
config.settings.openExternalLinkInNewTab = true

default value setted for openExternalLinkInNewTab is true