### PR TITLE
fix: add clear:both to bottom-metadata and richtext-blocks classes

### DIFF
--- a/src/theme/ItaliaTheme/Components/_metadata.scss
+++ b/src/theme/ItaliaTheme/Components/_metadata.scss
@@ -10,5 +10,6 @@
   &.bottom-metadata {
     margin: 1rem 0;
     font-size: 0.8rem;
+    clear: both;
   }
 }

--- a/src/theme/ItaliaTheme/Widgets/_blocksWidget.scss
+++ b/src/theme/ItaliaTheme/Widgets/_blocksWidget.scss
@@ -1,4 +1,5 @@
 .richtext-blocks {
+  clear: both;
   .row-full-width {
     max-width: 100%;
     margin: 0 -20px !important;


### PR DESCRIPTION
Come da richiesta 
![image](https://github.com/user-attachments/assets/fac3ffca-609c-4118-b8cc-fefe4dec23c5)
