### PR TITLE
feat: CartellaModulistica view improvements

### DIFF
--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
@@ -108,7 +108,7 @@ const CartellaModulisticaView = ({ content }) => {
         <TextOrBlocks content={content} />
 
         {/* -------SEARCH------- */}
-        {content?.ricerca_in_testata && (
+        {(true || content?.ricerca_in_testata) && (
           <CartellaModulisticaSearchBar setSearchableText={setSearchableText} />
         )}
 

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
@@ -139,12 +139,19 @@ const CartellaModulisticaView = ({ content }) => {
                               doc={doc}
                               key={doc['@id']}
                               items={items.length === 0 ? doc.items : items}
+                              searchableText={searchableText}
                               /*se items.length ===0 significa che è stato fatto il match sul titolo del
                                 documento, quindi devo mostrare tutti i suoi figli*/
                             />
                           );
                         } else {
-                          return <DocRow doc={doc} key={doc['@id']} />;
+                          return (
+                            <DocRow
+                              doc={doc}
+                              key={doc['@id']}
+                              searchableText={searchableText}
+                            />
+                          );
                         }
                       })}
                     </div>
@@ -157,12 +164,13 @@ const CartellaModulisticaView = ({ content }) => {
                     items={
                       section.items ? section.items.filter(filterItemsFN) : []
                     }
+                    searchableText={searchableText}
                   />
                 </div>
               ) : (
                 <div className="document-row-section" key={section['@id']}>
                   {/*file,immagine,link*/}
-                  <DocRow doc={section} />
+                  <DocRow doc={section} searchableText={searchableText} />
                 </div>
               );
             })}

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
@@ -108,7 +108,7 @@ const CartellaModulisticaView = ({ content }) => {
         <TextOrBlocks content={content} />
 
         {/* -------SEARCH------- */}
-        {(true || content?.ricerca_in_testata) && (
+        {content?.ricerca_in_testata && (
           <CartellaModulisticaSearchBar setSearchableText={setSearchableText} />
         )}
 

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
@@ -138,10 +138,12 @@ const CartellaModulisticaView = ({ content }) => {
                             <DocRow
                               doc={doc}
                               key={doc['@id']}
-                              items={items.length === 0 ? doc.items : items}
                               searchableText={searchableText}
-                              /*se items.length ===0 significa che è stato fatto il match sul titolo del
-                                documento, quindi devo mostrare tutti i suoi figli*/
+                              collapsable={!content.non_collassare_gli_elementi}
+                              items={
+                                items.length === 0 ? doc.items : items
+                              } /*se items.length ===0 significa che è stato fatto il match sul titolo del
+                              documento, quindi devo mostrare tutti i suoi figli*/
                             />
                           );
                         } else {
@@ -150,6 +152,7 @@ const CartellaModulisticaView = ({ content }) => {
                               doc={doc}
                               key={doc['@id']}
                               searchableText={searchableText}
+                              collapsable={!content.non_collassare_gli_elementi}
                             />
                           );
                         }
@@ -165,12 +168,17 @@ const CartellaModulisticaView = ({ content }) => {
                       section.items ? section.items.filter(filterItemsFN) : []
                     }
                     searchableText={searchableText}
+                    collapsable={!content.non_collassare_gli_elementi}
                   />
                 </div>
               ) : (
                 <div className="document-row-section" key={section['@id']}>
                   {/*file,immagine,link*/}
-                  <DocRow doc={section} searchableText={searchableText} />
+                  <DocRow
+                    doc={section}
+                    searchableText={searchableText}
+                    collapsable={!content.non_collassare_gli_elementi}
+                  />
                 </div>
               );
             })}

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
@@ -108,7 +108,9 @@ const CartellaModulisticaView = ({ content }) => {
         <TextOrBlocks content={content} />
 
         {/* -------SEARCH------- */}
-        <CartellaModulisticaSearchBar setSearchableText={setSearchableText} />
+        {content?.ricerca_in_testata && (
+          <CartellaModulisticaSearchBar setSearchableText={setSearchableText} />
+        )}
 
         {modulistica.length > 0 && (
           <section className="modulistica">
@@ -137,7 +139,7 @@ const CartellaModulisticaView = ({ content }) => {
                               doc={doc}
                               key={doc['@id']}
                               items={items.length === 0 ? doc.items : items}
-                              /*se items.length ===0 significa che è stato fatto il match sul titolo del 
+                              /*se items.length ===0 significa che è stato fatto il match sul titolo del
                                 documento, quindi devo mostrare tutti i suoi figli*/
                             />
                           );

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/CartellaModulisticaView.jsx
@@ -184,7 +184,7 @@ const CartellaModulisticaView = ({ content }) => {
             })}
           </section>
         )}
