### PR TITLE
fix: changed focus color

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 ### Migliorie
 
 - Migliorato il layout della galleria immagini nei CT.
+- Il colore del focus da tastiera sugli elementi della pagina è ora bianco e nero per garantire sempre un contrasto ottimale su tutti gli sfondi.
 
 ### Novità
 

--- a/src/theme/ItaliaTheme/Addons/volto-gdpr-privacy.scss
+++ b/src/theme/ItaliaTheme/Addons/volto-gdpr-privacy.scss
@@ -49,11 +49,6 @@
           outline: none;
           vertical-align: baseline;
 
-          input:focus ~ label::before {
-            box-shadow: $gdpr-focus-shadow !important;
-            outline: none !important;
-          }
-
           label {
             position: relative;
             display: block;
@@ -238,19 +233,6 @@ body.has-toolbar-collapsed {
       }
     }
   }
-}
-
-.gdpr-privacy-banner
-  .gdpr-privacy-content-wrapper
-  .gdpr-privacy-content
-  .buttons
-  button.gdpr-privacy-banner-button:focus,
-.gdpr-privacy-banner
-  .gdpr-privacy-content-wrapper
-  .gdpr-privacy-content
-  a:focus {
-  box-shadow: $gdpr-focus-shadow;
-  outline: none !important;
 }
 
 .gdpr-privacy-banner

--- a/src/theme/ItaliaTheme/Blocks/common/_searchBlockFilters.scss
+++ b/src/theme/ItaliaTheme/Blocks/common/_searchBlockFilters.scss
@@ -15,7 +15,8 @@
         min-width: 150px;
 
         &:focus-within {
-          box-shadow: 0 0 0 2px $focus-outline-color;
+          border: 2px solid $inner-focus-border !important;
+          box-shadow: 0 0 0 2px $outer-focus-outline !important;
         }
 
         .react-select__control {
@@ -57,7 +58,8 @@
             }
 
             &.DateInput_input__focused {
-              box-shadow: 0 0 0 2px $focus-outline-color;
+              border: 2px solid $inner-focus-border !important;
+              box-shadow: 0 0 0 2px $outer-focus-outline !important;
             }
           }
 

--- a/src/theme/ItaliaTheme/Widgets/_reactSelect.scss
+++ b/src/theme/ItaliaTheme/Widgets/_reactSelect.scss
@@ -20,6 +20,7 @@
 .react-select__control,
 .react-select__control:hover {
   &.react-select__control--is-focused {
-    box-shadow: 0 0 0 2px $focus-outline-color !important;
+    border: 2px solid $inner-focus-border !important;
+    box-shadow: 0 0 0 2px $outer-focus-outline !important;
   }
 }

--- a/src/theme/ItaliaTheme/_common.scss
+++ b/src/theme/ItaliaTheme/_common.scss
@@ -7,11 +7,8 @@
   button.btn,
   button.rounded-right {
     &:focus {
-      border-color: $focus-outline-color !important;
-      box-shadow:
-        inset 0 1px 0 $focus-outline-color,
-        0 1px 1px $focus-outline-color,
-        0 0 0 0.2rem $focus-outline-color !important;
+      border: 2px solid $inner-focus-border !important;
+      box-shadow: 0 0 0 2px $outer-focus-outline !important;
       outline: none;
     }
   }

--- a/src/theme/_site-variables.scss
+++ b/src/theme/_site-variables.scss
@@ -30,12 +30,7 @@ $gdpr-accept-all: #005700 !default;
 $gdpr-toggle-checked: #005700 !default;
 $gdpr-toggle: #b22515 !default;
 $gdpr-toggle-border: #000 !default;
-$gdpr-focus-color: #ff9800 !default;
 $gdpr-link-color: #004285 !default;
-$gdpr-focus-shadow:
-  inset 0 1px 0 rgba(255, 255, 255, 0.15),
-  0 1px 1px rgba(0, 0, 0, 0.075),
-  0 0 0 0.2rem $gdpr-focus-color !default;
 
 $caption-text: #455b71 !default;
 
@@ -65,5 +60,5 @@ $ribbon-spacing-h: calc($spacer * 3);
 $ribbon-width: calc($spacer * 2);
 
 // accessible focus colors
-$outer-focus-outline: #fff !default;
-$inner-focus-border: #000 !default;
+$outer-focus-outline: #000 !default;
+$inner-focus-border: #fff !default;

--- a/src/theme/_site-variables.scss
+++ b/src/theme/_site-variables.scss
@@ -63,3 +63,7 @@ $dvt-navigation-v-padding: 15px !default;
 $spacer: 16px;
 $ribbon-spacing-h: calc($spacer * 3);
 $ribbon-width: calc($spacer * 2);
+
+// accessible focus colors
+$outer-focus-outline: #fff !default;
+$inner-focus-border: #000 !default;

--- a/src/theme/bootstrap-override/bootstrap-italia/_focus.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_focus.scss
@@ -1,3 +1,9 @@
+:focus:not(.focus--mouse),
+%focus {
+  box-shadow: 0 0 0 2px $outer-focus-outline !important;
+  border: 2px solid $inner-focus-border !important;
+}
+
 .skiplinks a:focus:not(.focus--mouse) {
   border: 2px solid;
 }

--- a/src/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
@@ -20,10 +20,11 @@
 
       .it-search-wrapper {
         a.search-link {
-          outline: $header-center-bg-color 2px solid !important;
+          border: $header-center-bg-color 2px solid !important;
 
           &:focus {
-            box-shadow: 0 0 0 5px $focus-outline-color !important;
+            outline: 2.5px solid $inner-focus-border !important;
+            box-shadow: 0 0 0 5px $outer-focus-outline !important;
           }
         }
       }


### PR DESCRIPTION
Il focus arancione scuro scelto non è sempre visibile su tutti i colori.

Questo problema era già noto dalle prime analisi. Siamo in attesa di un riscontro e di una decisione da parte di Bootstrap Italia per l’aggiornamento del kit.

Si era parlato di una proposta di focus nero e bianco in modo che il contrasto fosse assicurato su ogni tema, ma non ci sono state decisioni lato design kit e questa decisione è rimasta in sospeso.
Success case: Comune di Siracusa.

Scelta di prodotto: doppio colore