### PR TITLE
Rrule monthly recurrence text

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Il testo che descrive la ricorrenza mensile è stato corretto per coprire tutti i casi.
+
 ## Versione 11.18.2 (25/07/2024)
 
 ### Fix

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -3030,7 +3030,7 @@ msgid "rrule_on"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: di
+# defaultMessage: il
 msgid "rrule_on the"
 msgstr ""
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -3015,7 +3015,7 @@ msgid "rrule_on"
 msgstr "on"
 
 #: overrideTranslations
-# defaultMessage: di
+# defaultMessage: il
 msgid "rrule_on the"
 msgstr "on the"
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -3024,7 +3024,7 @@ msgid "rrule_on"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: di
+# defaultMessage: il
 msgid "rrule_on the"
 msgstr ""
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -3032,7 +3032,7 @@ msgid "rrule_on"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: di
+# defaultMessage: il
 msgid "rrule_on the"
 msgstr ""
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -3015,9 +3015,9 @@ msgid "rrule_on"
 msgstr "di"
 
 #: overrideTranslations
-# defaultMessage: di
+# defaultMessage: il
 msgid "rrule_on the"
-msgstr "di"
+msgstr "il"
 
 #: overrideTranslations
 # defaultMessage: _

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-07-15T11:07:19.251Z\n"
+"POT-Creation-Date: 2024-08-06T16:50:24.401Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -3017,7 +3017,7 @@ msgid "rrule_on"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: di
+# defaultMessage: il
 msgid "rrule_on the"
 msgstr ""
 

--- a/src/components/ItaliaTheme/View/Commons/Dates.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Dates.jsx
@@ -50,13 +50,28 @@ const Dates = ({ content, show_image, moment: momentlib, rrule }) => {
   let recurrenceText = null;
 
   if (content.recurrence) {
+    const isRecurrenceByDay = content.recurrence.includes('BYDAY=+');
+    const isWeekdaySunday = content.recurrence
+      .split('BYDAY')[1]
+      ?.includes('SU');
     const RRULE_LANGUAGE = rrulei18n(intl, moment);
     rruleSet = rrulestr(content.recurrence, {
       compatible: true, //If set to True, the parser will operate in RFC-compatible mode. Right now it means that unfold will be turned on, and if a DTSTART is found, it will be considered the first recurrence instance, as documented in the RFC.
       forceset: true,
     });
+
     recurrenceText = rruleSet.rrules()[0]?.toText(
       (t) => {
+        if (moment.locale(intl.locale) === 'it' && isRecurrenceByDay) {
+          RRULE_LANGUAGE.strings.th = '°';
+          RRULE_LANGUAGE.strings.nd = '°';
+          RRULE_LANGUAGE.strings.rd = '°';
+          RRULE_LANGUAGE.strings.st = '°';
+
+          if (isWeekdaySunday) {
+            RRULE_LANGUAGE.strings['on the'] = 'la';
+          }
+        }
         return RRULE_LANGUAGE.strings[t];
       },
       RRULE_LANGUAGE,

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -27,7 +27,7 @@ defineMessages({
   },
   rrule_on_the: {
     id: 'rrule_on the',
-    defaultMessage: 'di',
+    defaultMessage: 'il',
   },
   weekdays: {
     id: 'rrule_weekdays',


### PR DESCRIPTION
Quando la ricorrenza è mensile/annuale ed è impostato il parametro "Si ripete ogni x giorno-della-settimana" es. (Si ripete ogni 3° martedì del mese/del mese di novembre), la stringa prodotta non era in un italiano corretto ("ogni mese di 2 domenica fino al 15 dicembre 2024")

Siccome non è possibile agire all'interno della libreria rrule e delle logiche che regolano la funzione toText che converte i parametri di recurrence in testo, plasmati comunque su espressioni inglesi, sono andata a sovrascrivere le traduzioni specifiche per questo caso e per il locale 'it'.

E' un po' una toppa, però o si mette mano alla libreria e si crea una funzione interna a ioComune che calcola le stringhe di ogni singolo caso della ricorrenza, oppure si agisce in questo modo solo per l'italiano e per questo caso. 