### PR TITLE
fix: removed query b_size limit for event_location vocabulary

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Il menu a tendina da cui è possibile filtrare i luoghi nel blocco Ricerca Eventi mostra tutti i luoghi collegati agli eventi presenti nel percorso selezionato dalla Sidebar, senza limitarne il numero.
+
 ## Versione 11.25.3 (12/12/2024)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/SelectFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/SelectFilter.jsx
@@ -11,6 +11,7 @@ const SelectFilter = ({
   onChange,
   placeholder,
   isSearchable = false,
+  optionsQuerySize = 25,
 }) => {
   const dispatch = useDispatch();
 
@@ -52,15 +53,20 @@ const SelectFilter = ({
         );
       }
     } else if (options.vocabulary) {
-      dispatch(getVocabulary({ vocabNameOrURL: options.vocabulary }));
+      dispatch(
+        getVocabulary({
+          vocabNameOrURL: options.vocabulary,
+          size: optionsQuerySize,
+        }),
+      );
     }
   }, []);
 
   const select_options = options?.choices
     ? options.choices
     : options?.vocabulary
-      ? vocabularies?.[options.vocabulary]?.items
-      : selectOptions;
+    ? vocabularies?.[options.vocabulary]?.items
+    : selectOptions;
 
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper select-filter">

--- a/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
@@ -72,6 +72,7 @@ const DefaultFilters = () => {
             vocabulary: 'design.plone.vocabularies.event_location',
             placeholder: intl.formatMessage(messages.venues),
           },
+          optionsQuerySize: -1,
         },
       },
       query: (value, query) => {

--- a/src/customizations/volto/actions/vocabularies/vocabularies.js
+++ b/src/customizations/volto/actions/vocabularies/vocabularies.js
@@ -36,7 +36,9 @@ export function getVocabulary({
   const vocabulary = getVocabName(vocabNameOrURL);
   const contextualVocabularies = config.settings.contextualVocabularies;
   const vocabPath =
-    contextualVocabularies && contextualVocabularies.includes(vocabulary) && vocabulary !== vocabNameOrURL
+    contextualVocabularies &&
+    contextualVocabularies.includes(vocabulary) &&
+    vocabulary !== vocabNameOrURL
       ? flattenToAppURL(vocabNameOrURL)
       : `/@vocabularies/${vocabulary}`;
   let queryString = `b_start=${start}${size ? '&b_size=' + size : ''}`;
@@ -74,7 +76,9 @@ export function getVocabularyTokenTitle({
   const vocabulary = getVocabName(vocabNameOrURL);
   const contextualVocabularies = config.settings.contextualVocabularies;
   const vocabPath =
-    contextualVocabularies && contextualVocabularies.includes(vocabulary) && vocabulary !== vocabNameOrURL
+    contextualVocabularies &&
+    contextualVocabularies.includes(vocabulary) &&
+    vocabulary !== vocabNameOrURL
       ? flattenToAppURL(vocabNameOrURL)
       : `/@vocabularies/${vocabulary}`;
   const queryString = {


### PR DESCRIPTION
The Events Search block location filter takes options from a vocabulary populated by all the venues linked to an Event in the path selected through the Sidebar.
The vocabulary query had the classic Plone limit of 25 so in case of higher numbers of results, it cut the list to 25.
Added a parameter to the SelectFilter that is set to 25 by default, but that can be changed or removed (by setting -1) when necessary