### PR TITLE
fix: added trasparenza fields to CT Persona

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Novità
+
+- Aggiunti al CT Persona i campi per la gestione della Trasparenza per allegare i file sugli emolumenti a carico della finanza pubblica e le dichiarazioni di insussistenza e incompatibilità.
+
 ## Versione 11.21.0 (14/08/2024)
 
 ### Fix

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1701,6 +1701,11 @@ msgstr ""
 msgid "dichiarazione_dei_redditi"
 msgstr ""
 
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Dichiarazioni di insussistenza e incompatibilità
+msgid "dichiarazioni_di_insussistenza_e_incompatibilita"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Dirigente
@@ -1912,6 +1917,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: YouTube Video {id}
 msgid "embedVideo"
+msgstr ""
+
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Emolumenti a carico della finanza pubblica
+msgid "emolumenti_a_carico_della_finanza_pubblica"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1686,6 +1686,11 @@ msgstr "Details of the type of procedure"
 msgid "dichiarazione_dei_redditi"
 msgstr "Tax declaration"
 
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Dichiarazioni di insussistenza e incompatibilità
+msgid "dichiarazioni_di_insussistenza_e_incompatibilita"
+msgstr "Statements of Incompatibility"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Dirigente
@@ -1898,6 +1903,11 @@ msgstr "E-mail"
 # defaultMessage: YouTube Video {id}
 msgid "embedVideo"
 msgstr ""
+
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Emolumenti a carico della finanza pubblica
+msgid "emolumenti_a_carico_della_finanza_pubblica"
+msgstr "Remuneration Charged to Public Finances"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
 # defaultMessage: Please select an item in the sidebar in order to show it here

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1695,6 +1695,11 @@ msgstr "Detalles del tipo de procedimiento"
 msgid "dichiarazione_dei_redditi"
 msgstr "Declaración de impuestos"
 
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Dichiarazioni di insussistenza e incompatibilità
+msgid "dichiarazioni_di_insussistenza_e_incompatibilita"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Dirigente
@@ -1906,6 +1911,11 @@ msgstr "Correo electrónico"
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: YouTube Video {id}
 msgid "embedVideo"
+msgstr ""
+
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Emolumenti a carico della finanza pubblica
+msgid "emolumenti_a_carico_della_finanza_pubblica"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1703,6 +1703,11 @@ msgstr "Détail type de procédure"
 msgid "dichiarazione_dei_redditi"
 msgstr "Déclaration d'impôts"
 
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Dichiarazioni di insussistenza e incompatibilità
+msgid "dichiarazioni_di_insussistenza_e_incompatibilita"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Dirigente
@@ -1914,6 +1919,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: YouTube Video {id}
 msgid "embedVideo"
+msgstr ""
+
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Emolumenti a carico della finanza pubblica
+msgid "emolumenti_a_carico_della_finanza_pubblica"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1686,6 +1686,11 @@ msgstr "Dettaglio tipologia procedimento"
 msgid "dichiarazione_dei_redditi"
 msgstr "Dichiarazione dei redditi"
 
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Dichiarazioni di insussistenza e incompatibilità
+msgid "dichiarazioni_di_insussistenza_e_incompatibilita"
+msgstr "Dichiarazioni di insussistenza e incompatibilità"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Dirigente
@@ -1898,6 +1903,11 @@ msgstr "E-mail"
 # defaultMessage: YouTube Video {id}
 msgid "embedVideo"
 msgstr "YouTube Video {id}"
+
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Emolumenti a carico della finanza pubblica
+msgid "emolumenti_a_carico_della_finanza_pubblica"
+msgstr "Emolumenti a carico della finanza pubblica"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
 # defaultMessage: Please select an item in the sidebar in order to show it here

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-08-06T16:50:24.401Z\n"
+"POT-Creation-Date: 2024-09-05T11:07:39.844Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1688,6 +1688,11 @@ msgstr ""
 msgid "dichiarazione_dei_redditi"
 msgstr ""
 
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Dichiarazioni di insussistenza e incompatibilità
+msgid "dichiarazioni_di_insussistenza_e_incompatibilita"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Dirigente
@@ -1899,6 +1904,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: YouTube Video {id}
 msgid "embedVideo"
