### PR TITLE
Bug 60364 universal link safari and lazy icons slate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,23 +43,14 @@
 
 ## Versione X.X.X (dd/mm/yyyy)
 
-### Fix
-
-- Risolto un problema di visualizzazione grafica per il bottone di login all'area personale per alcune specifiche dimensioni di schermi
-
-## Versione X.X.X (dd/mm/yyyy)
-
 ### Migliorie
 
 - Inserito messaggio di avviso quando si tenta di caricare un file dalla cartella Modulistica all'interno di un Servizio per segnalare limitazione sull'upload
 
-### Novità
-
-- ...
-
 ### Fix
 
-- ...
+- Risolto un problema di visualizzazione grafica per il bottone di login all'area personale per alcune specifiche dimensioni di schermi
+- [WebKit, Safari, iOS] Risolto un problema di visualizzazione grafica di alcuni bottoni che contengono al loro interno un link ad un sito esterno.
 
 ## Versione 11.24.3 (24/10/2024)
 

--- a/src/components/ItaliaTheme/Icons/DesignIcon.jsx
+++ b/src/components/ItaliaTheme/Icons/DesignIcon.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { v4 as uuid } from 'uuid';
 import PropTypes from 'prop-types';
 
@@ -12,50 +12,101 @@ const propTypes = {
 
 const defaultProps = {
   color: '',
-  size: '',
+  size: '24px',
   icon: '',
   padding: false,
 };
 
+// No ts means we get many different things here, standardize it
+const SIZE_MAPPINGS = {
+  xs: '1rem',
+  sm: '1.25rem',
+  md: defaultProps.size,
+  lg: '1.75rem',
+  xl: '2rem',
+};
+
+function getIconMapSizeConfig(size) {
+  const mapKeys = Object.keys(SIZE_MAPPINGS);
+  if (mapKeys.includes(size)) return SIZE_MAPPINGS[size];
+  return size;
+}
+
+const iconCache = new Map(); // Global cache using Map
+
 const Icon = ({ icon, title, className, size }) => {
-  const ImportedIconRef = useRef(null);
-  const [loading, setLoading] = useState(false);
-  const iconID = useMemo(() => uuid(), []);
+  const [iconState, setIconState] = useState({
+    loading: true,
+    icon: undefined,
+    // Move to useId in react18
+    id: uuid(),
+  });
 
   useEffect(() => {
-    setLoading(true);
-    const importIcon = async () => {
-      try {
-        const { default: namedImport } = await import(
-          `bootstrap-italia/src/svg/${icon}.svg`
-        );
-        ImportedIconRef.current = namedImport;
-      } catch (err) {
-        throw err;
-      } finally {
-        setLoading(false);
-      }
-    };
-    importIcon();
+    let loadableIcon = iconCache.get(icon);
+    // Use the cached icon if available
+    if (loadableIcon) {
+      setIconState((prev) => ({
+        ...prev,
+        loading: false,
+        icon: loadableIcon,
+      }));
+    } else {
+      // Otherwise, dynamically import the icon
+      const importIcon = async () => {
+        try {
+          const { default: namedImport } = await import(
+            `bootstrap-italia/src/svg/${icon}.svg`
+          );
+          iconCache.set(icon, namedImport); // Cache the imported icon
+          loadableIcon = namedImport;
+        } catch (err) {
+          console.error(`Error loading icon: ${icon}`, err);
+        } finally {
+          setIconState((prev) => ({
+            ...prev,
+            loading: false,
+            icon: loadableIcon,
+          }));
+        }
+      };
+      importIcon();
+    }
   }, [icon]);
 
-  if (!loading && ImportedIconRef.current) {
-    const { current: name } = ImportedIconRef;
+  const iconSize = getIconMapSizeConfig(size);
+
+  // Placeholder that is shown while the icon is loading
+  if (iconState.loading) {
+    return (
+      <span
+        style={{
+          width: iconSize,
+          height: iconSize,
+          backgroundColor: 'transparent',
+        }}
+        className={className}
+      />
+    );
+  }
+
+  // Render the icon once it's loaded
+  if (iconState.icon) {
     return (
       <svg
-        xmlns={name.attributes?.xmlns}
-        viewBox={name.attributes?.viewBox}
-        width={name.attributes?.width}
-        height={name.attributes?.height}
-        style={{ height: size, width: 'auto' }}
+        xmlns={iconState.icon.attributes?.xmlns}
+        viewBox={iconState.icon.attributes?.viewBox}
+        width={iconState.icon.attributes?.width}
+        height={iconState.icon.attributes?.height}
+        style={{ height: iconSize, width: iconSize }}
         className={className}
         aria-hidden="true"
         dangerouslySetInnerHTML={{
           __html: title
-            ? `<title id="${iconID}">${title}</title>${name.content}`
-            : name.content,
+            ? `<title id="${iconState.id}">${title}</title>${iconState.icon.content}`
+            : iconState.icon.content,
         }}
-        aria-labelledby={iconID}
+        aria-labelledby={iconState.id}
       />
     );
   }

--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -22,6 +22,7 @@ import {
 import { matchPath } from 'react-router';
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import { EnhanceLink } from 'design-comuni-plone-theme/helpers';
+import cx from 'classnames';
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
@@ -132,7 +133,9 @@ const UniversalLink = ({
     extended_children = enhanced_link.children;
     aria_label = enhanced_link.aria_label;
   }
-
+  const showExternalIcon =
+    !overrideMarkSpecialLinks &&
+    config.settings.siteProperties.markSpecialLinks;
   let tag = (
     <Link
       to={flattenToAppURL(url)}
@@ -167,22 +170,23 @@ const UniversalLink = ({
             : null
         }
         rel="noopener noreferrer"
-        className={className}
+        className={cx(className, {
+          'with-external-link-icon': showExternalIcon,
+        })}
         {...props}
         aria-label={aria_label}
       >
         {children}
-        {!overrideMarkSpecialLinks &&
-          config.settings.siteProperties.markSpecialLinks && (
-            <Icon
-              icon="it-external-link"
-              title={`${title ? title + ' - ' : ''}${intl?.formatMessage({
-                id: 'opensInNewTab',
-              })}`}
-              size="xs"
-              className="ms-1 align-sub external-link"
-            />
-          )}
+        {showExternalIcon && (
+          <Icon
+            icon="it-external-link"
+            title={`${title ? title + ' - ' : ''}${intl?.formatMessage({
+              id: 'opensInNewTab',
+            })}`}
+            size="xs"
+            className="ms-1 align-sub external-link"
+          />
+        )}
       </a>
     );
   } else if (isDownload) {

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -121,6 +121,37 @@ iframe {
 }
 
 //slate LINK
+/*
+  Safari rendering issue workaround - B#60364
+  Safari rendering fix, icons and fonts coming late means shenanigans for Safari rendering, as
+  Safari is lazy and slow in loading fonts and icons dynamically.
+  Problem: Safari (tested on Safari 17.6) sometimes fails to calculate the layout correctly
+  when dealing with dynamic content such as lazy-loaded icons or fonts, combined with
+  `display: inline-block`. This can result in improperly positioned elements
+  until the page is re-rendered or refocused.
+
+  Solution: To fix this issue:
+  1. Replace `display: inline-block` with `display: inline-flex`. This ensures Safari
+      handles the box model and inline context properly, especially when the element's
+      size or alignment depends on dynamic content.
+  2. Add `position: relative;` to force a recalculation of layout, resolving rendering quirks.
+
+  Background: Safari's WebKit engine has known issues with `inline-block` combined
+  with delayed content rendering, such as lazy-loaded icons. Switching to `inline-flex`
+  better aligns with modern CSS rendering engines, while `position: relative;`
+  ensures the layout is recalculated.
+
+  References:
+  - CSS-Tricks: What Forces Layout or Reflow: https://css-tricks.com/what-forces-layout-reflow/
+  - WebKit Bug Reports on `inline-block` rendering issues with dynamic content.
+  - Testing and observations on Safari 17.6 behavior with lazy-loaded assets.
+*/
+@supports (-webkit-appearance: none) {
+  a.with-external-link-icon {
+    display: inline-flex; /* Evita problemi con inline-block */
+    position: relative; /* Forza Safari a calcolare il layout reflow correttamente */
+  }
+}
 // .inline-link {
 //   margin-left: 0.5rem;
 //   margin-right: 0.5rem;


### PR DESCRIPTION
Sistema questo comportamento causato da bug di webkit e mala gestione del rendering con lazy-loaded icons esclusivamente su Safari, WebKit, iOS.
Migliorato il sistema di lazy loading delle icone di bootstrap-italia per non causare 4x render rispetto al necessario con una mappa globale degli import
