### PR TITLE
fix: grid block on mobile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (xx/xx/xxxx)
+
+### Fix
+
+- Sistemata la visualizzazione del blocco griglia su mobile: disposti verticalmente ogni blocco della griglia
+
 ## Versione 11.26.3 (15/01/2025)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
+++ b/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
@@ -89,6 +89,15 @@
       }
     }
   }
+
+  @media (max-width: #{map-get($grid-breakpoints, md)}) {
+    > .row {
+      gap: 1em;
+      > .col {
+        flex: 1 0 100%;
+      }
+    }
+  }
 }
 
 body.cms-ui.has-toolbar.has-sidebar {


### PR DESCRIPTION
Disposti verticalmente le colonne di un blocco griglia su mobile. 

Richiesto dalla RER.


come era prima su mobile: 
<img width="574" alt="Screenshot 2025-02-03 alle 12 04 49" src="https://github.com/user-attachments/assets/b7bb85eb-17ab-4468-8db3-0bac7617b722" />


come è ora su mobile: 
<img width="456" alt="Screenshot 2025-02-03 alle 12 09 39" src="https://github.com/user-attachments/assets/ea0f58ed-9cfa-485e-a5e0-65f99dfa7762" />

