### PR TITLE
fix: fixed calculation of prefix of fontawesome icon if prefix is in …

### DIFF
--- a/src/components/ItaliaTheme/Icons/FontAwesomeIcon.jsx
+++ b/src/components/ItaliaTheme/Icons/FontAwesomeIcon.jsx
@@ -36,8 +36,10 @@ const FontAwesomeIcon = (props) => {
       prefixKey === 'fab'
         ? 'brands'
         : prefixKey === 'far'
-          ? 'regular'
-          : 'solid',
+        ? 'regular'
+        : prefixKey != null
+        ? prefixKey
+        : 'solid',
       iconName,
     ];
   };


### PR DESCRIPTION
…icon string


Ad esempio, se nel pannello di configurazione dei social scrivevo "brands spotify" l'icona non veniva mostrata perchè defaultava su 'solid' 