### PR TITLE
fix: changed default filters in EventSearch DataFilter + query parameters

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Il blocco Ricerca Eventi permette di eliminare il filtro date.
+
 ## Versione 11.12.6 (30/05/2024)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -101,6 +101,8 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
           fullobjects: 1,
           query: query,
           b_size: b_size,
+          sort_order: 'ascending',
+          sort_on: 'start',
         },
         id + '_events_search',
         page,

--- a/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
@@ -99,12 +99,12 @@ const DefaultFilters = () => {
         component: DateFilter,
         props: {
           value: {
-            startDate: moment().startOf('day'),
-            endDate: moment().endOf('day'),
+            startDate: null,
+            endDate: null,
           },
           showClearDates: true,
-          defaultStart: moment().startOf('day'),
-          defaultEnd: moment().endOf('day'),
+          defaultStart: null,
+          defaultEnd: null,
           isOutsideRange: () => false,
         },
       },


### PR DESCRIPTION
Richiesto il porting della customizzazione fatta su Parma per permettere di eliminare il filtro date dalla ricerca eventi.
Inoltre, aggiunti i parametri per ordinare gli eventi per data di inizio in ordine crescente.