### PR TITLE
feat: changed clone blocks structure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,4 +63,7 @@ module.exports = {
       },
     },
   },
+  globals: {
+    structuredClone: true,
+  },
 };

--- a/src/customizations/volto/components/manage/Form/BlocksToolbar.jsx
+++ b/src/customizations/volto/components/manage/Form/BlocksToolbar.jsx
@@ -17,7 +17,7 @@ import { Icon } from '@plone/volto/components';
 import { Plug } from '@plone/volto/components/manage/Pluggable';
 import { load } from 'redux-localstorage-simple';
 import { isEqual, omit, without } from 'lodash';
-import { cloneBlock } from 'design-comuni-plone-theme/config/Blocks/ListingOptions';
+import { cloneBlock } from 'design-comuni-plone-theme/helpers/blocks';
 import { setBlocksClipboard, resetBlocksClipboard } from '@plone/volto/actions';
 import config from '@plone/volto/registry';
 

--- a/src/helpers/blocks.js
+++ b/src/helpers/blocks.js
@@ -1,0 +1,8 @@
+import { v4 as uuid } from 'uuid';
+
+export const cloneBlock = (blockData) => {
+  const blockID = uuid();
+  const clonedData = structuredClone(blockData);
+  clonedData.block = blockID;
+  return [blockID, clonedData];
+};


### PR DESCRIPTION
The problem occurred when cloning the table block, where the data saved from the newly cloned block was the same as the original. The issue was with using the spread operator on blockData, which created a shallow clone. As a result, when the cloned block was changed, the original block was also modified.

@pnicolli helped me to set the new `structuredClone()`