### PR TITLE
fix: changed cookies menu button icon

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- I bottoni del menu nel pannello di controllo dei cookies visualizzano correttamente le icone.
+
 ## Versione 11.26.3 (15/01/2025)
 
 ### Fix

--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -298,6 +298,27 @@ body.cms-ui {
     }
   }
 
+  //cookie banner icons
+  // replaced icon code with left and right as they actually render correctly
+  // and rotated the icon
+  &.section-gdpr-cookie-settings {
+    .cookies-widget .move-buttons {
+      i.icon.arrow.up {
+        transform: rotate(90deg);
+        &::before {
+          content: '\e911';
+        }
+      }
+
+      i.icon.arrow.down {
+        transform: rotate(90deg);
+        &::before {
+          content: '\e905';
+        }
+      }
+    }
+  }
+
   .sidebar-container .object-listing,
   .icon-align-name {
     svg.icon {


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/62342-sistemare-pannello-di-controllo-cookie-banner

semantic-ui-react icons can't render up and down arrows (even though the icon code inside the content css property is correct, by looking at fontawesome), but they can render left and right. I replaced the icon code for those icons and then rotated the icon.
(the same logic has been applied to the control panel for the menu and secondary menu)