### PR TITLE
fix: table styles in edit mode

### DIFF
--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -74,6 +74,48 @@ body.cms-ui {
     .block.text {
       line-height: 1.555;
     }
+
+    &.table {
+      @import 'bootstrap/scss/reboot';
+      @import 'bootstrap/scss/tables';
+      @import 'bootstrap-italia/src/scss/custom/tables';
+      @import 'extras/tables';
+
+      .ui.table {
+        &.inverted {
+          th,
+          td {
+            border-color: inherit !important;
+          }
+        }
+        thead th {
+          font-weight: bold;
+          text-transform: unset;
+          color: var(--bs-table-color);
+        }
+
+        &.very.basic {
+          &:not(.sortable):not(.striped) {
+            th:first-child,
+            td:first-child {
+              padding-left: 0.5rem;
+            }
+            thead tr:first-child th {
+              padding-top: 0.5rem;
+            }
+            td:last-child {
+              padding-right: 0.5rem;
+            }
+          }
+        }
+
+        &.striped {
+          tbody tr:nth-child(2n) {
+            background-color: rgba(0, 0, 50, 0.02) !important;
+          }
+        }
+      }
+    }
   }
 
   &.contenttype-document,

--- a/src/theme/extras/_tables.scss
+++ b/src/theme/extras/_tables.scss
@@ -20,6 +20,17 @@
   &.very.basic {
     border: none;
 
+    th,
+    td {
+      &:first-of-type {
+        border-left: none;
+      }
+
+      &:last-of-type {
+        border-right: none;
+      }
+    }
+
     tbody > tr {
       &:first-of-type {
         th,
@@ -28,23 +39,11 @@
         }
       }
 
-      &:last-of-type {
-        th,
-        td {
-          border-bottom: none;
-        }
-      }
-
       th,
       td {
-        &:first-of-type {
-          border-left: none;
-        }
-
-        &:last-of-type {
-          border-right: none;
-        }
+        border-bottom: none;
       }
+      border-width: 0;
     }
   }
 


### PR DESCRIPTION
Sistemati gli stili delle tabelle per renderli uniformi tra edit e view:

Ora, se in view il risultato è questo:
<img width="995" alt="Screenshot 2024-12-03 alle 12 01 43" src="https://github.com/user-attachments/assets/3c5d4b92-4ff6-4a6c-b121-69b1056f4501">

quando si va in edit non c'è corrispondenza di stili:
<img width="768" alt="Screenshot 2024-12-03 alle 12 02 34" src="https://github.com/user-attachments/assets/ab18fc95-cd23-4b57-8e98-4ccf5fc2d0ef">


ma con le nuove regole aggiunte in questa pr, gli stili corrispondono anche in edit:

<img width="870" alt="Screenshot 2024-12-03 alle 12 01 55" src="https://github.com/user-attachments/assets/3da67fc5-ac0b-4693-85e3-bfe591c047fa">


(richiesto dalla RER)