### PR TITLE
fix: megamenu active item

### DIFF
--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -66,7 +66,10 @@ const isActive = (item, pathname) => {
   );
 };
 
-const isChildActive = (itemUrl, pathname) => {
+const isChildActive = (itemUrl, pathname, exact = false) => {
+  if (exact) {
+    return itemUrl === pathname;
+  }
   return pathname.indexOf(itemUrl) > -1;
 };
 
@@ -328,6 +331,7 @@ const MegaMenu = ({ item, pathname }) => {
                                     active: isChildActive(
                                       flattenToAppURL(child['@id']),
                                       pathname,
+                                      true,
                                     ),
                                   })}
                                   role="menuitem"


### PR DESCRIPTION
<img width="1720" alt="Schermata 2024-06-17 alle 14 14 48" src="https://github.com/RedTurtle/design-comuni-plone-theme/assets/51911425/bd4b8801-f91b-429e-9903-da0f5a35e0bc">
c'era questo problema (segnalato dalla rer)
Se nel megamenu ci sono due link che hanno la parte iniziale del link uguale al path in cui sei, te li seleziona entrambi nel caso in cui ti trovi in uno dei due path.
Ad esempio, se i link sono
/a/b/test
e
/a/b/test-pippo

se vado su /a/b/test-pippo mi selezionava entrambi


da riportare anche sul 12.0.x
