### PR TITLE
fix: removed bg from template-wrapper inside block search

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/ListingBody.jsx
@@ -82,7 +82,7 @@ const ListingBody = React.memo(
             isSearchBlockResults ? '' : 'full-width'
           }`;
         } else {
-          return `py-5 ${bg_color} ${
+          return `py-5 ${
             isSearchBlockResults ? 'template-wrapper' : 'full-width'
           }`;
         }


### PR DESCRIPTION
Rimosso lo sfondo per i card, il comportamento per l'intero blocco rimane lo stesso.

Test fatto su ogni singolo blocco tipo "search"