### PR TITLE
fix: Table block translations

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -301,6 +301,11 @@ msgstr ""
 msgid "Hide all content types"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: Hide headers
+msgid "Hide headers"
+msgstr ""
+
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
@@ -413,6 +418,11 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 # defaultMessage: Luogo
 msgid "Luogo location filter"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Make the table sortable
+msgid "Make the table sortable"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
@@ -615,6 +625,16 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: Table block
+msgid "Table block"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Table color inverted
+msgid "Table color inverted"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
@@ -751,6 +771,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Video Gallery
 msgid "VideoGalleryBlock"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Visible only in view mode
+msgid "Visible only in view mode"
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -249,6 +249,11 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: Add border to inner columns
+msgid "Divide each row into separate cells"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Download
 msgid "Download"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -234,6 +234,11 @@ msgstr "Procedure details"
 msgid "Dimensione della mappa"
 msgstr "Map dimensions"
 
+#: overrideTranslations
+# defaultMessage: Add border to inner columns
+msgid "Divide each row into separate cells"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Download
 msgid "Download"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -286,6 +286,11 @@ msgstr "Hide"
 msgid "Hide all content types"
 msgstr "Hide all content types"
 
+#: overrideTranslations
+# defaultMessage: Hide headers
+msgid "Hide headers"
+msgstr ""
+
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
@@ -398,6 +403,11 @@ msgstr "Place"
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 # defaultMessage: Luogo
 msgid "Luogo location filter"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Make the table sortable
+msgid "Make the table sortable"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
@@ -600,6 +610,16 @@ msgstr "Some errors occured"
 msgid "Subscribe"
 msgstr "Subscribe"
 
+#: overrideTranslations
+# defaultMessage: Table block
+msgid "Table block"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Table color inverted
+msgid "Table color inverted"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
@@ -736,6 +756,11 @@ msgstr "Video"
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Video Gallery
 msgid "VideoGalleryBlock"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Visible only in view mode
+msgid "Visible only in view mode"
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -295,6 +295,11 @@ msgstr "Ocultar"
 msgid "Hide all content types"
 msgstr "Ocultar todos los tipos de contenido"
 
+#: overrideTranslations
+# defaultMessage: Hide headers
+msgid "Hide headers"
+msgstr ""
+
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
@@ -408,6 +413,11 @@ msgstr "Lugar"
 # defaultMessage: Luogo
 msgid "Luogo location filter"
 msgstr "Lugar"
+
+#: overrideTranslations
+# defaultMessage: Make the table sortable
+msgid "Make the table sortable"
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Medio
@@ -609,6 +619,16 @@ msgstr "Se produjeron algunos errores."
 msgid "Subscribe"
 msgstr "Suscribir"
 
+#: overrideTranslations
+# defaultMessage: Table block
+msgid "Table block"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Table color inverted
+msgid "Table color inverted"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
@@ -746,6 +766,11 @@ msgstr "Vídeo"
 # defaultMessage: Video Gallery
 msgid "VideoGalleryBlock"
 msgstr "Galería de Vídeos"
+
+#: overrideTranslations
+# defaultMessage: Visible only in view mode
+msgid "Visible only in view mode"
+msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
 # defaultMessage: You are trying to access a protected resource, please {login} first.

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -243,6 +243,11 @@ msgstr "Detalles del procedimiento"
 msgid "Dimensione della mappa"
 msgstr "Tamaño de mapa"
 
+#: overrideTranslations
+# defaultMessage: Add border to inner columns
+msgid "Divide each row into separate cells"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Download
 msgid "Download"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -303,6 +303,11 @@ msgstr "Cacher"
 msgid "Hide all content types"
 msgstr "Masquer tous les types de contenu"
 
+#: overrideTranslations
+# defaultMessage: Hide headers
+msgid "Hide headers"
+msgstr ""
+
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
@@ -415,6 +420,11 @@ msgstr "Lieu"
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 # defaultMessage: Luogo
 msgid "Luogo location filter"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Make the table sortable
+msgid "Make the table sortable"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
@@ -617,6 +627,16 @@ msgstr "Des erreurs se sont produites"
 msgid "Subscribe"
 msgstr "S'abonner"
 
+#: overrideTranslations
+# defaultMessage: Table block
+msgid "Table block"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Table color inverted
+msgid "Table color inverted"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
@@ -753,6 +773,11 @@ msgstr "Vidéo"
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Video Gallery
 msgid "VideoGalleryBlock"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Visible only in view mode
+msgid "Visible only in view mode"
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -251,6 +251,11 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: Add border to inner columns
+msgid "Divide each row into separate cells"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Download
 msgid "Download"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -234,6 +234,11 @@ msgstr "Dettagli procedimento"
 msgid "Dimensione della mappa"
 msgstr "Dimensione della mappa"
 
