### PR TITLE
feat: porting of volto-form-block autocomplete changes

### DIFF
--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -17,6 +17,8 @@ export default function TextInput(props) {
     groupClassName,
     ...otherProps
   } = props;
+
+  console.log(props);
   const [isFocused, setIsFocused] = useState(false);
 
   const toggleFocusLabel = () => {

--- a/src/customizations/volto-form-block/components/Field.jsx
+++ b/src/customizations/volto-form-block/components/Field.jsx
@@ -16,6 +16,7 @@ import FileWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import { TextBlockView } from '@plone/volto-slate/blocks/Text';
 import { TextEditorWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { TextInput } from 'design-comuni-plone-theme/components';
 import config from '@plone/volto/registry';
 
 import { fromHtml } from 'design-comuni-plone-theme/config/Slate/utils';
@@ -70,7 +71,9 @@ const Field = ({
   errorMessage,
   id,
   reactSelect,
+  autocomplete,
 }) => {
+  console.log(autocomplete);
   const intl = useIntl();
   const Select = reactSelect.default;
 
@@ -117,6 +120,7 @@ const Field = ({
             onChange(name, e.target.value);
           }}
           value={value ?? ''}
+          autoComplete={autocomplete}
         />
       )}
       {field_type === 'textarea' && (
@@ -135,6 +139,7 @@ const Field = ({
             onChange(name, e.target.value);
           }}
           value={value ?? undefined}
+          autoComplete={autocomplete}
         />
       )}
       {field_type === 'select' && (
@@ -166,6 +171,7 @@ const Field = ({
               classNamePrefix="react-select"
               className={isInvalid() ? 'is-invalid' : ''}
               value={value ? [{ value: value, label: value }] : []}
+              autoComplete={autocomplete}
             />
             {description && <small className="form-text">{description}</small>}
             {errorMessage && (
@@ -301,6 +307,7 @@ const Field = ({
             onChange(name, e.target.value);
           }}
           value={value ?? ''}
+          autoComplete={autocomplete}
         />
       )}
       {field_type === 'attachment' && (
@@ -335,6 +342,7 @@ const Field = ({
             onChange(name, e.target.value);
           }}
           value={value ?? ''}
+          autoComplete={autocomplete}
         />
       )}
 
@@ -405,6 +413,7 @@ Field.propTypes = {
   value: PropTypes.any,
   formHasErrors: PropTypes.bool,
   onChange: PropTypes.func,
+  autoComplete: PropTypes.string,
 };
 
 export default injectLazyLibs('reactSelect')(Field);

--- a/src/customizations/volto-form-block/fieldSchema.js
+++ b/src/customizations/volto-form-block/fieldSchema.js
@@ -79,6 +79,199 @@ const messages = defineMessages({
     defaultMessage:
       'Check this box if the value entered in this field can be used only once.',
   },
+  field_autocomplete: {
+    id: 'field_autocomplete',
+    defaultMessage: '"Autocomplete" attribute',
+  },
+  field_autocomplete_description: {
+    id: 'field_autocomplete_description',
+    defaultMessage:
+      'This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>',
+  },
+  field_autocomplete_name_complete: {
+    id: 'field_autocomplete_name_complete',
+    defaultMessage: 'Full name',
+  },
+  field_autocomplete_honorific_prefix: {
+    id: 'field_autocomplete_honorific_prefix',
+    defaultMessage: 'Prefix (ex. mr, mrs)',
+  },
+  field_autocomplete_given_name: {
+    id: 'field_autocomplete_given_name',
+    defaultMessage: 'Given name',
+  },
+  field_autocomplete_additional_name: {
+    id: 'field_autocomplete_additional_name',
+    defaultMessage: 'Additional name',
+  },
+  field_autocomplete_family_name: {
+    id: 'field_autocomplete_family_name',
+    defaultMessage: 'Family name',
+  },
+  field_autocomplete_honorific_suffix: {
+    id: 'field_autocomplete_honorific_suffix',
+    defaultMessage: 'Suffix (ex. jr, sr)',
+  },
+  field_autocomplete_nickname: {
+    id: 'field_autocomplete_nickname',
+    defaultMessage: 'Nickname',
+  },
+  field_autocomplete_email: {
+    id: 'field_autocomplete_email',
+    defaultMessage: 'Email',
+  },
+  field_autocomplete_username: {
+    id: 'field_autocomplete_username',
+    defaultMessage: 'Username',
+  },
+  field_autocomplete_new_password: {
+    id: 'field_autocomplete_new_password',
+    defaultMessage: 'New password',
+  },
+  field_autocomplete_current_password: {
+    id: 'field_autocomplete_current_password',
+    defaultMessage: 'Current password',
+  },
+  field_autocomplete_organization_title: {
+    id: 'field_autocomplete_organization_title',
+    defaultMessage: 'Organization title',
+  },
+  field_autocomplete_organization: {
+    id: 'field_autocomplete_organization',
+    defaultMessage: 'Organization',
+  },
+  field_autocomplete_street_address: {
+    id: 'field_autocomplete_street_address',
+    defaultMessage: 'Street address',
+  },
+  field_autocomplete_address_line1: {
+    id: 'field_autocomplete_address_line1',
+    defaultMessage: 'Address line 1',
+  },
+  field_autocomplete_address_line2: {
+    id: 'field_autocomplete_address_line2',
+    defaultMessage: 'Address line 2',
+  },
+  field_autocomplete_address_line3: {
+    id: 'field_autocomplete_address_line3',
+    defaultMessage: 'Address line 3',
+  },
+  field_autocomplete_country: {
+    id: 'field_autocomplete_country',
+    defaultMessage: 'Country',
+  },
+  field_autocomplete_country_name: {
+    id: 'field_autocomplete_country_name',
+    defaultMessage: 'Country name',
+  },
+  field_autocomplete_postal_code: {
+    id: 'field_autocomplete_postal_code',
+    defaultMessage: 'Postal code',
+  },
+  field_autocomplete_cc_name: {
+    id: 'field_autocomplete_cc_name',
+    defaultMessage: 'Cardholder name',
+  },
+  field_autocomplete_cc_given_name: {
+    id: 'field_autocomplete_cc_given_name',
+    defaultMessage: 'Cardholder given name',
+  },
+  field_autocomplete_cc_additional_name: {
+    id: 'field_autocomplete_cc_additional_name',
+    defaultMessage: 'Cardholder additional name',
+  },
+  field_autocomplete_cc_family_name: {
+    id: 'field_autocomplete_cc_family_name',
+    defaultMessage: 'Cardholder family name',
+  },
+  field_autocomplete_cc_number: {
+    id: 'field_autocomplete_cc_number',
+    defaultMessage: 'Credit card number',
+  },
+  field_autocomplete_cc_exp: {
+    id: 'field_autocomplete_cc_exp',
+    defaultMessage: 'Credit card expiration date',
+  },
+  field_autocomplete_cc_exp_month: {
+    id: 'field_autocomplete_cc_exp_month',
+    defaultMessage: 'Credit card expiration month',
+  },
+  field_autocomplete_cc_exp_year: {
+    id: 'field_autocomplete_cc_exp_year',
+    defaultMessage: 'Credit card expiration year',
+  },
+  field_autocomplete_cc_csc: {
+    id: 'field_autocomplete_cc_csc',
+    defaultMessage: 'Credit card security code',
+  },
+  field_autocomplete_cc_type: {
+    id: 'field_autocomplete_cc_type',
+    defaultMessage: 'Credit card type',
+  },
+  field_autocomplete_transaction_currency: {
+    id: 'field_autocomplete_transaction_currency',
+    defaultMessage: 'Transaction currency',
+  },
+  field_autocomplete_transaction_amount: {
+    id: 'field_autocomplete_transaction_amount',
+    defaultMessage: 'Transaction amount',
+  },
+  field_autocomplete_language: {
+    id: 'field_autocomplete_language',
+    defaultMessage: 'Language',
+  },
+  field_autocomplete_bday: {
+    id: 'field_autocomplete_bday',
+    defaultMessage: 'Birthday',
+  },
+  field_autocomplete_bday_day: {
+    id: 'field_autocomplete_bday_day',
+    defaultMessage: 'Birth day',
+  },
+  field_autocomplete_bday_month: {
+    id: 'field_autocomplete_bday_month',
+    defaultMessage: 'Birth month',
+  },
+  field_autocomplete_bday_year: {
+    id: 'field_autocomplete_bday_year',
+    defaultMessage: 'Birth year',
+  },
+  field_autocomplete_sex: {
+    id: 'field_autocomplete_sex',
+    defaultMessage: 'Gender',
+  },
+  field_autocomplete_tel: {
+    id: 'field_autocomplete_tel',
+    defaultMessage: 'Telephone number',
+  },
+  field_autocomplete_tel_country_code: {
+    id: 'field_autocomplete_tel_country_code',
+    defaultMessage: 'Telephone country code',
+  },
+  field_autocomplete_tel_national: {
+    id: 'field_autocomplete_tel_national',
+    defaultMessage: 'National telephone number',
+  },
+  field_autocomplete_tel_area_code: {
+    id: 'field_autocomplete_tel_area_code',
+    defaultMessage: 'Telephone area code',
+  },
+  field_autocomplete_tel_local: {
+    id: 'field_autocomplete_tel_local',
+    defaultMessage: 'Local telephone number',
+  },
+  field_autocomplete_tel_extension: {
+    id: 'field_autocomplete_tel_extension',
+    defaultMessage: 'Telephone extension',
+  },
+  field_autocomplete_url: {
+    id: 'field_autocomplete_url',
+    defaultMessage: 'Website URL',
+  },
+  field_autocomplete_photo: {
+    id: 'field_autocomplete_photo',
+    defaultMessage: 'Photo',
+  },
 });
 
 export default (props) => {
@@ -99,6 +292,132 @@ export default (props) => {
     ['static_text', intl.formatMessage(messages.field_type_static_text)],
     ['hidden', intl.formatMessage(messages.field_type_hidden)],
   ];
+
+  const autocompleteValues = [
+    ['name', intl.formatMessage(messages.field_autocomplete_name_complete)],
+    [
+      'honorific-prefix',
+      intl.formatMessage(messages.field_autocomplete_honorific_prefix),
+    ],
+    ['given-name', intl.formatMessage(messages.field_autocomplete_given_name)],
+    [
+      'additional-name',
+      intl.formatMessage(messages.field_autocomplete_additional_name),
+    ],
+    [
+      'family-name',
+      intl.formatMessage(messages.field_autocomplete_family_name),
+    ],
+    [
+      'honorific-suffix',
+      intl.formatMessage(messages.field_autocomplete_honorific_suffix),
+    ],
+    ['nickname', intl.formatMessage(messages.field_autocomplete_nickname)],
+    ['email', intl.formatMessage(messages.field_autocomplete_email)],
+    ['username', intl.formatMessage(messages.field_autocomplete_username)],
+    [
+      'new-password',
+      intl.formatMessage(messages.field_autocomplete_new_password),
+    ],
+    [
+      'current-password',
+      intl.formatMessage(messages.field_autocomplete_current_password),
+    ],
+    [
+      'organization-title',
+      intl.formatMessage(messages.field_autocomplete_organization_title),
+    ],
+
+    [
+      'organization',
+      intl.formatMessage(messages.field_autocomplete_organization),
+    ],
+    [
+      'street-address',
+      intl.formatMessage(messages.field_autocomplete_street_address),
+    ],
+    [
+      'address-line1',
+      intl.formatMessage(messages.field_autocomplete_address_line1),
+    ],
+    [
+      'address-line2',
+      intl.formatMessage(messages.field_autocomplete_address_line2),
+    ],
+    [
+      'address-line3',
+      intl.formatMessage(messages.field_autocomplete_address_line3),
+    ],
+    ['country', intl.formatMessage(messages.field_autocomplete_country)],
+    [
+      'country-name',
+      intl.formatMessage(messages.field_autocomplete_country_name),
+    ],
+    [
+      'postal-code',
+      intl.formatMessage(messages.field_autocomplete_postal_code),
+    ],
+    ['cc-name', intl.formatMessage(messages.field_autocomplete_cc_name)],
+    [
+      'cc-given-name',
+      intl.formatMessage(messages.field_autocomplete_cc_given_name),
+    ],
+    [
+      'cc-additional-name',
+      intl.formatMessage(messages.field_autocomplete_cc_additional_name),
+    ],
+    [
+      'cc-family-name',
+      intl.formatMessage(messages.field_autocomplete_cc_family_name),
+    ],
+    ['cc-number', intl.formatMessage(messages.field_autocomplete_cc_number)],
+    ['cc-exp', intl.formatMessage(messages.field_autocomplete_cc_exp)],
+    [
+      'cc-exp-month',
+      intl.formatMessage(messages.field_autocomplete_cc_exp_month),
+    ],
+    [
+      'cc-exp-year',
+      intl.formatMessage(messages.field_autocomplete_cc_exp_year),
+    ],
+    ['cc-csc', intl.formatMessage(messages.field_autocomplete_cc_csc)],
+    ['cc-type', intl.formatMessage(messages.field_autocomplete_cc_type)],
+    [
+      'transaction-currency',
+      intl.formatMessage(messages.field_autocomplete_transaction_currency),
+    ],
+    [
+      'transaction-amount',
+      intl.formatMessage(messages.field_autocomplete_transaction_amount),
+    ],
+    ['language', intl.formatMessage(messages.field_autocomplete_language)],
+    ['bday', intl.formatMessage(messages.field_autocomplete_bday)],
+    ['bday-day', intl.formatMessage(messages.field_autocomplete_bday_day)],
+    ['bday-month', intl.formatMessage(messages.field_autocomplete_bday_month)],
+    ['bday-year', intl.formatMessage(messages.field_autocomplete_bday_year)],
+    ['sex', intl.formatMessage(messages.field_autocomplete_sex)],
+    ['tel', intl.formatMessage(messages.field_autocomplete_tel)],
+    [
+      'tel-country-code',
+      intl.formatMessage(messages.field_autocomplete_tel_country_code),
+    ],
+    [
+      'tel-national',
+      intl.formatMessage(messages.field_autocomplete_tel_national),
+    ],
+    [
+      'tel-area-code',
+      intl.formatMessage(messages.field_autocomplete_tel_area_code),
+    ],
+    ['tel-local', intl.formatMessage(messages.field_autocomplete_tel_local)],
+    [
+      'tel-extension',
+      intl.formatMessage(messages.field_autocomplete_tel_extension),
+    ],
+    ['url', intl.formatMessage(messages.field_autocomplete_url)],
+    ['photo', intl.formatMessage(messages.field_autocomplete_photo)],
+  ];
+
   var attachmentDescription =
     props?.field_type === 'attachment'
       ? {
@@ -125,6 +444,13 @@ export default (props) => {
           'description',
           'field_type',
           ...schemaExtenderValues.fields,
+          ...(props?.field_type !== 'checkbox' &&
+          props?.field_type !== 'attachment' &&
+          props?.field_type !== 'single_choice' &&
+          props?.field_type !== 'multiple_choice' &&
+          props?.field_type !== 'static_text'
+            ? ['autocomplete']
+            : []),
           ...(props?.field_type === 'static_text' ? [] : ['required']),
           'unique',
         ],
@@ -149,6 +475,25 @@ export default (props) => {
           ) ?? []),
         ],
         ...attachmentDescription,
+      },
+      autocomplete: {
+        title: intl.formatMessage(messages.field_autocomplete),
+        type: 'string',
+        description: intl.formatMessage(
+          messages.field_autocomplete_description,
+          {
+            a: (...chunks) => (
+              <a
+                href="https://www.w3.org/TR/WCAG21/#input-purposes"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {chunks}
+              </a>
+            ),
+          },
+        ),
+        choices: autocompleteValues,
       },
       required: {
         title: intl.formatMessage(messages.field_required),


### PR DESCRIPTION
To be merged after https://github.com/collective/volto-form-block/pull/118 is merged and released on io-Comune.

Porting of changes to use autocomplete field on form fields.

Accessibility tools point out as errors the fact that form fields do not have an autocomplete attribute.
This PR aims to allow editors to set autocomplete values according to the form field role.

Since semantic-ui does not support autocomplete as a prop, I added the react-aria-components library as a dependency from this addon. However, since this library is going to be applied to volto as a whole, someday probably it won't be necessary to have it installed in this addon.
I used this library as it is the one that will be implemented, but of course I'm open to discuss and making changes in case it is not the best option.