-        <PageMetadata content={content} />
+        {content.show_modified && <PageMetadata content={content} />}
       </div>
 
       <CartellaModulisticaAfterContent content={content} />

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
@@ -4,12 +4,14 @@
  */
 
 import React, { useState } from 'react';
+import cx from 'classnames';
+import Highlighter from 'react-highlight-words';
+
 import { UniversalLink } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { DownloadFileFormat } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
 import { FontAwesomeIcon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import cx from 'classnames';
 
 /**
  * DocRow view component class.
@@ -18,13 +20,18 @@ import cx from 'classnames';
  * @returns {string} Markup of the component.
  */
 
-const Downloads = ({ item, titleDoc }) => {
+const Downloads = ({ item, titleDoc, filteredWords }) => {
   return item['@type'] === 'Modulo' ? (
     <React.Fragment>
-      {!titleDoc ? (
-        <div className="title">{item.title}</div>
-      ) : (
-        titleDoc !== item.title && <div className="title">{item.title}</div>
+      {(!titleDoc || titleDoc !== item.title) && (
+        <div className="title">
+          <Highlighter
+            highlightClassName="highlighted-text"
+            searchWords={filteredWords}
+            autoEscape={true}
+            textToHighlight={item.title}
+          />
+        </div>
       )}
       <div className="downloads">
         <DownloadFileFormat file={item?.file_principale} />
@@ -49,7 +56,9 @@ const Downloads = ({ item, titleDoc }) => {
   );
 };
 
-const DocRow = ({ doc, items }) => {
+const DocRow = ({ doc, items, searchableText }) => {
+  const filteredWords = searchableText.split(' ');
+
   const [itemOpen, setItemOpen] = useState(false);
 
   const titleWrapper = (
@@ -60,7 +69,12 @@ const DocRow = ({ doc, items }) => {
     >
       <div id={`title-${doc.id}`} className="title">
         <UniversalLink href={doc.remoteUrl || flattenToAppURL(doc['@id'])}>
-          {doc.title}
+          <Highlighter
+            highlightClassName="highlighted-text"
+            searchWords={filteredWords}
+            autoEscape={true}
+            textToHighlight={doc.title}
+          />
         </UniversalLink>
         {doc?.description && (
           <p className="description text-muted">{doc.description}</p>
@@ -85,7 +99,11 @@ const DocRow = ({ doc, items }) => {
       {items?.length === 1 && (
         <div className="doc">
           {titleWrapper}
-          <Downloads item={items[0]} titleDoc={doc.title} />
+          <Downloads
+            item={items[0]}
+            titleDoc={doc.title}
+            filteredWords={filteredWords}
+          />
         </div>
       )}
 
@@ -120,7 +138,11 @@ const DocRow = ({ doc, items }) => {
             <div className="accordion-inner">
               {items.map((modulo) => (
                 <div className="doc modulo" key={modulo['@id']}>
-                  <Downloads item={modulo} titleDoc={null} />
+                  <Downloads
+                    item={modulo}
+                    titleDoc={null}
+                    filteredWords={filteredWords}
+                  />
                 </div>
               ))}
             </div>

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import cx from 'classnames';
+import { v4 as uuid } from 'uuid';
 import Highlighter from 'react-highlight-words';
 
 import { UniversalLink } from '@plone/volto/components';
@@ -40,24 +41,41 @@ const Downloads = ({ item, titleDoc, filteredWords }) => {
       </div>
     </React.Fragment>
   ) : (
-    <UniversalLink
-      href={item.remoteUrl || flattenToAppURL(item['@id'])}
-      title={item.title}
-      className="modulistica-link"
-    >
-      <div className="title">{item.title}</div>
-      <FontAwesomeIcon
-        icon={['fas', 'link']}
-        alt={item.title}
-        role="presentation"
-        aria-hidden={true}
-      />
-    </UniversalLink>
+    <>
+      <div className="title">
+        <UniversalLink
+          href={item.remoteUrl || flattenToAppURL(item['@id'])}
+          title={item.title}
+        >
+          <Highlighter
+            highlightClassName="highlighted-text"
+            searchWords={filteredWords}
+            autoEscape={true}
+            textToHighlight={item.title}
+          />
+        </UniversalLink>
+      </div>
+      <div className="downloads">
+        <UniversalLink
+          href={item.remoteUrl || flattenToAppURL(item['@id'])}
+          title={item.title}
+          className="modulistica-link"
+        >
+          <FontAwesomeIcon
+            icon={['fas', 'link']}
+            alt={item.title}
+            role="presentation"
+            aria-hidden={true}
+          />
+        </UniversalLink>
+      </div>
+    </>
   );
 };
 
 const DocRow = ({ doc, items, searchableText, collapsable }) => {
   const filteredWords = searchableText.split(' ');
+  const id = uuid();
 
   const [itemOpen, setItemOpen] = useState(!collapsable);
 
@@ -131,19 +149,20 @@ const DocRow = ({ doc, items, searchableText, collapsable }) => {
                   setItemOpen(itemOpen ? false : true);
                 }}
                 aria-expanded={itemOpen}
-                aria-controls="collapsedContent"
+                aria-controls={`accordion-content-${id}`}
                 aria-labelledby={`title-${doc.id}`}
               >
                 <Icon
                   color="primary"
                   icon={itemOpen ? 'it-minus' : 'it-plus'}
                   padding={false}
+                  key={itemOpen + id}
                 />
               </button>
             )}
           </div>
           <div
-            id="collapsedContent"
+            id={`accordion-content-${id}`}
             className={cx('accordion-content', { open: itemOpen })}
             role="region"
             aria-labelledby="headingAccordion"

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
@@ -56,19 +56,21 @@ const Downloads = ({ item, titleDoc, filteredWords }) => {
   );
 };
 
-const DocRow = ({ doc, items, searchableText }) => {
+const DocRow = ({ doc, items, searchableText, collapsable }) => {
   const filteredWords = searchableText.split(' ');
 
-  const [itemOpen, setItemOpen] = useState(searchableText?.length > 0 ?? false);
+  const [itemOpen, setItemOpen] = useState(!collapsable);
 
   useEffect(() => {
     //se ho fatto una ricerca, espando l'elemento
-    if (searchableText?.length > 0) {
-      setItemOpen(true);
-    } else {
-      setItemOpen(false);
+    if (collapsable) {
+      if (searchableText?.length > 0) {
+        setItemOpen(true);
+      } else {
+        setItemOpen(false);
+      }
     }
-  }, [searchableText]);
+  }, [searchableText, collapsable]);
 
   const titleWrapper = (
     <div
@@ -123,20 +125,22 @@ const DocRow = ({ doc, items, searchableText }) => {
             <div id="headingAccordion" className="accordion-header doc">
               {titleWrapper}
             </div>
-            <button
-              onClick={() => {
-                setItemOpen(itemOpen ? false : true);
-              }}
-              aria-expanded={itemOpen}
-              aria-controls="collapsedContent"
-              aria-labelledby={`title-${doc.id}`}
-            >
-              <Icon
-                color="primary"
-                icon={itemOpen ? 'it-minus' : 'it-plus'}
-                padding={false}
-              />
-            </button>
+            {collapsable && (
+              <button
+                onClick={() => {
+                  setItemOpen(itemOpen ? false : true);
+                }}
+                aria-expanded={itemOpen}
+                aria-controls="collapsedContent"
+                aria-labelledby={`title-${doc.id}`}
+              >
+                <Icon
+                  color="primary"
+                  icon={itemOpen ? 'it-minus' : 'it-plus'}
+                  padding={false}
+                />
+              </button>
+            )}
           </div>
           <div
             id="collapsedContent"

--- a/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
+++ b/src/components/ItaliaTheme/View/CartellaModulisticaView/DocRow.jsx
@@ -3,7 +3,7 @@
  * @module components/theme/View/DocRow
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import cx from 'classnames';
 import Highlighter from 'react-highlight-words';
 
@@ -59,7 +59,16 @@ const Downloads = ({ item, titleDoc, filteredWords }) => {
 const DocRow = ({ doc, items, searchableText }) => {
   const filteredWords = searchableText.split(' ');
 
-  const [itemOpen, setItemOpen] = useState(false);
+  const [itemOpen, setItemOpen] = useState(searchableText?.length > 0 ?? false);
+
+  useEffect(() => {
+    //se ho fatto una ricerca, espando l'elemento
+    if (searchableText?.length > 0) {
+      setItemOpen(true);
+    } else {
+      setItemOpen(false);
+    }
+  }, [searchableText]);
 
   const titleWrapper = (
     <div

--- a/theme/ItaliaTheme/Views/_cartellaModulistica.scss
+++ b/theme/ItaliaTheme/Views/_cartellaModulistica.scss
@@ -16,6 +16,11 @@ $docs-section-margin: 3em;
     }
   }
 
+  mark.highlighted-text {
+    padding: 0.2rem 0;
+    background-color: $highlight-search;
+  }
+
   section.modulistica {
     .documents-section,
     .document-row-section {
@@ -52,6 +57,7 @@ $docs-section-margin: 3em;
         &.has-children {
           padding-bottom: 1em;
         }
+
         .description {
           font-size: 0.9rem;
         }
@@ -68,10 +74,12 @@ $docs-section-margin: 3em;
             &.single-row {
               max-width: 70%;
             }
+
             .title {
               font-size: 1.2em;
               font-weight: 500;
             }
+
             p.description {
               margin: 0;
             }
@@ -124,6 +132,7 @@ $docs-section-margin: 3em;
             color: $secondary;
             font-size: 1rem;
           }
+
           button {
             padding: 0 0.4em;
             border: none;
@@ -135,6 +144,7 @@ $docs-section-margin: 3em;
             }
           }
         }
+
         .accordion-content {
           overflow: hidden;
           height: auto;
@@ -186,11 +196,13 @@ $docs-section-margin: 3em;
             flex-wrap: wrap;
             align-items: unset;
             justify-content: unset;
+
             .title-wrap {
               &.single-row {
                 max-width: none;
               }
             }
+
             .title,
             .downloads {
               flex: 1 1 100%;

--- a/theme/ItaliaTheme/Views/_cartellaModulistica.scss
+++ b/theme/ItaliaTheme/Views/_cartellaModulistica.scss
@@ -110,10 +110,9 @@ $docs-section-margin: 3em;
           }
 
           a.modulistica-link {
-            display: flex;
-            width: 100%;
-            align-items: center;
-            justify-content: space-between;
+            .external-link {
+              display: none;
+            }
 
             svg {
               width: 2em;


### PR DESCRIPTION
- Mostra la ricerca in testata nella Cartella Modulistica solo se c'è il flag attivato nel contenuto
- evidenza il testo cercato 
<img width="1254" alt="Schermata 2024-05-30 alle 13 42 43" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/4cd4c36c-7b6e-4852-a6be-586e1dd7f753">

- se faccio una ricerca gli elementi collassabili che rimangono collassabili nei risultati (perchè c'è piu di un elemento al suo interno che corrisponde alla ricerca) vengono esplosi. 
- se nel content-type è stato flaggato il campo 'non_collassare_gli_elementi' non vengono mostrati i bottoni per il toggle e gli elementi sono tutti esplosi