### PR TITLE
fix: start date in recurrences

### DIFF
--- a/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -408,11 +408,9 @@ class RecurrenceWidget extends Component {
               } else if (isEqual(value, MONDAYFRIDAY_DAYS)) {
                 formValues['freq'] = FREQUENCES.MONDAYFRIDAY;
               } else
-                formValues[option] = value
-                  ? value.map((d) => {
+                formValues[option] = value.map((d) => {
                       return this.getWeekday(d);
-                    })
-                  : [];
+                    });
             }
             break;
           case 'bymonthday':

--- a/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -408,9 +408,11 @@ class RecurrenceWidget extends Component {
               } else if (isEqual(value, MONDAYFRIDAY_DAYS)) {
                 formValues['freq'] = FREQUENCES.MONDAYFRIDAY;
               } else
-                formValues[option] = value.map((d) => {
-                  return this.getWeekday(d);
-                });
+                formValues[option] = value
+                  ? value.map((d) => {
+                      return this.getWeekday(d);
+                    })
+                  : [];
             }
             break;
           case 'bymonthday':
@@ -538,7 +540,7 @@ class RecurrenceWidget extends Component {
     }
     let exdates = Object.assign([], rruleSet.exdates());
     let rdates = Object.assign([], rruleSet.rdates());
-    if (field === 'dstart') dstart = value;
+    if (field === 'dtstart') dstart = value;
     else if (field === 'exdates') exdates = value;
     else if (field === 'rdates') rdates = value;
     else if (field === 'freq') {


### PR DESCRIPTION
Sistemato un problema nel calcolo delle ricorrenze, non venivano calcolate correttamente, e veniva messa solamente la data finale, perchè la data iniziale non veniva impostata. 

Esempio del problema: 
ho un evento che inizia il 8/12 e finisce il 29/12, voglio impostare una ricorrenza settimanale la domenica, ma come giorni della ricorrenza mi vengono proposti solo il 29 dicembre. Invece dovrei vedere anche 8,15 e 22 dicembre. 

https://github.com/user-attachments/assets/794ad387-faf1-4091-adc5-a8dca73554d7


Esempio della soluzione: 
vengono correttamente aggiunte le date 8,15 e 22 dicembre (oltre al 29)

https://github.com/user-attachments/assets/37044920-f25d-4b23-afc6-a6b6b9810645



se le modifiche sulle ricorrenze erano state fatte anche per la 11, va fatto cherry pick li

https://redturtle.tpondemand.com/entity/61247-eventi-non-permette-di-inserire-le
