### PR TITLE
fix: arlogin styles in 992px-1200px media query space

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,13 @@
 ### Fix
 
 - ...
--->
+ -->
+
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Risolto un problema di visualizzazione grafica per il bottone di login all'area personale per alcune specifiche dimensioni di schermi
 
 ## Versione 11.24.3 (24/10/2024)
 

--- a/src/components/ItaliaTheme/Header/HeaderSlim/LoginButton.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/LoginButton.jsx
@@ -9,7 +9,7 @@ import { Button } from 'design-react-kit';
 const LoginButton = ({ children, baseLoginUrl, size = 'full' }) => {
   return baseLoginUrl ? (
     <Button
-      className="btn-icon"
+      className="btn-icon login-button"
       color="primary"
       href={baseLoginUrl}
       icon={false}

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -381,3 +381,13 @@ iframe {
     }
   }
 }
+
+.public-ui
+  .it-header-slim-wrapper
+  .it-header-slim-wrapper-content
+  .it-header-slim-right-zone.header-slim-right-zone
+  .login-button {
+  @media (min-width: #{map-get($grid-breakpoints, md)}) and (max-width:#{map-get($grid-breakpoints, xl)}) {
+    flex: unset;
+  }
+}


### PR DESCRIPTION
Risolto un problema di visualizzazione grafica per il bottone di login all'area personale per alcune specifiche dimensioni di schermi (992px-1200px)

Before
![image](https://github.com/user-attachments/assets/de83bd6f-ad62-47af-a8c0-4aec204574cb)

After
![image](https://github.com/user-attachments/assets/118f0f0b-cb12-417d-af40-b8deec1924bc)
