### PR TITLE
fix: removed id_lighthouse field in cardWithSlideUpTextTemplate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Rimosso il campo "ID lighthouse" dal blocco elenco con variazione Card con Testo Animato perchè entra in contrasto con asseveratore. Pianificato evento per ripristinarlo.
+
 ## Versione 11.22.0 (05/09/2024)
 
 ### Migliorie

--- a/src/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate.js
@@ -13,7 +13,12 @@ export const addCardWithSlideUpTextTemplateOptions = (
 ) => {
   let pos = position;
 
-  pos = addLighthouseField(schema, intl, pos);
+  // hidden to avoid use of lighthouse on this block
+  // which creates problems with asseverazione
+  // 1. clients instructed not to use this variation when data-element is needed
+  // 2. planned intervention to change structure of variation to allow use of
+  //    data element without wrapping entire card in link
+  // pos = addLighthouseField(schema, intl, pos);
 
   pos = addDefaultOptions(schema, formData, intl, pos);
 


### PR DESCRIPTION
Parlato con Nicola, per ora rimuoviamo questo campo da questa variazione per evitare che i clienti la usino in futuro. Lui si occuperà di farla cambiare ai clienti che attualmente ce l'hanno su.

Più avanti con un po' più di budget si farà il rework del blocco