### PR TITLE
fix: no load PuntoDiContatto in ContactsCard

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/ContactsCard.jsx
+++ b/src/components/ItaliaTheme/View/Commons/ContactsCard.jsx
@@ -1,41 +1,12 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { Card, CardBody, CardText, CardTitle, Icon } from 'design-react-kit';
-import { getContent, resetContent } from '@plone/volto/actions';
 import { UniversalLink } from '@plone/volto/components';
-import { flattenToAppURL } from '@plone/volto/helpers';
+
 import { renderPDCItemValue } from 'design-comuni-plone-theme/helpers';
 import { useIntl } from 'react-intl';
 
 const ContactsCard = ({ contact = {}, show_title = false, ...rest }) => {
-  const dispatch = useDispatch();
   const intl = useIntl();
   const contactUrl = contact['@id'];
-
-  const { loading, loaded, error, data } = useSelector(
-    (state) => state.content.subrequests[flattenToAppURL(contactUrl)] ?? {},
-  );
-
-  useEffect(() => {
-    if (!loading && !loaded) {
-      dispatch(
-        getContent(
-          flattenToAppURL(contactUrl),
-          null,
-          flattenToAppURL(contactUrl),
-        ),
-      );
-    }
-  }, [dispatch, contactUrl, loading, loaded]);
-
-  useEffect(
-    () => () => dispatch(resetContent(flattenToAppURL(contactUrl))),
-    [dispatch, contactUrl],
-  );
-
-  if (error) {
-    return null;
-  }
 
   return (
     <Card
@@ -54,7 +25,7 @@ const ContactsCard = ({ contact = {}, show_title = false, ...rest }) => {
           )}
         </CardTitle>
         <CardText>
-          {data?.value_punto_contatto.map((pdc, index) => (
+          {contact?.value_punto_contatto?.map((pdc, index) => (
             <span key={index}>
               <strong>
                 <span className="pdc-type">{pdc.pdc_type}</span>


### PR DESCRIPTION
Rimosso il load del Punto di Contatto nel componente ContactsCard perchè inutile e creava problemi con il validatore agid. 

Verificati tutti i punti in cui viene usato:

- Unità Organizzativa
- Servizio
- Evento
- Persona
- Luogo