### PR TITLE
fix: removed whole day condition in page header subtitle

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Quando un evento ha impostata l'opzione "Tutta la giornata", le date sotto il titolo vengono visualizzate in maniera corretta.
+
 ## Versione 11.24.3 (24/10/2024)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderEventDates.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderEventDates.jsx
@@ -83,9 +83,7 @@ const PageHeaderEventDates = ({ content, moment, rrule }) => {
         !openEnd &&
         !renderOnlyStart &&
         `dal ${Moment(content.start).format('DD-MM-Y')} al ${endDate}`}
-      {(wholeDay ||
-        renderOnlyStart ||
-        Moment(content.end).isSame(actualEndDate)) &&
+      {(renderOnlyStart || Moment(content.end).isSame(actualEndDate)) &&
         !openEnd &&
         `${Moment(content.start).format('DD-MM-Y')}`}
       {openEnd &&


### PR DESCRIPTION
whether the event is marked as "whole day" or not, it won't change the logic or how the date is shown in the subtitle of the event ct.
Only the start date is shown and the new recurrence management provides enough conditions to manage each different case.
having the whole day condition makes it so both the first string and the second string are rendered. Could have managed the whole day condition in another way but still, it does not impact how date should be shown