### PR TITLE
fix: removed expiration date from event header

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Rimossa dal CT Evento la data di scadenza del CT per evitare confusione con le date effettive dell'evento
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
 ## Versione 11.24.5 (22/11/2024)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderDates.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderDates.jsx
@@ -39,16 +39,6 @@ const PageHeaderDates = ({ content }) => {
               </div>
             </div>
           )}
-          {content.expires && content['@type'] !== 'News Item' && (
-            <div className="row">
-              <div className="col-12">
-                <small>{intl.formatMessage(messages.expire)}:</small>
-                <p className="font-monospace">
-                  {viewDate(intl.locale, content.expires, 'DD-MM-Y')}
-                </p>
-              </div>
-            </div>
-          )}
         </div>
       )}
     </>


### PR DESCRIPTION
As requested, the expiration date has been removed from the header of the event to avoid generation confusion with actual event dates