### PR TITLE
fix: added block id to date ids to ensure unique field ids

### DIFF
--- a/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
@@ -167,6 +167,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
                 <>
                   {React.createElement(filterOne.widget.component, {
                     ...filterOne.widget?.props,
+                    blockID: id,
                     id: 'filterOne',
                     onChange: (filter, value) => {
                       dispatchFilter({
@@ -180,6 +181,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
               {filterTwo &&
                 React.createElement(filterTwo.widget?.component, {
                   ...filterTwo.widget?.props,
+                  blockID: id,
                   id: 'filterTwo',
                   onChange: (filter, value) =>
                     dispatchFilter({
@@ -190,6 +192,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
               {filterThree &&
                 React.createElement(filterThree.widget?.component, {
                   ...filterThree.widget?.props,
+                  blockID: id,
                   id: 'filterThree',
                   onChange: (filter, value) =>
                     dispatchFilter({

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
@@ -188,6 +188,7 @@ const DateFilter = (props) => {
     endLabel,
     defaultStart,
     defaultEnd,
+    blockID,
     ...rest
   } = props;
   const { DateRangePicker } = reactDates;
@@ -230,12 +231,12 @@ const DateFilter = (props) => {
       <DateRangePicker
         {...rest}
         startDate={value?.startDate || defaultStart}
-        startDateId="start-date-filter"
+        startDateId={`start-date-filter-${blockID}`}
         startDatePlaceholderText={
           startLabel ?? intl.formatMessage(messages.eventSearchStartDate)
         }
         endDate={value?.endDate || defaultEnd}
-        endDateId="end-date-filter"
+        endDateId={`end-date-filter-${blockID}`}
         endDatePlaceholderText={
           endLabel ?? intl.formatMessage(messages.eventSearchEndDate)
         }

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -177,6 +177,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
                 <>
                   {React.createElement(filterOne.widget.component, {
                     ...filterOne.widget?.props,
+                    blockID: id,
                     id: 'filterOne',
                     onChange: (filter, value) => {
                       dispatchFilter({
@@ -190,6 +191,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
               {filterTwo &&
                 React.createElement(filterTwo.widget?.component, {
                   ...filterTwo.widget?.props,
+                  blockID: id,
                   id: 'filterTwo',
                   onChange: (filter, value) =>
                     dispatchFilter({
@@ -200,6 +202,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
               {filterThree &&
                 React.createElement(filterThree.widget?.component, {
                   ...filterThree.widget?.props,
+                  blockID: id,
                   id: 'filterThree',
                   onChange: (filter, value) =>
                     dispatchFilter({


### PR DESCRIPTION
- Stesso filtro per blocchi cerca diversi + Input filter data per blocchi cerca 

- Screen reader message per filtri blocchi ricerca

utilizzando uuid o l’id del blocco (univoci) dentro l’attributo startDateId="start-date-filter" e endDateId="end-date-filter" si può risolvere la questione dell’id duplicato. 