### PR TITLE
fix: changed aria-hidden to false

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,6 +65,7 @@
 - Sistemato un problema nella vista del CT Evento, che mostrava tra le date aggiuntive della ricorrenza anche le date escluse.
 - Sistemato un problema per cui la visualizzazione della sitemap in presenza di un sito multilingua generava errore.
 - Migliorata l'accessibilità dei link nel footer.
+- Migliorata l'accessibilità del blocco elenco nella variazione Slider.
 
 ## Versione 11.9.1 (03/04/2024)
 

--- a/src/components/ItaliaTheme/Slider/NextArrow.jsx
+++ b/src/components/ItaliaTheme/Slider/NextArrow.jsx
@@ -20,7 +20,7 @@ export default function NextArrow(props) {
       onClick={onClick}
       title={_title}
       aria-label={_title}
-      aria-hidden={true}
+      aria-hidden={false}
       onKeyDown={onKeyDown}
       id={id}
     >

--- a/src/components/ItaliaTheme/Slider/PrevArrow.jsx
+++ b/src/components/ItaliaTheme/Slider/PrevArrow.jsx
@@ -22,11 +22,11 @@ export default function PrevArrow(props) {
       onClick={onClick}
       title={_title}
       aria-label={_title}
-      aria-hidden={true}
+      aria-hidden={false}
       id={id}
       onKeyDown={onKeyDown}
     >
-      <Icon icon="chevron-left" key="chevron-left-prev"  title={_title} />
+      <Icon icon="chevron-left" key="chevron-left-prev" title={_title} />
       <span class="visually-hidden">{_title}</span>
     </button>
   );


### PR DESCRIPTION
@Wagner3UB 

yes yes I know what you're thinking: basta togliere aria-hidden=true, non serve impostarlo a false, è di default
Però senza attributo non impostato esplicitamente a false, NVDA continua a leggere "vuoto" invece dell'aria-label