### PR TITLE
fix: home link per languageRootFoolder

### DIFF
--- a/src/components/ItaliaTheme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/ItaliaTheme/Breadcrumbs/Breadcrumbs.jsx
@@ -21,6 +21,7 @@ import {
 import { UniversalLink } from '@plone/volto/components';
 import { Row, Col, BreadcrumbItem } from 'design-react-kit';
 import GoogleBreadcrumbs from 'design-comuni-plone-theme/components/ItaliaTheme/Breadcrumbs/GoogleBreadcrumbs';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
@@ -98,6 +99,7 @@ const Breadcrumbs = ({ pathname }) => {
       items = [];
     }
   }
+  const homepath = useHomePath();
 
   return items?.length > 0 ? (
     <>
@@ -110,7 +112,7 @@ const Breadcrumbs = ({ pathname }) => {
           >
             <ol className="breadcrumb" data-element="breadcrumb">
               <BreadcrumbItem tag="li">
-                <UniversalLink href="/">
+                <UniversalLink href={homepath}>
                   {intl.formatMessage(messages.home)}
                 </UniversalLink>
                 <span className="separator">/</span>

--- a/src/components/ItaliaTheme/Footer/FooterInfos.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterInfos.jsx
@@ -17,6 +17,8 @@ import {
   FooterSocials,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
+
 const messages = defineMessages({
   goToPage: {
     id: 'Vai alla pagina',
@@ -29,7 +31,7 @@ const FooterInfos = () => {
   const N_COLUMNS = 4;
   const location = useLocation();
   const dispatch = useDispatch();
-
+  const homepath = useHomePath();
   const footerConfiguration = useSelector(
     (state) => state.editableFooterColumns?.result,
   );
@@ -41,7 +43,7 @@ const FooterInfos = () => {
   //filter rootpaths
   const footerColumns = getItemsByPath(
     footerConfiguration,
-    location?.pathname?.length ? location.pathname : '/',
+    location?.pathname?.length ? location.pathname : homepath,
   );
 
   const colWidth =

--- a/src/components/ItaliaTheme/Footer/FooterMain.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterMain.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Container, Row, Col } from 'design-react-kit';
 
 import { UniversalLink } from '@plone/volto/components';
+import { FooterTop } from 'volto-editablefooter';
 import {
   FooterNavigation,
   FooterInfos,
@@ -14,8 +15,7 @@ import {
   BrandTextFooter,
   FooterPNRRLogo,
 } from 'design-comuni-plone-theme/components/ItaliaTheme/';
-
-import { FooterTop } from 'volto-editablefooter';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 
 /**
  * FooterMain component class.
@@ -24,7 +24,7 @@ import { FooterTop } from 'volto-editablefooter';
  */
 const FooterMain = () => {
   const footerTopContent = FooterTop();
-
+  const homepath = useHomePath();
   return (
     <div className="it-footer-main">
       <Container tag="div">
@@ -35,7 +35,7 @@ const FooterMain = () => {
                 {footerTopContent ?? (
                   <>
                     <FooterPNRRLogo />
-                    <UniversalLink href="/">
+                    <UniversalLink href={homepath}>
                       <LogoFooter />
                       <BrandTextFooter />
                     </UniversalLink>

--- a/src/components/ItaliaTheme/Footer/FooterSmall.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterSmall.jsx
@@ -5,15 +5,18 @@
 
 import React, { useEffect } from 'react';
 import cx from 'classnames';
-import { UniversalLink } from '@plone/volto/components';
 import { defineMessages, useIntl } from 'react-intl';
 import { Container } from 'design-react-kit';
-import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { getSubFooter, getItemsByPath } from 'volto-subfooter';
-import { flattenToAppURL } from '@plone/volto/helpers';
 import { displayBanner } from 'volto-gdpr-privacy';
+import { UniversalLink } from '@plone/volto/components';
+import { flattenToAppURL } from '@plone/volto/helpers';
+import {
+  getSiteProperty,
+  useHomePath,
+} from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
   goToPage: {
@@ -35,7 +38,7 @@ const FooterSmall = () => {
   const intl = useIntl();
   const pathname = useLocation().pathname;
   const dispatch = useDispatch();
-
+  const homepath = useHomePath();
   const subFooter = useSelector((state) => state.subFooter?.result);
   const subFooterItems = getItemsByPath(subFooter, pathname)?.filter(
     (item) => item.visible,
@@ -54,7 +57,9 @@ const FooterSmall = () => {
           {subFooterItems?.length > 0 &&
             subFooterItems.map((item, index) => {
               let url =
-                item.href || flattenToAppURL(item.linkUrl?.[0]?.['@id']) || '/';
+                item.href ||
+                flattenToAppURL(item.linkUrl?.[0]?.['@id']) ||
+                homepath;
               return (
                 <li
                   className={cx('list-inline-item', {

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -15,6 +15,7 @@ import {
   HeaderSearch,
   BrandText,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
   logoSubsiteAlt: {
@@ -35,13 +36,14 @@ const HeaderCenter = () => {
       <Logo alt={intl.formatMessage(messages.logoSubsiteAlt)} />
     </figure>
   );
+  const homepath = useHomePath();
 
   return (
     <Header small={false} theme="" type="center">
       <HeaderContent>
         <div className="it-brand-wrapper ps-4">
           <UniversalLink
-            href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : '/'}
+            href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : homepath}
             title={intl.formatMessage(messages.subsiteUniversalLink)}
           >
             {subsite?.subsite_logo ? logoSubsite : <Logo className="icon" />}

--- a/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
@@ -13,15 +13,18 @@ import {
   HeaderRightZone,
 } from 'design-react-kit';
 import { useIntl } from 'react-intl';
-import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
+import {
+  getSiteProperty,
+  useHomePath,
+} from 'design-comuni-plone-theme/helpers';
 import { SiteProperty } from 'volto-site-settings';
 
 const HeaderSlim = () => {
   const subsite = useSelector((state) => state.subsite?.data);
   const intl = useIntl();
-
+  const homepath = useHomePath();
   const parentSiteURL = subsite
-    ? '/'
+    ? homepath
     : getSiteProperty('parentSiteURL', intl.locale);
 
   const staticParentSiteTitle = getSiteProperty('parentSiteTitle', intl.locale);

--- a/src/components/ItaliaTheme/Header/ParentSiteMenu.jsx
+++ b/src/components/ItaliaTheme/Header/ParentSiteMenu.jsx
@@ -8,12 +8,14 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { Nav, NavItem, NavLink } from 'design-react-kit';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 
 const ParentSiteMenu = () => {
   const dropdownMenu = useSelector(
     (state) => state.dropdownMenuNavItems?.result,
   );
   const subsite = useSelector((state) => state.subsite?.data);
+  const homepath = useHomePath();
 
   let menu = null;
   if (subsite) {
@@ -23,7 +25,7 @@ const ParentSiteMenu = () => {
     let i = url_split.length - 1;
     while (i > 0) {
       let s = url_split.slice(0, i).join('/');
-      s = s.length === 0 ? '/' : s;
+      s = s.length === 0 ? homepath : s;
       // eslint-disable-next-line no-loop-func
       dropdownMenu.forEach((m) => {
         if (m.rootPath === s) {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -52,3 +52,4 @@ export {
 export { commonSearchBlockMessages } from 'design-comuni-plone-theme/helpers/Translations/searchBlockExtendedTranslations';
 
 export { getComponentWithFallback } from 'design-comuni-plone-theme/helpers/registry';
+export { useHomePath } from 'design-comuni-plone-theme/helpers/url';

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -1,14 +1,13 @@
 import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useIntl } from 'react-intl';
 
 import config from '@plone/volto/registry';
-import { useLocation } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 
 export const useHomePath = () => {
   const [path, setPath] = useState('/');
 
-  const locale = useSelector((state) => state.intl.locale);
-  //const { pathname } = useLocation();
+  const { locale } = useIntl();
 
   useEffect(() => {
     setPath(config.settings.isMultilingual ? '/' + locale : '/');

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+import config from '@plone/volto/registry';
+import { useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+export const useHomePath = () => {
+  const [path, setPath] = useState('/');
+
+  const locale = useSelector((state) => state.intl.locale);
+  //const { pathname } = useLocation();
+
+  useEffect(() => {
+    setPath(config.settings.isMultilingual ? '/' + locale : '/');
+  }, [locale]);
+  return path;
+};


### PR DESCRIPTION
è stato sistemato il link alla home page nel caso di siti multilingua.
Prima puntava sempre a '/' e poi in automatico veniva fatta la redirect alla radice di lingua.
Ora i link alla homepage puntano alla radice della lingua corrente.