### PR TITLE
fix: added closeMenu to it-external on megaMenu

### DIFF
--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -385,7 +385,10 @@ const MegaMenu = ({ item, pathname, closeMenu }) => {
                         <UniversalLink
                           className="list-item medium"
                           item={item.showMoreLink[0]}
-                          onClick={() => setMenuStatus(false)}
+                          onClick={() => {
+                            setMenuStatus(false);
+                            closeMenu();
+                          }}
                           role="menuitem"
                         >
                           <span>


### PR DESCRIPTION
Il menu non si chiude quando si fa click su un "show more" button su megamenu mobile. La pagina si carica, ma non sparisce il menu.

<img width="439" alt="Screenshot 2024-12-16 alle 15 37 02" src="https://github.com/user-attachments/assets/54006170-3d33-41f7-88ee-8074a1a6f892" />