+msgstr ""
+
+#: components/ItaliaTheme/View/PersonaView/PersonaDocumenti
+# defaultMessage: Emolumenti a carico della finanza pubblica
+msgid "emolumenti_a_carico_della_finanza_pubblica"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit

--- a/src/components/ItaliaTheme/View/PersonaView/PersonaDocumenti.jsx
+++ b/src/components/ItaliaTheme/View/PersonaView/PersonaDocumenti.jsx
@@ -53,6 +53,16 @@ const messages = defineMessages({
     id: 'altri_documenti_persona',
     defaultMessage: 'Altri documenti',
   },
+
+  dichiarazioni_di_insussistenza_e_incompatibilita: {
+    id: 'dichiarazioni_di_insussistenza_e_incompatibilita',
+    defaultMessage: 'Dichiarazioni di insussistenza e incompatibilita',
+  },
+
+  emolumenti_a_carico_della_finanza_pubblica: {
+    id: 'emolumenti_a_carico_della_finanza_pubblica',
+    defaultMessage: 'Emolumenti a carico della finanza pubblica',
+  },
 });
 
 const PersonaDocumenti = ({ content }) => {
@@ -203,6 +213,46 @@ const PersonaDocumenti = ({ content }) => {
             // title={intl.formatMessage(messages.altri_documenti_persona)}
             as_section={false}
           />
+        </RichTextSection>
+      )}
+      {content.dichiarazioni_di_insussistenza_e_incompatibilita?.download && (
+        <RichTextSection
+          tag_id="dichiarazioni_di_insussistenza_e_incompatibilita"
+          title={intl.formatMessage(
+            messages.dichiarazioni_di_insussistenza_e_incompatibilita,
+          )}
+        >
+          <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
+            <Attachment
+              download_url={
+                content.dichiarazioni_di_insussistenza_e_incompatibilita
+                  .download
+              }
+              title={
+                content.dichiarazioni_di_insussistenza_e_incompatibilita
+                  .filename
+              }
+            />
+          </div>
+        </RichTextSection>
+      )}
+      {content.emolumenti_a_carico_della_finanza_pubblica?.download && (
+        <RichTextSection
+          tag_id="emolumenti_a_carico_della_finanza_pubblica"
+          title={intl.formatMessage(
+            messages.emolumenti_a_carico_della_finanza_pubblica,
+          )}
+        >
+          <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
+            <Attachment
+              download_url={
+                content.emolumenti_a_carico_della_finanza_pubblica.download
+              }
+              title={
+                content.emolumenti_a_carico_della_finanza_pubblica.filename
+              }
+            />
+          </div>
         </RichTextSection>
       )}
     </>

--- a/src/components/ItaliaTheme/View/PersonaView/PersonaDocumenti.jsx
+++ b/src/components/ItaliaTheme/View/PersonaView/PersonaDocumenti.jsx
@@ -56,7 +56,7 @@ const messages = defineMessages({
 
   dichiarazioni_di_insussistenza_e_incompatibilita: {
     id: 'dichiarazioni_di_insussistenza_e_incompatibilita',
-    defaultMessage: 'Dichiarazioni di insussistenza e incompatibilita',
+    defaultMessage: 'Dichiarazioni di insussistenza e incompatibilità',
   },
 
   emolumenti_a_carico_della_finanza_pubblica: {


### PR DESCRIPTION
Added fields for Trasparenza in CT persona.
As requested, the new fields allow to attach files.
Mergeable after merging the design.plone.contenttype branch `us_57188_new_fields_for_persona`
