### PR TITLE
fix: added max-width attribute to row to fit elements within page when zoomed in

### DIFF
--- a/src/theme/ItaliaTheme/Blocks/_form.scss
+++ b/src/theme/ItaliaTheme/Blocks/_form.scss
@@ -1,45 +1,50 @@
 .public-ui {
   .block.form {
-    @media (max-width: #{map-get($grid-breakpoints, md)}) {
-      .form-group {
-        display: flex;
-        flex-direction: column;
+    .row {
+      max-width: 100%;
 
-        label {
-          position: relative;
-          order: 1;
-          font-size: 0.777rem;
-          line-height: 1.375rem;
-          transform: none;
-          transform: none;
-          white-space: normal;
+      @media (max-width: #{map-get($grid-breakpoints, md)}) {
+        .form-group {
+          display: flex;
+          flex-direction: column;
+          max-width: 100%;
 
-          &.active {
+          label {
+            position: relative;
+            order: 1;
+            font-size: 0.777rem;
+            line-height: 1.375rem;
+            transform: none;
+            transform: none;
+            white-space: normal;
+
+            &.active {
+              font-size: 0.777rem;
+              transform: none;
+            }
+          }
+
+          input,
+          textarea,
+          .form-input-file {
+            order: 2;
+          }
+
+          input[type='date'] ~ label {
             font-size: 0.777rem;
             transform: none;
           }
+
+          small.form-text {
+            position: relative;
+            order: 3;
+          }
         }
 
-        input,
-        textarea,
         .form-input-file {
-          order: 2;
-        }
-
-        input[type='date'] ~ label {
-          font-size: 0.777rem;
-          transform: none;
-        }
-
-        small.form-text {
-          position: relative;
-          order: 3;
-        }
-      }
-
-      .form-input-file {
-        .dropzone-placeholder {
-          margin-top: 0;
+          .dropzone-placeholder {
+            margin-top: 0;
+          }
         }
       }
     }
@@ -65,6 +70,7 @@
   &,
   .volto-subblocks-wrapper,
   .form-field {
+    max-width: 100%;
     .single-block {
       .dragsubblock {
         top: 0.3rem;


### PR DESCRIPTION
https://www.w3.org/WAI/WCAG21/Techniques/css/C38

questa WCAG controlla che gli stili segnalati (flexbox, max-width, width) vengano usati per fittare gli elementi sullo schermo quando lo zoom arriva anche a 400%.

Aggiunto max-width alla row dei form e ai form-field per far sì che tutti i campi fittino nello schermo senza dover fare scroll orizzontale con alti livelli di zoom
 
 