### PR TITLE
Fix internal url check in video blocks body

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,13 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Risolto problema con i video esterni che puntano a degli mp4: ora non vengono più erroneamente visti come link interni.
+
+
 ## Versione 11.24.0 (03/10/2024)
 
 ### Migliorie

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -34,7 +34,6 @@ const Body = ({ data, isEditMode }) => {
   let placeholder = null;
   let videoID = null;
   let listID = null;
-
   if (data.url) {
     const [computedID, computedPlaceholder] = videoUrlHelper(
       data.url,
@@ -74,6 +73,11 @@ const Body = ({ data, isEditMode }) => {
     ref: ref,
   };
 
+  let apiPath = config.settings.apiPath;
+  if (!apiPath.endsWith('/')) {
+    apiPath += '/';
+  }
+
   return (
     <>
       {data.url && (
@@ -105,10 +109,7 @@ const Body = ({ data, isEditMode }) => {
                       <video
                         src={
                           isInternalURL(
-                            data.url.replace(
-                              getParentUrl(config.settings.apiPath),
-                              '',
-                            ),
+                            data.url.replace(getParentUrl(apiPath), ''),
                           )
                             ? `${data.url}${
                                 data.url.indexOf('@@download/file') < 0


### PR DESCRIPTION
Append / to the end of apiPath because if it hasn't, internal url check for mp4 links fails.