### PR TITLE
feat: vista news su ct ComunicatoStampa

### DIFF
--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
@@ -39,6 +39,7 @@ const NewsItemText = ({ content }) => {
 NewsItemText.propTypes = {
   content: PropTypes.shape({
     descrizione_estesa: PropTypes.object,
+    text: PropTypes.object,
   }).isRequired,
 };
 

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
@@ -21,13 +21,13 @@ const NewsItemText = ({ content }) => {
   // (richtext senza blocchi).
   //
   // TODO: al momento viene presentato uno solo dei due, valutare se
-  // mettere entrambi, il componente comunqu non mostra nulla se il
+  // mettere entrambi, il componente comunque non mostra nulla se il
   // contenuto è vuoto.
   //
   // La condizione sul campo descrizione_estesa è volutamente semplificata
   // senza `richTextHasContent` perchè non interessa tanto se il campo
   // ha o non ha contenuto, ma se il campo esiste o non esiste
-  return content.descrizione_estesa ? (
+  return Object.hasOwn(content, 'descrizione_estesa') ? (
     <RichTextSection
       data={content.descrizione_estesa}
       tag_id={'text-body'}

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
@@ -4,6 +4,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import {
   RichText,
   RichTextSection,
+  richTextHasContent,
 } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
 
 const messages = defineMessages({
@@ -23,17 +24,25 @@ const NewsItemText = ({ content }) => {
   // La condizione sul campo descrizione_estesa è volutamente semplificata
   // senza `richTextHasContent` perchè non interessa tanto se il campo
   // ha o non ha contenuto, ma se il campo esiste o non esiste
-  return Object.hasOwn(content, 'descrizione_estesa') ? (
-    <RichTextSection
-      data={content.descrizione_estesa}
-      tag_id={'text-body'}
-      field="descrizione_estesa"
-      title={intl.formatMessage(messages.news_item_contenuto)}
-      show_title={false}
-    />
-  ) : (
-    <RichText data={content.text} />
-  );
+  return Object.hasOwn(content, 'descrizione_estesa')
+    ? richTextHasContent(content.descrizione_estesa) && (
+        <RichTextSection
+          data={content.descrizione_estesa}
+          tag_id={'text-body'}
+          field="descrizione_estesa"
+          title={intl.formatMessage(messages.news_item_contenuto)}
+          show_title={false}
+        />
+      )
+    : content.text && (
+        <RichTextSection
+          tag_id={'text-body'}
+          title={intl.formatMessage(messages.news_item_contenuto)}
+          show_title={false}
+        >
+          <RichText data={content.text} />
+        </RichTextSection>
+      );
 };
 
 NewsItemText.propTypes = {

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
@@ -21,8 +21,12 @@ const NewsItemText = ({ content }) => {
   // (richtext senza blocchi).
   //
   // TODO: al momento viene presentato uno solo dei due, valutare se
-  // mettere entrambi, il componente comuqneu non mostra nulla se il
+  // mettere entrambi, il componente comunqu non mostra nulla se il
   // contenuto è vuoto.
+  //
+  // La condizione sul campo descrizione_estesa è volutamente semplificata
+  // senza `richTextHasContent` perchè non interessa tanto se il campo
+  // ha o non ha contenuto, ma se il campo esiste o non esiste
   return content.descrizione_estesa ? (
     <RichTextSection
       data={content.descrizione_estesa}

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
@@ -20,10 +20,6 @@ const NewsItemText = ({ content }) => {
   // altri CT (come i Comunicati Stampa) potrebbero avere `text`
   // (richtext senza blocchi).
   //
-  // TODO: al momento viene presentato uno solo dei due, valutare se
-  // mettere entrambi, il componente comunque non mostra nulla se il
-  // contenuto è vuoto.
-  //
   // La condizione sul campo descrizione_estesa è volutamente semplificata
   // senza `richTextHasContent` perchè non interessa tanto se il campo
   // ha o non ha contenuto, ma se il campo esiste o non esiste

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemText.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
-import { RichTextSection } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
+import {
+  RichText,
+  RichTextSection,
+} from 'design-comuni-plone-theme/components/ItaliaTheme/View';
 
 const messages = defineMessages({
   news_item_contenuto: {
@@ -13,7 +16,14 @@ const messages = defineMessages({
 const NewsItemText = ({ content }) => {
   const intl = useIntl();
 
-  return (
+  // NewsItem ha la descrizione_estesa (testo con blocchi)
+  // altri CT (come i Comunicati Stampa) potrebbero avere `text`
+  // (richtext senza blocchi).
+  //
+  // TODO: al momento viene presentato uno solo dei due, valutare se
+  // mettere entrambi, il componente comuqneu non mostra nulla se il
+  // contenuto è vuoto.
+  return content.descrizione_estesa ? (
     <RichTextSection
       data={content.descrizione_estesa}
       tag_id={'text-body'}
@@ -21,6 +31,8 @@ const NewsItemText = ({ content }) => {
       title={intl.formatMessage(messages.news_item_contenuto)}
       show_title={false}
     />
+  ) : (
+    <RichText data={content.text} />
   );
 };
 

--- a/src/config/Views/views.js
+++ b/src/config/Views/views.js
@@ -44,6 +44,7 @@ defineMessages({
 const italiaContentTypesViews = {
   Document: PageView,
   'News Item': NewsItemView,
+  ComunicatoStampa: NewsItemView, // ct opzionale da volto-rer-ufficiostampa
   UnitaOrganizzativa: UOView,
   Persona: PersonaView,
   Venue: VenueView,


### PR DESCRIPTION
questa modifica non ha nessun effetto diretto sul prodotto, è quindi senza effetti collaterali e dal mio punto di vista si potrebbe già fare il merge

se presente un prodotto per i comunicatistampa (WIP rer.ufficiostampa/volto-rer-ufficiostampa Modena e RER) usa la vista Notizia per quel CT.
