### PR TITLE
fix: removed align-item from slick-track

### DIFF
--- a/theme/ItaliaTheme/Blocks/_photogallerytemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_photogallerytemplate.scss
@@ -116,7 +116,6 @@
 
   .slick-track {
     display: flex;
-    align-items: center;
   }
 
   @media (max-width: #{map-get($grid-breakpoints, md)}) {


### PR DESCRIPTION
Sistemata la mancanza di allineamento dentro photogallery