### PR TITLE
fix: added filter for eventi rassegne in Event Search

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 ### Migliorie
 
 - Migliorato il layout della galleria immagini nei CT.
+- Nel blocco Cerca Evento, nel caso di un Evento Rassegna, tra i risultati vengono ora visualizzati solo gli appuntamenti della rassegna e non l'evento contenitore.
 
 ### Novità
 

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -75,6 +75,11 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
         o: 'plone.app.querystring.operation.selection.any',
         v: ['Event'],
       },
+      {
+        i: 'rassegna',
+        o: 'plone.app.querystring.operation.boolean.isFalse',
+        v: '',
+      },
     ];
 
     [filterOne, filterTwo, filterThree].forEach((f) => {


### PR DESCRIPTION
Since parent events in "Rassegne" are just containers for the "appuntamenti", the Event Search block by default only shows the children events when returning results.