### PR TITLE
fix: removed no_value option from recurrence widget

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Rimossa l'opzione non selezionabile "nessun valore" dal widget ricorrenza.
+
 ## Versione 11.25.1 (28/11/2024)
 
 ### Fix

--- a/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -990,7 +990,9 @@ class RecurrenceWidget extends Component {
                             )}
                             value={formValues.freq}
                             onChange={this.onChangeRule}
+                            noValueOption={false}
                           />
+
                           {OPTIONS.frequences[formValues.freq].interval && (
                             <IntervalField
                               label={intl.formatMessage(messages.repeatEvery)}
@@ -1004,7 +1006,6 @@ class RecurrenceWidget extends Component {
                               onChange={this.onChangeRule}
                             />
                           )}
-
                           {/***** byday *****/}
                           {OPTIONS.frequences[formValues.freq].byday && (
                             <ByDayField
@@ -1013,7 +1014,6 @@ class RecurrenceWidget extends Component {
                               onChange={this.onChangeRule}
                             />
                           )}
-
                           {/***** bymonth *****/}
                           {OPTIONS.frequences[formValues.freq].bymonth && (
                             <ByMonthField
@@ -1027,7 +1027,6 @@ class RecurrenceWidget extends Component {
                               onChange={this.onChangeRule}
                             />
                           )}
-
                           {/***** byyear *****/}
                           {OPTIONS.frequences[formValues.freq].byyear && (
                             <ByYearField
@@ -1042,7 +1041,6 @@ class RecurrenceWidget extends Component {
                               onChange={this.onChangeRule}
                             />
                           )}
-
                           {/*-- ends after N recurrence or date --*/}
                           <EndField
                             value={formValues.recurrenceEnds}


### PR DESCRIPTION
Recurrence no_value option hidden from select widget

it was not selectable as it is not possible to calculate a recurrence without a recurrence :)