### PR TITLE
Us 55252 remove get content from view components

### DIFF
--- a/src/components/ItaliaTheme/View/BandoView/BandoApprofondimenti.jsx
+++ b/src/components/ItaliaTheme/View/BandoView/BandoApprofondimenti.jsx
@@ -33,7 +33,7 @@ const BandoApprofondimenti = ({ content }) => {
           item={item} //viene utilizzato nelle customizzazioni per ottenere altre proprietà
         />
       );
-    } else if (item.type === 'Link') {
+    } else if (item.type === 'Collegamento') {
       return (
         <Card
           className="card card-teaser shadow p-4 mt-3 rounded attachment"

--- a/src/components/ItaliaTheme/View/Commons/LocationsMap.jsx
+++ b/src/components/ItaliaTheme/View/Commons/LocationsMap.jsx
@@ -1,7 +1,5 @@
-import { useDispatch, useSelector } from 'react-redux';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useIntl, defineMessages } from 'react-intl';
-import { getContent, resetContent } from '@plone/volto/actions';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { OSMMap } from 'volto-venue';
 import PropTypes from 'prop-types';
@@ -30,9 +28,7 @@ const messages = defineMessages({
 });
 
 const LocationsMap = ({ center, locations }) => {
-  const dispatch = useDispatch();
   const intl = useIntl();
-  const fetchedLocations = useSelector((state) => state.content.subrequests);
   const venues = locations.map((location) => {
     let url = flattenToAppURL(location['@id']);
     return {
@@ -40,18 +36,6 @@ const LocationsMap = ({ center, locations }) => {
       url: url,
     };
   });
-
-  useEffect(() => {
-    venues.forEach((loc) => {
-      dispatch(getContent(loc.url, null, loc.key));
-    });
-
-    return () =>
-      venues.forEach((loc) => {
-        dispatch(resetContent(loc.key));
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, locations]);
 
   const pinContent = (item) => {
     return (
@@ -97,7 +81,9 @@ const LocationsMap = ({ center, locations }) => {
   };
 
   let venuesData = venues.reduce((acc, val) => {
-    let venue = fetchedLocations?.[val.key]?.data;
+    let venue = locations.find((el) => {
+      return el['@id'].includes(val.url);
+    });
 
     if (venue?.geolocation?.latitude && venue?.geolocation?.longitude) {
       return [

--- a/src/components/ItaliaTheme/View/Commons/Module.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Module.jsx
@@ -3,12 +3,9 @@
  * @module components/theme/View/DocumentoView/Modules
  */
 
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
-import { getContent, resetContent } from '@plone/volto/actions';
 
 import { Card, CardBody, CardTitle } from 'design-react-kit';
 
@@ -21,20 +18,7 @@ import { DownloadFileFormat } from 'design-comuni-plone-theme/components/ItaliaT
  * @returns {string} Markup of the component.
  */
 const Module = ({ item }) => {
-  const dispatch = useDispatch();
-  const subrequests = useSelector((state) => state.content.subrequests);
-  const url = flattenToAppURL(item['@id']);
-  const key = 'module_' + url;
-
-  useEffect(() => {
-    dispatch(getContent(url, null, key));
-    return () => dispatch(resetContent(key));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
-
-  let modulo = subrequests?.[key]?.data;
-
-  return modulo ? (
+  return item ? (
     <Card
       className="card card-teaser shadow p-4 mt-3 rounded modulo"
       noWrapper={true}
@@ -42,37 +26,37 @@ const Module = ({ item }) => {
     >
       <CardBody tag="div">
         <CardTitle className="h5">
-          {modulo.file_principale ? (
-            modulo.title ?? modulo.file_principale.filename
-          ) : modulo['@type'] === 'Link' ? (
-            <UniversalLink item={modulo} title={modulo.title}>
-              {modulo.title}
+          {item.file_principale ? (
+            item.title ?? item.file_principale.filename
+          ) : item['@type'] === 'Link' ? (
+            <UniversalLink item={item} title={item.title}>
+              {item.title}
             </UniversalLink>
           ) : (
-            modulo.title
+            item.title
           )}
         </CardTitle>
 
-        {modulo.description && <p>{modulo.description}</p>}
+        {item.description && <p>{item.description}</p>}
         <div className="download-formats">
           <DownloadFileFormat
-            file={modulo.file_principale}
+            file={item.file_principale}
             showLabel={true}
-            title={modulo.title ?? modulo.file_principale.filename}
+            title={item.title ?? item.file_principale.filename}
             hideFileFormatLabel={true}
             className="mb-4"
           />
           <DownloadFileFormat
-            file={modulo.formato_alternativo_1}
+            file={item.formato_alternativo_1}
             showLabel={true}
-            title={modulo.title ?? modulo.formato_alternativo_1.filename}
+            title={item.title ?? item.formato_alternativo_1.filename}
             hideFileFormatLabel={true}
             className="mb-4"
           />
           <DownloadFileFormat
-            file={modulo.formato_alternativo_2}
+            file={item.formato_alternativo_2}
             showLabel={true}
-            title={modulo.title ?? modulo.formato_alternativo_2.filename}
+            title={item.title ?? item.formato_alternativo_2.filename}
             hideFileFormatLabel={true}
           />
         </div>

--- a/src/components/ItaliaTheme/View/Commons/Modules.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Modules.jsx
@@ -18,7 +18,9 @@ import {
  */
 const Modules = ({ content, title, id = 'documenti' }) => {
   const moduli =
-    content.items?.filter((item) => item.id !== 'multimedia') ?? [];
+    content.moduli_del_documento ??
+    content.items?.filter((item) => item.id !== 'multimedia') ??
+    [];
 
   return moduli.length > 0 ? (
     <RichTextSection tag_id={id} title={title}>

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
@@ -3,9 +3,8 @@
  * @module components/theme/View/PaginaArgomentoView/PaginaArgomentoView
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
 import { Portal } from 'react-portal';
 import cx from 'classnames';
 
@@ -16,7 +15,6 @@ import {
   flattenToAppURL,
   hasBlocksData,
 } from '@plone/volto/helpers';
-import { getContent, resetContent } from '@plone/volto/actions';
 import {
   CardCategory,
   Breadcrumbs,
@@ -44,32 +42,6 @@ import config from '@plone/volto/registry';
 const PaginaArgomentoView = ({ content }) => {
   const Image = config.getComponent({ name: 'Image' }).component;
   const location = useLocation();
-  const dispatch = useDispatch();
-
-  const searchResults = useSelector((state) => state.content?.subrequests);
-
-  // one request is made for every 'unita_amministrative_responsabili' selected
-  useEffect(() => {
-    if (content?.unita_amministrative_responsabili?.length > 0) {
-      content.unita_amministrative_responsabili.forEach((x) => {
-        const url = flattenToAppURL(x['@id']);
-        const loaded =
-          searchResults?.[url]?.loading || searchResults?.[url]?.loaded;
-        if (!loaded) {
-          dispatch(getContent(url, null, url));
-        }
-      });
-    }
-
-    return () => {
-      if (content?.unita_amministrative_responsabili?.length > 0) {
-        content.unita_amministrative_responsabili.forEach((x) => {
-          dispatch(resetContent(flattenToAppURL(x['@id'])));
-        });
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content]);
 
   const rightHeaderHasContent =
     richTextHasContent(content.ulteriori_informazioni) ||
@@ -99,12 +71,17 @@ const PaginaArgomentoView = ({ content }) => {
 
               {content?.unita_amministrative_responsabili?.length > 0 &&
                 content?.unita_amministrative_responsabili?.map((u, index) => {
-                  const uo_object =
-                    searchResults[flattenToAppURL(u['@id'])]?.data;
+                  const uo_object = u;
                   let alt = u.title;
-                  if (uo_object?.preview_image && uo_object?.preview_caption) {
+                  if (
+                    uo_object.image_scales.preview_image.length > 0 &&
+                    uo_object?.preview_caption
+                  ) {
                     alt = uo_object.preview_caption;
-                  } else if (uo_object?.image && uo_object?.image_caption) {
+                  } else if (
+                    uo_object.image_scales.image.length > 0 &&
+                    uo_object?.image_caption
+                  ) {
                     alt = uo_object.image_caption;
                   }
 
@@ -132,7 +109,9 @@ const PaginaArgomentoView = ({ content }) => {
                               </CardText>
                             </CardBody>
                             {uo_object &&
-                              (uo_object.preview_image || uo_object.image) && (
+                              (uo_object.image_scales.image.length > 0 ||
+                                uo_object.image_scales.preview_image.length >
+                                  0) && (
                                 <div className="image-container me-3">
                                   <Image
                                     item={uo_object}


### PR DESCRIPTION
Removed getContent from all CT and CT common components.
RelatedNews, Venue e VenueSmall use getContent but are not used by any CT

Before merging, must merge and release BE branch us55252_upgrade_serializer

I did not update the release.md as it is not something that impacts usability