### PR TITLE
fix: metadata field in EventSearch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Le date delle card nella Ricerca Eventi vengono mostrate correttamente come impostate nell'evento.
+
 ## Versione 11.20.2 (12/08/2024)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -99,7 +99,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
         subsite ? flattenToAppURL(subsite['@id']) : '',
         {
           query: query,
-          metadata: '_all',
+          metadata_fields: '_all',
           b_size: b_size,
           sort_order: 'ascending',
           sort_on: 'start',


### PR DESCRIPTION
Self-explanatory

Quello che succedeva da segnalazione cliente, è che impostando la data di fine come filtro nella ricerca eventi, veniva impostata quella data come data di fine evento, invece che la data di fine evento.
Correggendo la query e chiamando tutti i dati, questo problema si "risolve", ma a breve arriverà un'altra pr per come vengono calcolate le date nelle card perchè abbiamo notato altri problemi a riguardo nel debuggare questa richiesta.