### PR TITLE
fix: freeze page with gallery

### DIFF
--- a/src/components/ItaliaTheme/View/ViewUtils.jsx
+++ b/src/components/ItaliaTheme/View/ViewUtils.jsx
@@ -67,9 +67,8 @@ export const useSideMenu = (content, documentBody) => {
     }
     if (observer) {
       observer.observe(documentBody.current, {
-        //attributes: true,
         childList: true,
-        subtree: true,
+        //subtree: true, //commentato, perchè a noi interessano solo i figli di primo livello. Con questo abilitato, se in pagina ci sono delle gallery si impalla il browser
       });
     }
     return () => {


### PR DESCRIPTION
Quando si aveva abilitata l'opzione "updateSideMenuOnLoadingBlocks" per una vista di un content-type, se veniva mostrata una gallery con molti elementi la pagina si freezzava e il browser si impallava perchè il mutation observer veniva reinizializzato di continuo a causa probabilmente dei continui rerender del componente della gallery. 

Togliendo la prop "subtree" all'observe dell'observer gli diciamo di rimanere in ascolto solamente i suoi figli diretti (che è quello che a noi interessa per costruire i titoli del menu laterale" 