### PR TITLE
fix: blocks widget table block toolbar position

### DIFF
--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -94,6 +94,12 @@ body.cms-ui {
     }
   }
 
+  .blocks-widget-container {
+    .block.table .toolbar {
+      top: -3.34rem;
+    }
+  }
+
   .it-header-wrapper,
   .public-ui {
     font-size: 18px;


### PR DESCRIPTION
nel widget dei blocchi (ad esempio quando editi il testo di una news), si vedeva la toolbar della tabella sopra alle celle di intestazione e dava problemi durante l'editing delle celle: 
<img width="1680" alt="Schermata 2024-07-11 alle 13 30 08" src="https://github.com/italia/design-comuni-plone-theme/assets/51911425/f660ef8a-2f4a-46a8-b50b-5e424f7d1580">
ora la toolbar è stata spostata piu in alto