+#: overrideTranslations
+# defaultMessage: Add border to inner columns
+msgid "Divide each row into separate cells"
+msgstr "Mostra i margini delle colonne"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 # defaultMessage: Download
 msgid "Download"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -286,6 +286,11 @@ msgstr "Nascondi"
 msgid "Hide all content types"
 msgstr "Nascondi tutti i tipi di contenuto"
 
+#: overrideTranslations
+# defaultMessage: Hide headers
+msgid "Hide headers"
+msgstr "Nascondi le intestazioni"
+
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
@@ -399,6 +404,11 @@ msgstr "Luogo"
 # defaultMessage: Luogo
 msgid "Luogo location filter"
 msgstr "Luogo"
+
+#: overrideTranslations
+# defaultMessage: Make the table sortable
+msgid "Make the table sortable"
+msgstr "Rendi la tabella ordinabile"
 
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
 # defaultMessage: Medio
@@ -600,6 +610,16 @@ msgstr "Sono occorsi degli errori"
 msgid "Subscribe"
 msgstr "Iscriviti"
 
+#: overrideTranslations
+# defaultMessage: Table block
+msgid "Table block"
+msgstr "Blocco Tabella"
+
+#: overrideTranslations
+# defaultMessage: Table color inverted
+msgid "Table color inverted"
+msgstr "Inverti i colori della tabella"
+
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
@@ -737,6 +757,11 @@ msgstr "Video"
 # defaultMessage: Video Gallery
 msgid "VideoGalleryBlock"
 msgstr "Video gallery"
+
+#: overrideTranslations
+# defaultMessage: Visible only in view mode
+msgid "Visible only in view mode"
+msgstr "Visibile solamente in modalità visualizzazione"
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
 # defaultMessage: You are trying to access a protected resource, please {login} first.

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-12-12T10:59:56.243Z\n"
+"POT-Creation-Date: 2025-01-03T12:01:53.263Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -288,6 +288,11 @@ msgstr ""
 msgid "Hide all content types"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: Hide headers
+msgid "Hide headers"
+msgstr ""
+
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
@@ -400,6 +405,11 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 # defaultMessage: Luogo
 msgid "Luogo location filter"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Make the table sortable
+msgid "Make the table sortable"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar
@@ -602,6 +612,16 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: Table block
+msgid "Table block"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Table color inverted
+msgid "Table color inverted"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
@@ -738,6 +758,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/VideoGallery/Sidebar
 # defaultMessage: Video Gallery
 msgid "VideoGalleryBlock"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Visible only in view mode
+msgid "Visible only in view mode"
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-01-03T12:01:53.263Z\n"
+"POT-Creation-Date: 2025-01-03T12:21:33.430Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -234,6 +234,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/mapTemplate
 # defaultMessage: Dimensione della mappa
 msgid "Dimensione della mappa"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: Add border to inner columns
+msgid "Divide each row into separate cells"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -99,4 +99,25 @@ defineMessages({
     defaultMessage:
       'As per the official information architecture outlined in measure 1.4.1, all forms must be properly uploaded in the designated section within Amministrazione > Documenti e Dati > Modulistica, and linked to the relevant service sheet. It is no longer possible to upload files and attachments directly into this container.',
   },
+  //table block
+  hideHeaders: {
+    id: 'Hide headers',
+    defaultMessage: 'Hide headers',
+  },
+  sortable: {
+    id: 'Make the table sortable',
+    defaultMessage: 'Make the table sortable',
+  },
+  sortableDescription: {
+    id: 'Visible only in view mode',
+    defaultMessage: 'Visible only in view mode',
+  },
+  inverted: {
+    id: 'Table color inverted',
+    defaultMessage: 'Table color inverted',
+  },
+  table_block: {
+    id: 'Table block',
+    defaultMessage: 'Table block',
+  },
 });

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -120,4 +120,8 @@ defineMessages({
     id: 'Table block',
     defaultMessage: 'Table block',
   },
+  divideRows: {
+    id: 'Divide each row into separate cells',
+    defaultMessage: 'Add border to inner columns',
+  },
 });


### PR DESCRIPTION
Aggiunte le traduzioni per il blocco tabella. 
E' stata fatta anche una pr su volto-slate per aggiungere le traduzioni in italiano che fin'ora mancavano (https://github.com/plone/volto/pull/6563)

<img width="1728" alt="Screenshot 2025-01-03 alle 13 12 21" src="https://github.com/user-attachments/assets/9176ab8c-2cc8-4f45-b655-cbb6a19f258d" />

(il nome del blocco nella sidebar "Table block" non si può tradurre perchè è scritto fisso nello schema)

us https://redturtle.tpondemand.com/entity/59841-blocco-tabella-le-opzioni-della-sidebar