### PR TITLE
fix: default sort for day-items in Calendar block

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
@@ -123,6 +123,7 @@ const Body = ({ data, block, inEditMode, path, onChangeBlock, reactSlick }) => {
   const adaptedQuery = Object.assign(
     {
       fullobjects: 1,
+      sort_on: !Object.keys(_querystring).includes('sort_on') ? 'start' : null,
     },
     ...copyFields.map((name) =>
       Object.keys(_querystring).includes(name)


### PR DESCRIPTION
Sistemato l'ordinamento di default degli elementi nel blocco calendario . 
Ora vengono ordinati per data/ora di inizio. 

Fare cherry-pick anche sulla 11. 

Non è strettamente necessario, ma è legata a questa pr di Be: https://github.com/RedTurtle/design.plone.contenttypes/pull/290/files