### PR TITLE
chore: added BE info in release.md bc impacts usability

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -202,6 +202,10 @@
 
 ## Versione 11.12.5 (30/05/2024)
 
+### Novità
+
+- Per ragioni di conformità alle linee guida Agid, inibito l'inserimento di CT File nella cartella modulistica.
+
 ### Fix
 
 - Sistemato il layout "Card con immagine" dei blocchi elenco quando gli elementi non hanno immagine.


### PR DESCRIPTION
Added info in corresponding release
It's not formally correct but at the same time, it's an important change that heavily impacts usability and that clients have no records of.
It might be worth it to think about how to convey important information about BE changes that have no corresponding FE commits but must be notified to clients.