### PR TITLE
fix: changed styles of headings for text editor in cts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Impostando degli heading all'interno delle sezioni di testo nei vari CT, gli stili sono ora coerenti con l'ordine corretto dei titoli utilizzati.
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
 ## Versione 11.26.3 (15/01/2025)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Widgets/_blocksWidget.scss
+++ b/src/theme/ItaliaTheme/Widgets/_blocksWidget.scss
@@ -14,3 +14,39 @@
     font-family: $font-family-sans-serif;
   }
 }
+
+// <h> styles for text editor content in CTs
+
+#main-content-section.it-page-sections-container .richtext-blocks {
+  h2 {
+    font-size: 1.555rem;
+    line-height: 1.428;
+    font-weight: 600;
+  }
+
+  h3 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+    font-weight: 600;
+  }
+
+  h4 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+    font-weight: 600;
+    color: $gray-600;
+  }
+
+  h5 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+    font-weight: 600;
+    color: $gray-500;
+  }
+
+  h6 {
+    font-size: 1.2rem;
+    line-height: 1.15;
+    font-weight: 400;
+  }
+}


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/64168-gestione-h1-h6split

The styles of the headings applied to text added by text editor in the cts were not cohesive with the correct semantic heading order. i.e. by putting the correct order of headings (h2 > h3) the h3 heading was bigger and bolder than the h2.
To guarantee a correct order even from a style pov and to prevent users from using the wrong semantic order to have a pleasant effect, the styles of the headings in the text editor sections of cts have been improved

all styles are accessibility-safe