### PR TITLE
fix: getFileViewFormat regex inconsistencies with different filenames that included @@download/**, added anti-regression tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Risolto un problema riguardante la visualizzazione delle estensioni dei file quando si utilizza un link ad un documento nei blocchi di testo.
+
 ## Versione 11.26.0 (20/12/2024)
 
 ### Migliorie

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -119,11 +119,18 @@ export const FILE_EXTENSIONS = {
     icon: { lib: '', name: faFileOdp, svg_format: true },
     format_name: 'ODP',
   },
+  pdf: {
+    icon: { lib: 'far', name: 'file-pdf' },
+    format_name: 'PDF',
+  },
 };
 
 export const getFileViewFormat = (file) => {
-  const regexEx = /(?:\.([^.]+))?$/;
-  const fileExtension = regexEx.exec(file.filename)[1];
+  const cleanedFilename = (file.filename || '').split(/\/[@?#]/)[0];
+  const regexEx = /\.([a-zA-Z0-9]+)$/;
+
+  const match = regexEx.exec(cleanedFilename);
+  const fileExtension = match ? match[1] : null;
   const typeOfContent = file['content-type'] ?? file['mime_type'];
 
   const viewFormat = {

--- a/src/helpers/files.test.js
+++ b/src/helpers/files.test.js
@@ -1,0 +1,90 @@
+import { getFileViewFormat, FILE_EXTENSIONS, FILE_FORMATS } from './files';
+
+describe('getFileViewFormat', () => {
+  test('should correctly extract the extension and match the icon for a valid PDF URL with multiple segments after the extension', () => {
+    const file = {
+      filename:
+        'https://example.com/amministrazione/documenti-e-dati/modulistica/area-servizi-educativi-e-scolastici/intestazione-ripartizione-rette/modulo_intestazione_ripartizione_rette_nona_784_9690.pdf/@@download/file_principale',
+      'content-type': 'application/pdf',
+    };
+
+    const result = getFileViewFormat(file);
+
+    expect(result.icon).toEqual(FILE_EXTENSIONS.pdf.icon); // Verifica che l'icona sia corretta
+    expect(result.label).toEqual(FILE_EXTENSIONS.pdf.format_name); // Verifica che il formato sia corretto
+  });
+
+  test('should correctly handle a PDF URL without multiple segments after the extension', () => {
+    const file = {
+      filename:
+        'https://example.com/amministrazione/documenti-e-dati/modulistica/area-servizi-educativi-e-scolastici/intestazione-ripartizione-rette/modulo_intestazione_ripartizione_rette_nona_784_9690.pdf/@@download/filehttps://example.com/amministrazione/documenti-e-dati/modulistica/area-servizi-educativi-e-scolastici/intestazione-ripartizione-rette/modulo_intestazione_ripartizione_rette_nona_784_9690.pdf',
+      'content-type': 'application/pdf',
+    };
+
+    const result = getFileViewFormat(file);
+
+    expect(result.icon).toEqual(FILE_EXTENSIONS.pdf.icon);
+    expect(result.label).toEqual(FILE_EXTENSIONS.pdf.format_name);
+  });
+
+  test('should return correct format for a non-PDF file extension', () => {
+    const file = {
+      filename: 'https://example.com/file/example.xsd',
+      'content-type': 'application/xml',
+    };
+
+    const result = getFileViewFormat(file);
+
+    expect(result.icon).toEqual(FILE_EXTENSIONS.xsd.icon);
+    expect(result.label).toEqual(FILE_EXTENSIONS.xsd.format_name);
+  });
+
+  test('should return correct format for a non-PDF content-type', () => {
+    const file = {
+      filename: 'https://example.com/file/example.xml',
+      'content-type': 'application/xml',
+    };
+
+    const result = getFileViewFormat(file);
+
+    expect(result.icon).toEqual(FILE_FORMATS['application/xml'].icon);
+    expect(result.label).toEqual(FILE_FORMATS['application/xml'].format_name);
+  });
+
+  test('should return null format when extension or content-type is not found', () => {
+    const file = {
+      filename: 'https://example.com/file/unknown.xyz',
+      'content-type': 'application/unknown',
+    };
+
+    const result = getFileViewFormat(file);
+
+    expect(result.icon).toBeNull();
+    expect(result.label).toBeNull();
+  });
+
+  test('should handle file URLs without an extension', () => {
+    const file = {
+      filename: 'https://example.com/file/no-extension/',
+      'content-type': 'text/plain',
+    };
+
+    const result = getFileViewFormat(file);
+
+    expect(result.icon).toEqual(FILE_FORMATS['text/plain'].icon);
+    expect(result.label).toEqual(FILE_FORMATS['text/plain'].format_name);
+  });
+
+  test('should handle case where URL is .pdf but content-type is text/plain', () => {
+    const file = {
+      filename: 'https://example.com/file/example.pdf',
+      'content-type': 'text/plain',
+    };
+
+    const result = getFileViewFormat(file);
+
+    // La funzione dovrebbe comunque dare priorità all'estensione ".pdf" rispetto al content-type "text/plain"
+    expect(result.icon).toEqual(FILE_EXTENSIONS.pdf.icon); // Verifica che l'icona PDF venga restituita
+    expect(result.label).toEqual(FILE_EXTENSIONS.pdf.format_name); // Verifica che il formato PDF venga restituito
+  });
+});


### PR DESCRIPTION
Prima
<img width="762" alt="image" src="https://github.com/user-attachments/assets/2e1accc9-924b-4de3-aee9-aef3416b7835" />

Dopo
<img width="502" alt="image" src="https://github.com/user-attachments/assets/bf1a4b5b-4969-4a23-b07a-82e0d4cb8494" />


Non chiaro perche' in caso di pdf si ritorni da backend text/plain, ma facendo affidamento sull'url ignoriamo anche questa casistica buffa.
Aggiunti i test per evitare regressioni, da portare con cherry su 11.x.x