### PR TITLE
fix: listing template attachments download and display file

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (x/x/x)
+
+### Fix
+
+- sistemata l'opzione "Mostra i PDF in anteprima" dell template 'Allegati' del blocco elenco, perchè non aveva alcun effetto.
+
 ## Versione 11.26.3 (15/01/2025)
 
 ### Fix

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,11 +43,6 @@
 
 ## Versione x.x.x (x/x/x)
 
-### Fix
-
-- sistemata l'opzione "Mostra i PDF in anteprima" dell template 'Allegati' del blocco elenco, perchè non aveva alcun effetto.
-## Versione X.X.X (dd/mm/yyyy)
-
 ### Migliorie
 
 - Nei blocchi elenco, gli stili dei testi nelle card che richiamano un CT persona sono conformi alle card che rappresentano gli altri CT.
@@ -61,6 +56,7 @@
 
 - I bottoni del menu nel pannello di controllo dei cookies visualizzano correttamente le icone.
 - Gli argomenti nelle card con immagine sono allineati correttamente.
+- Sistemata l'opzione "Mostra i PDF in anteprima" dell template "Allegati" del blocco elenco, perchè non aveva alcun effetto.
 
 ## Versione 11.26.3 (15/01/2025)
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -3817,7 +3817,7 @@ msgstr ""
 #: config/Blocks/ListingOptions/attachmentCardTemplate
 # defaultMessage: Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.
 msgid "show_pdf_desc"
-msgstr "Allows you to open the preview of all the PDFs in this list in a separate tab otherwise they will be downloaded."
+msgstr "Allows preview of all PDF files in this list to be opened in a separate tab. If not set, PDF files are downloaded instead."
 
 #: config/Blocks/ListingOptions/attachmentCardTemplate
 # defaultMessage: Mostra i PDF in anteprima

--- a/src/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/AttachmentCardTemplate.jsx
@@ -52,16 +52,18 @@ const AttachmentCardTemplate = ({
           {items.map((item, index) => {
             let itemUrl = { ...item };
             //la parte qui sotto commentata non serve perchè gestisce gia tutto UniversalLink e in view si vedrebbe /@@download/file duplicato nell url
-            // if (item['@type'] === 'File') {
-            //   itemUrl = {
-            //     ...item,
-            //     file: item,
-            //     '@id':
-            //       show_pdf_preview && item?.mime_type === 'application/pdf'
-            //         ? item?.['@id'] + '/@@display-file/file'
-            //         : item?.['@id'] + '/@@download/file',
-            //   };
-            // }
+            if (
+              item['@type'] === 'File' &&
+              item?.mime_type === 'application/pdf'
+            ) {
+              itemUrl = {
+                ...item,
+                file: item,
+                '@id': show_pdf_preview
+                  ? item?.['@id'] + '/@@display-file/file'
+                  : item?.['@id'] + '/@@download/file',
+              };
+            }
 
             return (
               <Card
@@ -86,6 +88,7 @@ const AttachmentCardTemplate = ({
                       item={!isEditMode ? itemUrl : null}
                       href={isEditMode ? '#' : null}
                       data-element={id_lighthouse}
+                      download={!show_pdf_preview}
                     >
                       {item.title || item.id}
                     </UniversalLink>

--- a/src/config/Blocks/ListingOptions/attachmentCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/attachmentCardTemplate.js
@@ -10,7 +10,7 @@ const messages = defineMessages({
   show_pdf_desc: {
     id: 'show_pdf_desc',
     defaultMessage:
-      "Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata altrimenti vengono scaricati.",
+      "Permette di aprire l'anteprima di tutti i PDF di questo elenco in una tab separata. Se non impostato, i PDF vengono scaricati.",
   },
 });
 

--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -7,6 +7,7 @@
  * - aggiunto title informativo per link esterni
  * - aggiunta la dimensione del file se il link punta a un file (enhanced_link_infos)
  * - aggiunto il parametro hideFileFormat per nascondere il formato del file dall'enhance link
+ * - aggiunta la condizione su @@display-file e @download-file per gestire i casi in cui questi parametri vengono imposti a monte
  */
 
 import React from 'react';
@@ -86,18 +87,21 @@ const UniversalLink = ({
       }
 
       //case: item of type 'File'
-      if (
-        !token &&
-        config.settings.downloadableObjects.includes(item['@type'])
-      ) {
-        url = `${url}/@@download/file`;
-      }
+      if (!url.includes('@@download') && !url.includes('@@display-file')) {
+        //se non è gia stato aggiunto il suffisso per il download nell'@id dell'item
+        if (
+          !token &&
+          config.settings.downloadableObjects.includes(item['@type'])
+        ) {
+          url = `${url}/@@download/file`;
+        }
 
-      if (
-        !token &&
-        config.settings.viewableInBrowserObjects.includes(item['@type'])
-      ) {
-        url = `${url}/@@display-file/file`;
+        if (
+          !token &&
+          config.settings.viewableInBrowserObjects.includes(item['@type'])
+        ) {
+          url = `${url}/@@display-file/file`;
+        }
       }
     }
   }


### PR DESCRIPTION
segnalato dalla RER. Us. 64372

Nel template del blocco elenco 'Allegati' l'opzione "Mostra i PDF in anteprima" non aveva alcun effetto, i file venivano sempre scaricati.

Ora, con le modifiche fatte, i file pdf vengono aperti in anteprima se c'è il flag su quella opzione.
Per tutti gli altri file, continuano ad essere valide le regole precedenti, ovvero quelle definite dal config per ogni tipo di file.

Aggiunta una condizione in UniversalLink per aggiungere i parametri @@Download o @@display-file solo se non sono già presenti nell'url