### PR TITLE
fix: changed aria-hidden to false for slider arrows

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,7 @@
 - Sistemato il flag Mostra tipologia bandi nel blocco elenco con variazione Bandi in Evidenza
 - Tradotto il messaggio per Screen Reader del bottone per aprire e chiudere il menu in mobile.
 - Menu dropdown si chiude correttamente quando il percorso è un sottosito con un menu diverso rispetto al sito principale
+- Migliorata l'accessibilità del blocco Elenco nella variazione Slider.
 
 ## Versione 7.25.3 (07/03/2024)
 

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -74,7 +74,7 @@ function NextArrow(props) {
       onClick={handleClick}
       title={intl.formatMessage(messages.successivo)}
       aria-label={intl.formatMessage(messages.successivo)}
-      aria-hidden={true}
+      aria-hidden={false}
       onKeyDown={handleKeyboardUsers}
       id="sliderNextArrow"
     >
@@ -117,7 +117,7 @@ function PrevArrow(props) {
       onClick={handleClick}
       title={intl.formatMessage(messages.precedente)}
       aria-label={intl.formatMessage(messages.precedente)}
-      aria-hidden={true}
+      aria-hidden={false}
       id="sliderPrevArrow"
       onKeyDown={handleKeyboardUsers}
     >


### PR DESCRIPTION
yes yes I know what you're thinking: basta togliere aria-hidden=true, non serve impostarlo a false, è di default
Però senza attributo non impostato esplicitamente a false, NVDA continua a leggere "vuoto" invece dell'aria-label