### PR TITLE
fix: match path

### DIFF
--- a/src/helpers/getItemsByPath.js
+++ b/src/helpers/getItemsByPath.js
@@ -1,3 +1,25 @@
+/**
+ * Retrieves items based on a given pathname from a list of items with specified root paths.
+ *
+ * @param {Array} items - An array of objects where each object contains a `rootPath` and `items` property.
+ * @param {string} pathname - The pathname to match against the root paths.
+ * @param {boolean} [defaultRootPath=true] - A flag to determine if the root path ('/') items should be returned when no match is found.
+ * @returns {Array} - The items corresponding to the matched root path or the root path if no match is found and defaultRootPath is true. Returns an empty array if no match is found and defaultRootPath is false.
+ *
+ * @example
+ * // Sample items array
+ * const items = [
+ *   { rootPath: '/', items: ['homeItem1', 'homeItem2'] },
+ *   { rootPath: '/about', items: ['aboutItem1'] },
+ *   { rootPath: '/products', items: ['productItem1', 'productItem2'] },
+ * ];
+ *
+ * getItemsByPath(items, '/about'); // returns ['aboutItem1']
+ * getItemsByPath(items, '/products/item'); // returns ['productItem1', 'productItem2']
+ * getItemsByPath(items, '/contact'); // returns ['homeItem1', 'homeItem2'] assuming defaultRootPath is true
+ * getItemsByPath(items, '/contact', false); // returns []
+ */
+
 export function getItemsByPath(items, pathname, defaultRootPath = true) {
   let rootPathConfig = null;
   const itemsByPath = items?.reduce((acc, val) => {

--- a/src/helpers/getItemsByPath.js
+++ b/src/helpers/getItemsByPath.js
@@ -8,7 +8,7 @@ export function getItemsByPath(items, pathname, defaultRootPath = true) {
     return { ...acc, [val.rootPath]: val };
   }, {});
   const matchingPaths = Object.keys(itemsByPath)
-    .filter((path) => pathname.startsWith(path))
+    .filter((path) => pathname === path || pathname.startsWith(`${path}/`))
     .sort((a, b) => {
       if (a.length > b.length) return -1;
       else if (a.length < b.length) return 1;


### PR DESCRIPTION
this fix handles this cases:

if items contains a rule for path  _"/**test**"_

if i navigate to _"/**test**-number-one"_ now this path doesn't matches
if i navigate to _"/pippo/pluto/**test**"_ now this path doesn't matches (before it was matching and it was wrong)

