### PR TITLE
fix: restored Metadata component in UO View

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Ripristinato l'informazione sull'ultimo aggiornamento nel CT UO
+
 ## Versione 11.21.0 (14/08/2024)
 
 ### Fix

--- a/src/components/ItaliaTheme/View/UOView/UOMetadati.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOMetadati.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import { Metadata } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
+
+const UOMetadati = ({ content }) => {
+  return <Metadata content={content} showSectionTitle={false} />;
+};
+
+UOMetadati.propTypes = {
+  content: PropTypes.object,
+};
+
+export default UOMetadati;

--- a/src/components/ItaliaTheme/View/UOView/UOView.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOView.jsx
@@ -19,6 +19,7 @@ import {
   UODocuments,
   UOWhatDoesItDo,
   UOMoreInfos,
+  UOMetadati,
   RelatedItemInEvidence,
   SkipToMainContent,
   ContentTypeViewSections,
@@ -46,6 +47,8 @@ export const UOViewSectionsOrder = [
   { /* DOCUMENTI */ component: UODocuments },
 
   { /* ULTERIORI INFORMAZIONI */ component: UOMoreInfos },
+
+  { /*METADATI*/ component: UOMetadati },
 ];
 
 /**

--- a/src/components/ItaliaTheme/View/index.js
+++ b/src/components/ItaliaTheme/View/index.js
@@ -183,6 +183,7 @@ export UOContacts from 'design-comuni-plone-theme/components/ItaliaTheme/View/UO
 export UOContactsLocations from 'design-comuni-plone-theme/components/ItaliaTheme/View/UOView/UOContactsParts/UOContactsLocations';
 export UOContactsContacts from 'design-comuni-plone-theme/components/ItaliaTheme/View/UOView/UOContactsParts/UOContactsContacts';
 export UOContactsSediSecondarie from 'design-comuni-plone-theme/components/ItaliaTheme/View/UOView/UOContactsParts/UOContactsSediSecondarie';
+export UOMetadati from 'design-comuni-plone-theme/components/ItaliaTheme/View/UOView/UOMetadati';
 
 export UODocuments from 'design-comuni-plone-theme/components/ItaliaTheme/View/UOView/UODocuments';
 export UOWhatDoesItDo from 'design-comuni-plone-theme/components/ItaliaTheme/View/UOView/UOWhatDoesItDo';


### PR DESCRIPTION
The component that provides info on the CT last update had been deleted in this commit:
https://github.com/RedTurtle/design-comuni-plone-theme/commit/d562d1f2de714fef8cca3ba639b340135ce0da0a#diff-242becc687a024ddc511a8f392480e9f979de57446ba23b2b091c07cc222f5ad

to make room for other "Ulteriori Informazioni" fields.
Added a new section in the page to restore the Metadata without creating a new item in the SideMenu component.
Used the same logics as in the ServizioView