### PR TITLE
fix: custom feedback form title (v11)

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2095,11 +2095,6 @@ msgid "feedback_form_title"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
-# defaultMessage: How easy was it to use this service?
-msgid "feedback_form_title_service"
-msgstr ""
-
-#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Yes
 msgid "feedback_form_yes"
 msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2080,11 +2080,6 @@ msgid "feedback_form_title"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
-# defaultMessage: How easy was it to use this service?
-msgid "feedback_form_title_service"
-msgstr ""
-
-#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Yes
 msgid "feedback_form_yes"
 msgstr ""

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2089,11 +2089,6 @@ msgid "feedback_form_title"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
-# defaultMessage: How easy was it to use this service?
-msgid "feedback_form_title_service"
-msgstr ""
-
-#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Yes
 msgid "feedback_form_yes"
 msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2097,11 +2097,6 @@ msgid "feedback_form_title"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
-# defaultMessage: How easy was it to use this service?
-msgid "feedback_form_title_service"
-msgstr ""
-
-#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Yes
 msgid "feedback_form_yes"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2080,11 +2080,6 @@ msgid "feedback_form_title"
 msgstr "Quanto sono chiare le informazioni su questa pagina?"
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
-# defaultMessage: How easy was it to use this service?
-msgid "feedback_form_title_service"
-msgstr "Quanto è stato facile usare questo servizio?"
-
-#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Yes
 msgid "feedback_form_yes"
 msgstr "Si"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-08-06T16:50:24.401Z\n"
+"POT-Creation-Date: 2024-08-29T12:09:17.914Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2079,11 +2079,6 @@ msgstr ""
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: How clear is the information on this page?
 msgid "feedback_form_title"
-msgstr ""
-
-#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
-# defaultMessage: How easy was it to use this service?
-msgid "feedback_form_title_service"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm

