### PR TITLE
fix: used p with h classname to ensure correct heading order

### DIFF
--- a/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody.jsx
+++ b/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody.jsx
@@ -26,9 +26,9 @@ const BottomBody = ({ data, intl, hasArguments }) => {
         <div
           className={data?.centerAlignment ? 'col-lg-12 mb-3' : 'col-lg-auto'}
         >
-          <h6 className="text-uppercase text-center mt-1">
+          <p className="h6 text-uppercase text-center mt-1">
             {intl?.formatMessage(messages.otherArguments)}
-          </h6>
+          </p>
         </div>
         <div className={data?.centerAlignment ? 'col-lg-12' : 'col-lg-auto'}>
           {data?.arguments?.map((argument, index) => (

--- a/src/components/ItaliaTheme/Footer/FooterInfos.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterInfos.jsx
@@ -70,7 +70,7 @@ const FooterInfos = () => {
             widths={['xs', 'sm', 'md', 'lg', 'xl']}
             key={index}
           >
-            <h4>
+            <p className="h4">
               {column?.title && (
                 <ConditionalLink
                   condition={column.titleLink?.length > 0}
@@ -83,7 +83,7 @@ const FooterInfos = () => {
                   {column.title}
                 </ConditionalLink>
               )}
-            </h4>
+            </p>
             {column.showSocial && <FooterSocials />}
             {column.slateText ? (
               <TextBlockView data={{ value: column.slateText }} />

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderEventDates.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderEventDates.jsx
@@ -63,7 +63,7 @@ const PageHeaderEventDates = ({ content, moment, rrule }) => {
     }
   }
   return content['@type'] === 'Event' ? (
-    <h4 className="py-2">
+    <p className="h4 py-2">
       {!wholeDay &&
         !openEnd &&
         !renderOnlyStart &&
@@ -80,7 +80,7 @@ const PageHeaderEventDates = ({ content, moment, rrule }) => {
       {eventRecurrenceText && (
         <div className="recurrence small">{eventRecurrenceText}</div>
       )}
-    </h4>
+    </p>
   ) : null;
 };
 

--- a/src/components/ItaliaTheme/View/Commons/RelatedItems.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItems.jsx
@@ -82,9 +82,9 @@ const RelatedItems = ({
                   <>
                     <Row>
                       <Col className="text-center">
-                        <p className="h3">
-                          {intl.formatMessage(messages.related_items)}
-                        </p>
+                        <h2 className="h3">
+                          {intl.formatMessage(messages.related_items)} ???
+                        </h2>
                       </Col>
                     </Row>
                     <Row className="mt-lg-4">
@@ -133,7 +133,9 @@ const RelatedItems = ({
               <>
                 <Row>
                   <Col className="text-center">
-                    <h3>{intl.formatMessage(messages.related_items)}</h3>
+                    <h2 className="h3">
+                      {intl.formatMessage(messages.related_items)}
+                    </h2>
                   </Col>
                 </Row>
                 <Row className="mt-lg-4">

--- a/src/components/ItaliaTheme/View/Commons/RelatedItems.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItems.jsx
@@ -82,7 +82,9 @@ const RelatedItems = ({
                   <>
                     <Row>
                       <Col className="text-center">
-                        <h3>{intl.formatMessage(messages.related_items)}</h3>
+                        <p className="h3">
+                          {intl.formatMessage(messages.related_items)}
+                        </p>
                       </Col>
                     </Row>
                     <Row className="mt-lg-4">

--- a/src/components/ItaliaTheme/View/Commons/SideMenu.jsx
+++ b/src/components/ItaliaTheme/View/Commons/SideMenu.jsx
@@ -163,7 +163,7 @@ const SideMenu = ({ data, content_uid }) => {
                   }}
                   aria-controls="side-menu-body"
                 >
-                  <p className="h3">{intl.formatMessage(messages.index)}</p>
+                  <h2 className="h3">{intl.formatMessage(messages.index)}</h2>
                 </AccordionHeader>
                 <div className="mb-3">
                   <Progress

--- a/src/components/ItaliaTheme/View/Commons/SideMenu.jsx
+++ b/src/components/ItaliaTheme/View/Commons/SideMenu.jsx
@@ -163,7 +163,7 @@ const SideMenu = ({ data, content_uid }) => {
                   }}
                   aria-controls="side-menu-body"
                 >
-                  <h3>{intl.formatMessage(messages.index)}</h3>
+                  <p className="h3">{intl.formatMessage(messages.index)}</p>
                 </AccordionHeader>
                 <div className="mb-3">
                   <Progress

--- a/src/components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView.jsx
+++ b/src/components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView.jsx
@@ -105,7 +105,7 @@ const PuntoDiContattoView = (props) => {
             {content?.value_punto_contatto?.map((pdc, i) => {
               return (
                 <div className="my-2" key={i}>
-                  <h5 className="h6">
+                  <p className="h6">
                     {messages[pdc?.pdc_type] === undefined
                       ? pdc?.pdc_type
                       : intl.formatMessage(messages[pdc.pdc_type])}
@@ -113,7 +113,7 @@ const PuntoDiContattoView = (props) => {
                     <span className="ms-1">
                       {renderPDCItemValue(pdc, intl)}
                     </span>
-                  </h5>
+                  </p>
                 </div>
               );
             })}

--- a/src/components/ItaliaTheme/View/VenueView/VenueWhere.jsx
+++ b/src/components/ItaliaTheme/View/VenueView/VenueWhere.jsx
@@ -39,7 +39,7 @@ const VenueWhere = ({ content }) => {
       <Card className="card card-teaser border-left-card preview-image-card card-big-io-comune shadow mt-3 rounded mb-4">
         <CardBody>
           <CardTitle>
-            <p className="h5 card-title">{content.title}</p>
+            <h3 className="h5 card-title">{content.title}</h3>
           </CardTitle>
           <CardText>
             <p>

--- a/src/components/ItaliaTheme/View/VenueView/VenueWhere.jsx
+++ b/src/components/ItaliaTheme/View/VenueView/VenueWhere.jsx
@@ -39,7 +39,7 @@ const VenueWhere = ({ content }) => {
       <Card className="card card-teaser border-left-card preview-image-card card-big-io-comune shadow mt-3 rounded mb-4">
         <CardBody>
           <CardTitle>
-            <h5 className="card-title">{content.title}</h5>
+            <p className="h5 card-title">{content.title}</p>
           </CardTitle>
           <CardText>
             <p>


### PR DESCRIPTION
Mauve segnala problemi principalmente su CT con layout “fisso” (a differenza dei blocchi che sono interscambiabili e difficili da gestire a livello di disposizione).

Per risolvere, controllare i casi segnalati da Mauve, e utilizzare tag <p> con classe dell’heading di cui si vuole utilizzare lo stile per assicurare un ordine giusto sull’utilizzo dei vari tag <h>

Es. Elemento che indica la ricorrenza in CT evento è un <h4>, posto subito dopo un <h1>. L’ordine dei tag <h> in questo caso non è corretto. Utilizzare un <p class=”h4”> garantisce la correttezza a livello di html, ma con stili conformi a quelli descritti da agid.