### PR TITLE
fix: improved alignment of topic links in card with image

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Gli argomenti nelle card con immagine sono allineati correttamente.
+
 ## Versione 11.26.3 (15/01/2025)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
@@ -151,7 +151,7 @@ const CardWithImageDefault = (props) => {
             <BlockExtraTags {...props} item={item} itemIndex={index} />
             {topics?.length > 0 && (
               <div
-                className={cx('', {
+                className={cx('card-with-image-additional-links', {
                   'mb-3': eventRecurrenceMore,
                 })}
               >

--- a/src/theme/ItaliaTheme/Blocks/_cardWithImage.scss
+++ b/src/theme/ItaliaTheme/Blocks/_cardWithImage.scss
@@ -13,6 +13,10 @@
       display: inline-block;
     }
 
+    .card-with-image-additional-links a {
+      width: auto;
+    }
+
     .img-responsive-wrapper {
       width: inherit;
 


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/59638-allineamento-argomenti-in-card-con-immagine