### PR TITLE
fix: added condition for spid user link redirect

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Gli utenti SPID vengono ora direttamente rediretti al link finale quando viene utilizzato un CT di tipo Collegamento
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
 ## Versione 11.23.1 (19/09/2024)
 
 ### Migliorie

--- a/src/customizations/volto/components/theme/View/LinkView.jsx
+++ b/src/customizations/volto/components/theme/View/LinkView.jsx
@@ -1,3 +1,6 @@
+// CUSTOMIZATION:
+// - Added condition to check if user is SPID user (16-18 and 21)
+
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/src/customizations/volto/components/theme/View/LinkView.jsx
+++ b/src/customizations/volto/components/theme/View/LinkView.jsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
+import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
+import { Container as SemanticContainer } from 'semantic-ui-react';
+import { UniversalLink } from '@plone/volto/components';
+import { FormattedMessage } from 'react-intl';
+import config from '@plone/volto/registry';
+
+const LinkView = ({ token, content }) => {
+  const history = useHistory();
+  const userIsSpidUser = useSelector(
+    (state) => state.users.user.roles.length === 0,
+  );
+
+  useEffect(() => {
+    if (!token || userIsSpidUser) {
+      const { remoteUrl } = content;
+      if (isInternalURL(remoteUrl)) {
+        history.replace(flattenToAppURL(remoteUrl));
+      } else if (!__SERVER__) {
+        window.location.href = flattenToAppURL(remoteUrl);
+      }
+    }
+  }, [content, history, token, userIsSpidUser]);
+  const { title, description, remoteUrl } = content;
+  const { openExternalLinkInNewTab } = config.settings;
+  const Container =
+    config.getComponent({ name: 'Container' }).component || SemanticContainer;
+
+  return (
+    <Container id="page-document">
+      <h1 className="documentFirstHeading">{title}</h1>
+      {content.description && (
+        <p className="documentDescription">{description}</p>
+      )}
+      {remoteUrl && (
+        <p>
+          <FormattedMessage
+            id="The link address is:"
+            defaultMessage="The link address is:"
+          />{' '}
+          <UniversalLink
+            href={remoteUrl}
+            openLinkInNewTab={
+              openExternalLinkInNewTab && !isInternalURL(remoteUrl)
+            }
+          >
+            {flattenToAppURL(remoteUrl)}
+          </UniversalLink>
+        </p>
+      )}
+    </Container>
+  );
+};
+
+LinkView.propTypes = {
+  content: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    remoteUrl: PropTypes.string,
+  }),
+  token: PropTypes.string,
+};
+
+LinkView.defaultProps = {
+  content: null,
+  token: null,
+};
+
+export default LinkView;


### PR DESCRIPTION
Whenever a spid user logs in, it will be part of the AuthenticatedUsers group but no roles will be assigned.
There are no other info on whether a user is logged in through spid or if it's an operator of some sort.
Added the customization to the LinkView Plone/Volto component at lines indicated at top of file

https://redturtle.tpondemand.com/restui/board.aspx?#page=userstory/58460