### PR TITLE
fix: fixed event search results

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+- Sistemato un bug che non restituiva i risultati di ricerca nel blocco di Ricerca Eventi anche se il flag "Di default, mostra i risultati" era attivo. Risolto problema che mandava in errore il blocco alla creazione di esso.
+
+
 ## Versione 7.33.2 (09/12/2024)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/Body.jsx
@@ -64,13 +64,6 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
     );
   });
 
-  const firstLoading = useSelector((state) => {
-    return (
-      !state.querystringsearch?.subrequests?.[id + '_events_search']?.loading &&
-      !state.querystringsearch?.subrequests?.[id + '_events_search']?.loaded
-    );
-  });
-
   const resultsRef = createRef();
 
   const doRequest = (page = currentPage) => {
@@ -116,7 +109,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
   // Se cambia uno dei tre filtri resetto lo stato dei filtri
   useEffect(() => {
     dispatchFilter({ type: 'reset' });
-    if (data.show_default_results && firstLoading) {
+    if (data.show_default_results) {
       doRequest();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/ItaliaTheme/Blocks/EventSearch/FiltersConfig.js
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/FiltersConfig.js
@@ -6,7 +6,7 @@ import DefaultFilters from 'design-comuni-plone-theme/components/ItaliaTheme/Blo
   componente da customizzare nel proprio sito per modificare/aggiungere tipologie di Filtri
   ***
  */
-const FiltersConfig = ({ data }) => {
+const FiltersConfig = (props) => {
   // const subsite = useSelector((state) => state.subsite?.data);
   const defaultFilters = DefaultFilters();
 


### PR DESCRIPTION
[BUG63803](https://redturtle.tpondemand.com/entity/63803-il-blocco-ricerca-eventi-non-si)
<img width="1295" alt="Screenshot 2025-01-15 alle 15 57 05" src="https://github.com/user-attachments/assets/363aa217-20b8-4970-a33e-165f07d085d5" />

