### PR TITLE
fix: updated volto_gdp_privacy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- L'impostazione "Solo cookie tecnici" non causa problemi nell'apertura del cookie banner.
+
 ## Versione 11.24.4 (07/11/2024)
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "volto-editablefooter": "5.1.7",
     "volto-feedback": "0.3.2",
     "volto-form-block": "3.10.0",
-    "volto-gdpr-privacy": "2.2.7",
+    "volto-gdpr-privacy": "2.2.9",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.2.1",
     "volto-querywidget-with-browser": "0.4.2",


### PR DESCRIPTION
When applying settings for "Only technical cookies" in gdpr control panel, the page would break everytime the cookie banner is opened.
The code would break as there was no conditional chaining in the profiling cookies section of the code.
The new version of volto-gdpr-privacy has fixed that and does not cause any other issues in the control panel