--- a/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
+++ b/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
@@ -269,23 +269,7 @@ const FeedbackForm = ({ title, pathname }) => {
                         className="title-medium-2-semi-bold mb-0"
                         data-element="feedback-title"
                       >
-                        {/* Il validatore a quanto pare fa il check per titolo.
-                            Il titolo da specifiche deve essere diverso per Servizi, ma loro non lo sanno
-                            https://github.com/italia/pa-website-validator/blob/main/src/storage/municipality/feedbackComponentStructure.ts#L8
-                        */}
-                        {/* {contentType === 'Servizio'
-                          ? intl.formatMessage(messages.service_title)
-                          : intl.formatMessage(messages.title)} */}
-
-                        {/* Aggiunto titolo per compatibilità modello AGID di io-cittadino */}
-                        {/* {contentType === 'ModelloPratica'
-                          ? intl.formatMessage(messages.service_title)
-                          : intl.formatMessage(messages.title)} */}
-
-                        {/* Se serve un titolo custom va passato come prop, il ModelloPratica passerà
-                            un titolo custom a seconda dello step in cui ci si trova "... this service"
-                            va messo solo dopo l'invio */}
-                        {title ? title : intl.formatMessage(messages.title)}
+                        {title || intl.formatMessage(messages.title)}
                       </h2>
                       <div className="rating-container mb-0">
                         <RTRating

--- a/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
+++ b/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
@@ -32,10 +32,6 @@ const messages = defineMessages({
     id: 'feedback_form_title',
     defaultMessage: 'How clear is the information on this page?',
   },
-  service_title: {
-    id: 'feedback_form_title_service',
-    defaultMessage: 'How easy was it to use this service?',
-  },
   yes: {
     id: 'feedback_form_yes',
     defaultMessage: 'Yes',
@@ -120,7 +116,7 @@ const messages = defineMessages({
   },
 });
 
-const FeedbackForm = ({ contentType, pathname }) => {
+const FeedbackForm = ({ contentType, title, pathname }) => {
   const intl = useIntl();
   const location = useLocation();
   const path = pathname ?? location.pathname ?? '/';
@@ -282,9 +278,14 @@ const FeedbackForm = ({ contentType, pathname }) => {
                           : intl.formatMessage(messages.title)} */}
 
                         {/* Aggiunto titolo per compatibilità modello AGID di io-cittadino */}
-                        {contentType === 'ModelloPratica'
+                        {/* {contentType === 'ModelloPratica'
                           ? intl.formatMessage(messages.service_title)
-                          : intl.formatMessage(messages.title)}
+                          : intl.formatMessage(messages.title)} */}
+
+                        {/* Se serve un titolo custom va passato come prop, il ModelloPratica passerà
+                            un titolo custom a seconda dello step in cui ci si trova "... this service"
+                            va messo solo dopo l'invio */}
+                        {title ? title : intl.formatMessage(messages.title)}
                       </h2>
                       <div className="rating-container mb-0">
                         <RTRating

--- a/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
+++ b/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
@@ -116,7 +116,7 @@ const messages = defineMessages({
   },
 });
 
-const FeedbackForm = ({ contentType, title, pathname }) => {
+const FeedbackForm = ({ title, pathname }) => {
   const intl = useIntl();
   const location = useLocation();
   const path = pathname ?? location.pathname ?? '/';
@@ -456,7 +456,7 @@ const FeedbackForm = ({ contentType, title, pathname }) => {
 };
 
 FeedbackForm.propTypes = {
-  contentType: PropTypes.string,
+  title: PropTypes.string,
   pathname: PropTypes.string,
 };
 

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -280,6 +280,7 @@ export default function applyConfig(voltoConfig) {
       },
       enableFeedbackForm: true,
       noFeedbackFormFor: ['ModelloPratica'],
+      // ['Plone Site', 'LRF', 'Subsite']
       enableFeedbackFormCaptcha: false,
       enableVoltoFormBlockCaptcha: true,
       splitMegamenuColumns: true, //se impostato a false, non spezza le colonne con intestazioni nel megamenu

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -280,7 +280,6 @@ export default function applyConfig(voltoConfig) {
       },
       enableFeedbackForm: true,
       noFeedbackFormFor: ['ModelloPratica'],
-      // ['Plone Site', 'LRF', 'Subsite']
       enableFeedbackFormCaptcha: false,
       enableVoltoFormBlockCaptcha: true,
       splitMegamenuColumns: true, //se impostato a false, non spezza le colonne con intestazioni nel megamenu

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -279,6 +279,7 @@ export default function applyConfig(voltoConfig) {
         ],
       },
       enableFeedbackForm: true,
+      noFeedbackFormFor: ['ModelloPratica'],
       enableFeedbackFormCaptcha: false,
       enableVoltoFormBlockCaptcha: true,
       splitMegamenuColumns: true, //se impostato a false, non spezza le colonne con intestazioni nel megamenu

--- a/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -24,19 +24,15 @@ import config from '@plone/volto/registry';
 const Footer = () => {
   useGoogleAnalytics();
   const currentContent = useSelector((state) => state.content?.data);
-  let contentType = null;
-  if (currentContent != null) {
-    contentType = currentContent?.['@type'];
-  }
-  // const NoFeedbackFormFor = ['Plone Site', 'LRF', 'Subsite'];
+  const contentType = currentContent ? currentContent['@type'] : null;
   const noFeedbackFormFor = config.settings.siteProperties.noFeedbackFormFor || [];
 
   return (
     <>
-      {contentType != null &&
+      {contentType &&
         !noFeedbackFormFor.includes(contentType) &&
         config.settings.siteProperties.enableFeedbackForm && (
-          <FeedbackForm contentType={contentType} />
+          <FeedbackForm />
         )}
 
       <SubsiteFooter />

--- a/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -29,12 +29,12 @@ const Footer = () => {
     contentType = currentContent?.['@type'];
   }
   // const NoFeedbackFormFor = ['Plone Site', 'LRF', 'Subsite'];
-  const noFeedbackFormFor = config.settings.noFeedbackFormFor || [];
+  const noFeedbackFormFor = config.settings.siteProperties.noFeedbackFormFor || [];
 
   return (
     <>
       {contentType != null &&
-        noFeedbackFormFor.includes(contentType) &&
+        !noFeedbackFormFor.includes(contentType) &&
         config.settings.siteProperties.enableFeedbackForm && (
           <FeedbackForm contentType={contentType} />
         )}

--- a/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -21,7 +21,7 @@ import config from '@plone/volto/registry';
  * @extends Component
  */
 
-const Footer = ({ intl }) => {
+const Footer = () => {
   useGoogleAnalytics();
   const currentContent = useSelector((state) => state.content?.data);
   let contentType = null;
@@ -29,12 +29,12 @@ const Footer = ({ intl }) => {
     contentType = currentContent?.['@type'];
   }
   // const NoFeedbackFormFor = ['Plone Site', 'LRF', 'Subsite'];
-  const NoFeedbackFormFor = [];
+  const noFeedbackFormFor = config.settings.noFeedbackFormFor || [];
 
-  let content = (
+  return (
     <>
       {contentType != null &&
-        NoFeedbackFormFor.indexOf(contentType) < 0 &&
+        noFeedbackFormFor.includes(contentType) &&
         config.settings.siteProperties.enableFeedbackForm && (
           <FeedbackForm contentType={contentType} />
         )}
@@ -46,8 +46,6 @@ const Footer = ({ intl }) => {
       </footer>
     </>
   );
-
-  return content;
 };
 
 export default Footer;


### PR DESCRIPTION
Nelle pratiche il titolo della form di feedback deve essere "quanto ti è stata utile questa pagina" nei vari step e "quanto ti è stato utile questo servizio" solo dopo aver sottomesso la pratica.

Visto che lo stato è gestito nella pratica, viene fatto in modo che feedbackform possa gestire un title custom, rimosso dal footer per alcuni CT il feebackform (ie ModelloPratica), questi ct gestiranno in autonomia la componente FeedbackForm