### PR TITLE
fix: no close search popup when redirecting to results page

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 ### Migliorie
 
 - Rimossa dal CT Evento la data di scadenza del CT per evitare confusione con le date effettive dell'evento
+- Durante la ricerca nel sito dalla popup che compare cliccando sul bottone 'Cerca' nella testa del sito, viene mostrato un loader in overlay durante il caricamento della pagina dei risultati perchè questo potrebbe richiedere un po' di tempo. Prima di questa modifica non era chiaro se la ricerca fosse iniziata.
 
 ### Novità
 

--- a/src/components/ItaliaTheme/Header/HeaderSearch/SearchModal.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSearch/SearchModal.jsx
@@ -28,6 +28,7 @@ import {
   Input,
   Label,
   Toggle,
+  Spinner,
 } from 'design-react-kit';
 
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
@@ -173,6 +174,7 @@ const SearchModal = ({ closeModal, show }) => {
   const dispatch = useDispatch();
   const location = useLocation();
 
+  const [redirectingToResults, setRedirectingToResults] = useState(false);
   const [advancedSearch, setAdvancedSearch] = useState(false);
   const [advancedTab, setAdvancedTab] = useState(null);
   const [searchableText, setSearchableText] = useState(
@@ -296,10 +298,11 @@ const SearchModal = ({ closeModal, show }) => {
     setOptions((prevOptions) => ({ ...prevOptions, [optId]: value }));
 
   const submitSearch = () => {
+    setRedirectingToResults(true);
     setAdvancedSearch(false);
-    setTimeout(() => {
-      closeModal();
-    }, 500);
+    // setTimeout(() => {
+    //   closeModal();
+    // }, 500);
   };
 
   const handleEnterSearch = (e) => {
@@ -923,6 +926,11 @@ const SearchModal = ({ closeModal, show }) => {
             </div>
           )}
         </Container>
+        {redirectingToResults && (
+          <div className="overlay loading-results">
+            <Spinner active />
+          </div>
+        )}
       </ModalBody>
     </Modal>
   );

--- a/src/theme/extras/_modals.scss
+++ b/src/theme/extras/_modals.scss
@@ -34,4 +34,17 @@
   .chip {
     cursor: pointer;
   }
+
+  .overlay.loading-results {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    z-index: 9999;
+    top: 0;
+    left: 0;
+    background-color: hsl(0deg 0% 100% / 64%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
quando si faceva una ricerca nel sito tramite la popup di ricerca che si apre cliccando sul pulsante presente nell'Header del sito, al submit, la popup si chiudeva e se il caricamento della pagina dei risultati richiedeva tempo, si rimaneva in "stallo" senza nessuna informazione evidente, sulla pagina da cui era partita la ricerca. Per l'utente era fuorviante perchè non era chiaro se la ricerca era partita o meno.

Ho evitato che la popup si chiudesse e ho aggiunto in overlay un loader.


https://github.com/user-attachments/assets/0ba54034-5a07-4c41-9a76-38d2a49e46cd



su v2 non è necessario portarla perchè ho gia fatto io