### PR TITLE
fix: added check for subsite to path in venue query for events search filter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,10 @@
 
 - Ora il titolo, sottotitolo, favicon, logo e logo del footer sono editabili dal pannello di controllo del Sito. Se non impostati, verranno usati quelli definiti dagli sviluppatori.
 
+### Fix
+
+- Ripristinato il funzionamento del filtro luogo nella ricerca eventi.
+
 ## Versione 11.16.0 (10/07/2024)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
@@ -36,6 +36,8 @@ const DefaultFilters = () => {
   const intl = useIntl();
   moment.locale(intl.locale);
   const subsite = useSelector((state) => state.subsite?.data);
+  const isSubsiteValid = subsite && Object.keys(subsite).length > 0;
+  const path = isSubsiteValid ? flattenToAppURL(subsite['@id']) : '/';
 
   return {
     text_filter: {
@@ -68,7 +70,7 @@ const DefaultFilters = () => {
           isSearchable: true,
           options: {
             dispatch: {
-              path: subsite ? flattenToAppURL(subsite['@id']) : '/',
+              path: path,
               portal_types: ['Venue'],
               fullobjects: 0,
               b_size: 10000,


### PR DESCRIPTION
Il problema è che per popolare quella select viene fatta questa query:
 
```
dispatch: {
  path: subsite ? flattenToAppURL(subsite['@id']) : '/',
  portal_types: ['Venue'],
  fullobjects: 0,
  b_size: 10000,
  subrequests_name: 'venues',
  additionalParams: {
  sort_on: 'sortable_title',
  sort_order: 'ascending',
},
```
Le info del subsite però vengono prese dallo store di redux. Al momento del rendering della pagina, lo store redux per `state.subsite?.data` ha inizialmente un oggetto vuoto, visto come truthy, che quindi imposta come path  `flattenToAppURL(subsite['@id']) (= undefined) `
Solo dopo viene impostato a null quando si rende conto che non si tratta di un sottosito, e a questo punto però il path è già stato impostato e la search è fallita perchè ha /undefined/ come parametro

In teoria i sottositi verranno dismessi, ma dubito che ci sia in mente una review di ogni componente di ioComune per eliminare i residui di codice che calcolano la presenza o meno di un sottosito, quindi nel frattempo l'ho modificato così:
```
  const isSubsiteValid = subsite && Object.keys(subsite).length > 0;
  const path = isSubsiteValid ? flattenToAppURL(subsite['@id']) : '/';
```
 