### PR TITLE
Fixed site settings style issues and minor warnings

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -41,7 +41,7 @@ const messages = defineMessages({
 
 const Slide = (props) => {
   const intl = useIntl();
-  const { item, index, appearance, appearanceProp, onKeyDown } = props;
+  const { index, appearance, appearanceProp, onKeyDown } = props;
 
   const appearances = config.blocks.blocksConfig.listing.variations.filter(
     (v) => v.id === 'slider',
@@ -50,7 +50,6 @@ const Slide = (props) => {
 
   return (
     <SingleSlideWrapper
-      key={item['@id'] + index}
       index={index}
       onKeyDown={onKeyDown}
       aria-label={
@@ -130,6 +129,7 @@ const SliderTemplate = ({
             };
           return (
             <El
+              key={index}
               className={`${item.props.className} slick-dot`}
               tabIndex={-1}
               title={intl.formatMessage(messages.slideDot, {
@@ -228,6 +228,7 @@ const SliderTemplate = ({
                 const prevIndex = index > 0 ? index - 1 : null;
                 return (
                   <Slide
+                    key={item['@id'] + index}
                     image={image}
                     index={index}
                     full_width={full_width}

--- a/src/components/ItaliaTheme/BrandText/BrandText.jsx
+++ b/src/components/ItaliaTheme/BrandText/BrandText.jsx
@@ -4,27 +4,27 @@ import { useIntl } from 'react-intl';
 import { SiteProperty } from 'volto-site-settings';
 import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 
-const BrandText = ({ mobile = false, getParent = false }) => {
+const BrandText = ({ mobile = false }) => {
   const intl = useIntl();
   let title = SiteProperty({
     property: 'site_title',
     defaultValue: getSiteProperty('siteTitle', intl.locale),
     getValue: true,
-    getParent: getParent,
+    getParent: false,
   });
 
   const description = SiteProperty({
     property: 'site_subtitle',
     defaultValue: getSiteProperty('siteSubtitle', intl.locale),
     getValue: true,
-    getParent: getParent,
+    getParent: false,
   });
   const titleSplit = title?.split('\n') ?? null;
   title = titleSplit?.map((t, i) => (
-    <>
+    <React.Fragment key={i}>
       {t}
       {i < titleSplit.length - 1 && <br />}
-    </>
+    </React.Fragment>
   ));
 
   return (

--- a/src/components/ItaliaTheme/BrandTextFooter/BrandTextFooter.jsx
+++ b/src/components/ItaliaTheme/BrandTextFooter/BrandTextFooter.jsx
@@ -1,8 +1,37 @@
 import React from 'react';
-import { BrandText } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { useIntl } from 'react-intl';
+import { SiteProperty } from 'volto-site-settings';
+import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 
 const BrandTextFooter = () => {
-  return <BrandText getParent={true} />;
+  const intl = useIntl();
+  let title = SiteProperty({
+    property: 'site_title',
+    defaultValue: getSiteProperty('siteTitle', intl.locale),
+    getValue: true,
+    getParent: true,
+  });
+
+  const description = SiteProperty({
+    property: 'site_subtitle',
+    defaultValue: getSiteProperty('siteSubtitle', intl.locale),
+    getValue: true,
+    getParent: true,
+  });
+  const titleSplit = title?.split('\n') ?? null;
+  title = titleSplit?.map((t, i) => (
+    <React.Fragment key={i}>
+      {t}
+      {i < titleSplit.length - 1 && <br />}
+    </React.Fragment>
+  ));
+
+  return (
+    <div className="it-brand-text">
+      {title && <div className="h2">{title}</div>}
+      {description && <div className="h3">{description}</div>}
+    </div>
+  );
 };
 
 export default BrandTextFooter;

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -30,6 +30,11 @@ const messages = defineMessages({
 const HeaderCenter = () => {
   const intl = useIntl();
   const subsite = useSelector((state) => state.subsite?.data);
+  const logoSubsite = subsite?.subsite_logo && (
+    <figure className="icon">
+      <Logo alt={intl.formatMessage(messages.logoSubsiteAlt)} />
+    </figure>
+  );
 
   return (
     <Header small={false} theme="" type="center">
@@ -39,9 +44,7 @@ const HeaderCenter = () => {
             href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : '/'}
             title={intl.formatMessage(messages.subsiteUniversalLink)}
           >
-            <Logo
-              alt={subsite ? intl.formatMessage(messages.logoSubsiteAlt) : null}
-            />
+            {subsite?.subsite_logo ? logoSubsite : <Logo className="icon" />}
             <BrandText subsite={subsite} />
           </UniversalLink>
         </div>

--- a/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
@@ -26,7 +26,7 @@ const HeaderSlim = () => {
 
   const staticParentSiteTitle = getSiteProperty('parentSiteTitle', intl.locale);
 
-  const parentSiteTitle = SiteProperty({
+  const subsiteParentSiteTitle = SiteProperty({
     property: 'site_title',
     defaultValue: getSiteProperty('subsiteParentSiteTitle', intl.locale),
     getValue: true,
@@ -44,7 +44,7 @@ const HeaderSlim = () => {
           rel="noopener noreferrer"
         >
           {!subsite && staticParentSiteTitle}
-          {subsite && parentSiteTitle.replaceAll('\\n', ' - ')}
+          {subsite && subsiteParentSiteTitle.replaceAll('\\n', ' - ')}
         </HeaderBrand>
         <HeaderRightZone>
           <HeaderSlimRightZone />

--- a/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
@@ -26,10 +26,9 @@ const HeaderSlim = () => {
 
   const staticParentSiteTitle = getSiteProperty('parentSiteTitle', intl.locale);
 
-  const parentSiteTile = SiteProperty({
+  const parentSiteTitle = SiteProperty({
     property: 'site_title',
-    forceValue: subsite ? null : staticParentSiteTitle,
-    defaultValue: staticParentSiteTitle,
+    defaultValue: getSiteProperty('subsiteParentSiteTitle', intl.locale),
     getValue: true,
     getParent: true,
   });
@@ -44,7 +43,8 @@ const HeaderSlim = () => {
           target={target}
           rel="noopener noreferrer"
         >
-          {parentSiteTile.replaceAll('\\n', ' - ')}
+          {!subsite && staticParentSiteTitle}
+          {subsite && parentSiteTitle.replaceAll('\\n', ' - ')}
         </HeaderBrand>
         <HeaderRightZone>
           <HeaderSlimRightZone />

--- a/src/components/ItaliaTheme/Logo/Logo.jsx
+++ b/src/components/ItaliaTheme/Logo/Logo.jsx
@@ -23,12 +23,12 @@
 import logo from './logo.png';
 import { SiteProperty } from 'volto-site-settings';
 
-const Logo = ({ alt = 'Logo' }) => {
+const Logo = ({ alt = 'Logo', className }) => {
   return (
     <SiteProperty
       property="site_logo"
       defaultValue={{ url: logo, width: 82, height: 82 }}
-      className="icon"
+      className={className}
       alt={alt}
     />
   );

--- a/src/components/ItaliaTheme/Slider/NextArrow.jsx
+++ b/src/components/ItaliaTheme/Slider/NextArrow.jsx
@@ -25,7 +25,7 @@ export default function NextArrow(props) {
       id={id}
     >
       <Icon icon="chevron-right" key="chevron-right" title={_title} />
-      <span class="visually-hidden">{_title}</span>
+      <span className="visually-hidden">{_title}</span>
     </button>
   );
 }

--- a/src/components/ItaliaTheme/Slider/PrevArrow.jsx
+++ b/src/components/ItaliaTheme/Slider/PrevArrow.jsx
@@ -27,7 +27,7 @@ export default function PrevArrow(props) {
       onKeyDown={onKeyDown}
     >
       <Icon icon="chevron-left" key="chevron-left-prev" title={_title} />
-      <span class="visually-hidden">{_title}</span>
+      <span className="visually-hidden">{_title}</span>
     </button>
   );
 }

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -38,10 +38,7 @@ const Navigation = ({ pathname }) => {
   const subsite = useSelector((state) => state.subsite?.data);
   const logoSubsite = subsite?.subsite_logo && (
     <figure className="icon">
-      <img
-        src={flattenToAppURL(subsite.subsite_logo.scales?.mini?.download)}
-        alt="Logo"
-      />
+      <Logo />
     </figure>
   );
 
@@ -136,7 +133,11 @@ const Navigation = ({ pathname }) => {
                     }
                     onClick={() => setCollapseOpen(false)}
                   >
-                    {subsite?.subsite_logo ? logoSubsite : <Logo />}
+                    {subsite?.subsite_logo ? (
+                      logoSubsite
+                    ) : (
+                      <Logo className="icon" />
+                    )}
                     <BrandText mobile={true} subsite={subsite} />
                   </UniversalLink>
                 </div>


### PR DESCRIPTION
Risolto problemi di stili nel footer dovuti a markup html diversi previsti da bootstrap-italia tra header e footer.

Risolto problemi di retrocompatibilità del nostro css con i loghi dei sottositi, serve mantenere la `<figure class="icon">` oppure rifattorizzare il css per funzionare senza ma poi diventa un breaking change, oltre che altro tempo speso.

Risolto alcuni warning che si ottenevano durante il rendering degli slider.