### PR TITLE
fix problem with sort_on default; fix bug with total results

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
@@ -2,9 +2,8 @@
   - Agid styling
 
 */
-import React from 'react';
-import { defineMessages, useIntl } from 'react-intl';
 import { commonSearchBlockMessages } from 'design-comuni-plone-theme/helpers';
+import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
   searchResults: {
@@ -26,7 +25,7 @@ const SearchDetails = ({ total, text, as = 'p', data }) => {
               searchedtext: text,
             })}
           </>
-        )}
+        )}{' '}
         {data.showTotalResults && (
           <>
             {intl.formatMessage(messages.searchResults)}: <b>{total}</b>

--- a/src/customizations/volto/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -1,10 +1,10 @@
 /* CUSTOMIZATIONS:
   - Read puntual comments in code
 */
+import qs from 'query-string';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import qs from 'query-string';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { resolveExtension } from '@plone/volto/helpers/Extensions/withBlockExtensions';
 import config from '@plone/volto/registry';
@@ -236,7 +236,7 @@ const withSearch = (options) => (WrappedComponent) => {
   const { inputDelay = 1000 } = options || {};
 
   function WithSearch(props) {
-    const { data, id, editable = false } = props;
+    const { data, id, editable = false, properties } = props;
 
     const [locationSearchData, setLocationSearchData] = useSearchBlockState(
       id,
@@ -325,8 +325,10 @@ const withSearch = (options) => (WrappedComponent) => {
     const querystringResults = useSelector(
       (state) => state.querystringsearch.subrequests,
     );
+    const subrequestID = properties?.UID + '-' + id;
     const totalItems =
-      querystringResults[id]?.total || querystringResults[id]?.items?.length;
+      querystringResults[subrequestID]?.total ||
+      querystringResults[subrequestID]?.items?.length;
 
     return (
       <WrappedComponent


### PR DESCRIPTION
Using the custom search block within the design-comuni-plone-theme, we noticed that the default sorting always uses the effective date unless another sorting method is set. What we want is to use the block configuration's sorting setting for non-textual search results. For textual searches, we want to use Plone's ranking-based sorting.

As a side note, there was a need to add a space in a text because the searched word and the phrase 'search results' were stuck together.

Lastly, we noticed that the total number of items was being read incorrectly by the subrequest and therefore wasn't displayed. We have corrected this as well.