### PR TITLE
fix: removed fullobjects from query in EventSearch and UOSearch blocks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Migliorata la visualizzazione delle card risultato nella ricerca Eventi e Unità Organizzativa
+
 ## Versione 11.18.0 (19/07/2024)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -98,7 +98,6 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
       getQueryStringResults(
         subsite ? flattenToAppURL(subsite['@id']) : '',
         {
-          fullobjects: 1,
           query: query,
           b_size: b_size,
           sort_order: 'ascending',

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -99,6 +99,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
         subsite ? flattenToAppURL(subsite['@id']) : '',
         {
           query: query,
+          metadata: '_all',
           b_size: b_size,
           sort_order: 'ascending',
           sort_on: 'start',

--- a/src/components/ItaliaTheme/Blocks/UOSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/UOSearch/Body.jsx
@@ -88,7 +88,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
       getQueryStringResults(
         subsite ? flattenToAppURL(subsite['@id']) : '',
         {
-          fullobjects: 1,
+          metadata_fields: '_all',
           query: query,
           b_size: b_size,
         },


### PR DESCRIPTION
EventSearch and UOSearch still retained old queries for info. That meant that the info required from database asked for fullobjects, not only generating a very heavy query, but also requiring the wrong image fields. 
Changed it with the same logics as listing blocks, with metadata: "_all" to retain informations for UOSearch which also require other info to render cards.