### PR TITLE
Fix "/diff" regexp

### DIFF
--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -342,8 +342,10 @@ export default function applyConfig(voltoConfig) {
   };
 
   config.settings.nonContentRoutes = config.settings.nonContentRoutes.filter(
-    (route) => route !== '/contact-form',
+    (route) => route !== '/contact-form' && route !== '/diff',
   );
+  config.settings.nonContentRoutes.push(/\/diff$/);
+  config.settings.nonContentRoutes.push('/diff\\?');
   config.settings.nonContentRoutes.push('/release-log');
 
   /******************************************************************************


### PR DESCRIPTION
Better handle /diff route regexp as non-content route because otherwise "cms-ui" styles are applied also on contents that starts with "diff" like "diffusione".