### PR TITLE
fix: set maxFileUploadSize config setting to 100mb

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,6 +51,10 @@
 
 - Ripristinato il funzionamento del filtro luogo nella ricerca eventi.
 
+### Migliorie
+
+- Viene ora mostrato un errore parlante nel caso si tenti di caricare un file che superi le dimensioni massime consentite, di default 100mb, come già esplicitato sul manuale utente.
+
 ## Versione 11.16.0 (10/07/2024)
 
 ### Migliorie

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -127,6 +127,16 @@ export default function applyConfig(voltoConfig) {
         errorPages: true,
       },
     },
+    /*
+      Set to 100mb in BINARY bytes, not decimal, see volto/helpers/FormValidation.js.validateFileUploadSize error message
+      ...
+      messages.fileTooLarge, {
+        limit: `${Math.floor(
+          config.settings.maxFileUploadSize / 1024 / 1024,
+        )}MB`,
+      }
+    */
+    maxFileUploadSize: 104857600,
     querystringAdditionalFields: [],
     searchBlockTemplates: [
       'simpleCard',
@@ -305,7 +315,6 @@ export default function applyConfig(voltoConfig) {
         component: SiteSettingsExtras,
       },
     ],
-    maxFileUploadSize: null,
     'volto-blocks-widget': {
       allowedBlocks: [
         ...(config.settings['volto-blocks-widget']?.allowedBlocks ?? []).filter(


### PR DESCRIPTION
Set maxFileUploadSize to 100mb in BINARY bytes, not decimal, see volto/helpers/FormValidation.js.validateFileUploadSize error message

```
      messages.fileTooLarge, {
        limit: `${Math.floor(
          config.settings.maxFileUploadSize / 1024 / 1024,
        )}MB`,
      }
```