### PR TITLE
fix: fixed list style format in sidebar context and TextSize icon

### DIFF
--- a/src/config/RichTextEditor/ToolbarButtons/TextSizeButton.jsx
+++ b/src/config/RichTextEditor/ToolbarButtons/TextSizeButton.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import { defineMessages, useIntl } from 'react-intl';
+// import { defineMessages, useIntl } from 'react-intl';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 
 // import DraftJsDropdownButton from 'design-comuni-plone-theme/config/RichTextEditor/ToolbarButtons/DraftJsDropdownButton';
 
 import formatSVG from '@plone/volto/icons/format.svg';
 
-const messages = defineMessages({
-  TextSizeButton: {
-    id: 'text-size-button',
-    defaultMessage: 'Dimensione del testo',
-  },
-});
+// const messages = defineMessages({
+//   TextSizeButton: {
+//     id: 'text-size-button',
+//     defaultMessage: 'Dimensione del testo',
+//   },
+// });
 
 /*
 const TextSizeButton = (props) => {
@@ -44,22 +44,12 @@ const TextSizeButton = (props) => {
 };
 */
 
-const ButtonIcon = (props) => {
-  const intl = useIntl();
-  return (
-    <Icon
-      name={formatSVG}
-      size="1.25em"
-      title={intl.formatMessage(messages.TextSizeButton)}
-    />
-  );
-};
-
 const TextSizeButton = (props) => {
   const createInlineStyleButton = props.draftJsCreateInlineStyleButton.default;
+
   return createInlineStyleButton({
     style: 'TEXT_LARGER',
-    children: ButtonIcon,
+    children: <Icon name={formatSVG} size="24px" />,
   });
 };
 export default TextSizeButton;

--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -393,6 +393,14 @@ body.cms-ui {
     }
   }
 
+  // Sidebar - campi editabili con draftJs
+  // - liste
+  #sidebar .sidebar-container .ui.form ul.public-DraftStyleDefault-ul {
+    li.public-DraftStyleDefault-unorderedListItem {
+      display: list-item;
+    }
+  }
+
   [data-rbd-draggable-context-id] {
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
Sistemato bug nella sidebar con draftJs l'elenco puntato non veniva stilizzato e l'icona del TextSize nella toolbar non si vedeva con il title applicato.

<img width="1171" alt="Screenshot 2024-07-24 alle 10 13 55" src="https://github.com/user-attachments/assets/627d9bad-bd84-42e5-9c95-c547694d2ebe">
