### PR TITLE
paranoid check contextual_vocab

### DIFF
--- a/src/customizations/volto/actions/vocabularies/vocabularies.js
+++ b/src/customizations/volto/actions/vocabularies/vocabularies.js
@@ -36,7 +36,7 @@ export function getVocabulary({
   const vocabulary = getVocabName(vocabNameOrURL);
   const contextualVocabularies = config.settings.contextualVocabularies;
   const vocabPath =
-    contextualVocabularies && contextualVocabularies.includes(vocabulary)
+    contextualVocabularies && contextualVocabularies.includes(vocabulary) && vocabulary !== vocabNameOrURL
       ? flattenToAppURL(vocabNameOrURL)
       : `/@vocabularies/${vocabulary}`;
   let queryString = `b_start=${start}${size ? '&b_size=' + size : ''}`;
@@ -74,7 +74,7 @@ export function getVocabularyTokenTitle({
   const vocabulary = getVocabName(vocabNameOrURL);
   const contextualVocabularies = config.settings.contextualVocabularies;
   const vocabPath =
-    contextualVocabularies && contextualVocabularies.includes(vocabulary)
+    contextualVocabularies && contextualVocabularies.includes(vocabulary) && vocabulary !== vocabNameOrURL
       ? flattenToAppURL(vocabNameOrURL)
       : `/@vocabularies/${vocabulary}`;
   const queryString = {


### PR DESCRIPTION
https://github.com/RedTurtle/design-comuni-plone-theme/pull/738

aggiunto un check per evitare di dare la url sbagliat nel caso il vocabolario venga marcato contestuale ma chiamato senza contesto

(la modifica è già presente nella PR su volto)