### PR TITLE
fix: a11y of Contacts, Icons, and Numbers block

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (xx/xx/xxxx)
+
+### Fix
+
+- a11y - Migliorata l'accessibilità in edit dei blocchi Contatti, Icone, Numeri
+
 ## Versione 11.26.3 (15/01/2025)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock.jsx
@@ -52,24 +52,13 @@ class EditBlock extends SubblockEdit {
     // eslint-disable-next-line no-unused-expressions
     this.contact_item_ref?.current?.addEventListener('keydown', (e) => {
       if (e.keyCode === 13) {
-        if (!(this.state.focusOn === 'text')) {
-          this.setState({ focusOn: 'text' });
+        if (!(this.state.focusOn === 'title')) {
+          this.setState({ focusOn: 'title' });
         }
       }
     });
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!this.props.selected && nextProps.focusOn) {
-      this.props.onSelectBlock(this.props.block);
-    }
-
-    if (nextProps.selected && !this.state.focusOn) {
-      this.setState({ focusOn: 'title' });
-    } else if (!nextProps.selected) {
-      this.setState({ focusOn: null });
-    }
-  }
   /**
    * Render method.
    * @method render
@@ -95,6 +84,7 @@ class EditBlock extends SubblockEdit {
               {/* eslint-disable */}
               <TextEditorWidget
                 {...this.props}
+                index={this.props.blockIndex}
                 key="title"
                 showToolbar={false}
                 data={this.props.data}
@@ -125,6 +115,7 @@ class EditBlock extends SubblockEdit {
             <div className="contact-text">
               <TextEditorWidget
                 {...this.props}
+                index={this.props.blockIndex}
                 key="text"
                 data={this.props.data}
                 fieldName="text"
@@ -135,7 +126,9 @@ class EditBlock extends SubblockEdit {
                   this.props.onChangeBlock(this.props.index, _data);
                 }}
                 selected={this.props.selected && this.state.focusOn === 'text'}
-                setSelected={(f) => this.setState({ focusOn: f })}
+                setSelected={(f) => {
+                  this.setState({ focusOn: f });
+                }}
                 focusPrevField={() => {
                   this.setState({ focusOn: 'title' });
                 }}
@@ -151,6 +144,7 @@ class EditBlock extends SubblockEdit {
               </div>
               <TextEditorWidget
                 {...this.props}
+                index={this.props.blockIndex}
                 key="tel"
                 data={this.props.data}
                 fieldName="tel"
@@ -177,6 +171,7 @@ class EditBlock extends SubblockEdit {
               </div>
               <TextEditorWidget
                 {...this.props}
+                index={this.props.blockIndex}
                 key="email"
                 wrapClass="email"
                 data={this.props.data}
@@ -188,7 +183,14 @@ class EditBlock extends SubblockEdit {
                 placeholder={this.props.intl.formatMessage(
                   messages.textPlaceholder,
                 )}
-                setSelected={(f) => this.setState({ focusOn: f })}
+                setSelected={(f) => {
+                  if (!this.props.selected) {
+                    //a11y - per il focus del blocco da tastiera con navigazione inversa
+                    this.props.onSubblockChangeFocus(this.props.index);
+                    this.props.onSelectBlock(this.props.block);
+                  }
+                  this.setState({ focusOn: f });
+                }}
                 focusPrevField={() => {
                   this.setState({ focusOn: 'tel' });
                 }}

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
@@ -118,7 +118,6 @@ class Edit extends SubblocksEdit {
     if (__SERVER__) {
       return <div />;
     }
-    console.log(this.props);
 
     return (
       <div className="public-ui" tabIndex="-1" ref={this.nodeF}>

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
@@ -50,7 +50,10 @@ class Edit extends SubblocksEdit {
   UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.selected) {
       if (!this.props.selected) {
-        this.setState({ selectedField: 'title' });
+        if (!this.state.selectedField && this.state.subIndexSelected < 0) {
+          //a11y - test subIndexSelected<0 per gestire il focus con navigazione da tastiera al contrario (dal blocco successivo a questo blocco)
+          this.setState({ selectedField: 'title' });
+        }
       }
     } else {
       this.setState({ selectedField: null });
@@ -115,6 +118,7 @@ class Edit extends SubblocksEdit {
     if (__SERVER__) {
       return <div />;
     }
+    console.log(this.props);
 
     return (
       <div className="public-ui" tabIndex="-1" ref={this.nodeF}>
@@ -122,6 +126,8 @@ class Edit extends SubblocksEdit {
           className={`full-width section bg-${
             this.props.data.bg_color ?? 'primary'
           } py-5`}
+          role="form"
+          aria-label={this.props.blocksConfig[this.props.type].title}
         >
           <Container className="px-md-4">
             <div className="block-header">
@@ -134,9 +140,12 @@ class Edit extends SubblocksEdit {
                   fieldName="title"
                   selected={this.state.selectedField === 'title'}
                   placeholder={this.props.intl.formatMessage(messages.title)}
-                  onSelectBlock={() => {}}
                   setSelected={(f) => {
                     this.setState({ selectedField: f, subIndexSelected: -1 });
+                    if (!this.props.selected) {
+                      //a11y - per il focus del blocco da tastiera
+                      this.props.onSelectBlock(this.props.block);
+                    }
                   }}
                   focusNextField={() => {
                     this.setState({ selectedField: 'description' });
@@ -154,7 +163,6 @@ class Edit extends SubblocksEdit {
                   placeholder={this.props.intl.formatMessage(
                     messages.description,
                   )}
-                  onSelectBlock={() => {}}
                   setSelected={(f) => {
                     this.setState({ selectedField: f, subIndexSelected: -1 });
                   }}
@@ -182,12 +190,11 @@ class Edit extends SubblocksEdit {
                       {...this.props}
                       data={subblock}
                       index={subindex}
+                      blockIndex={this.props.index}
                       selected={this.isSubblockSelected(subindex)}
                       {...this.subblockProps}
-                      openObjectBrowser={this.props.openObjectBrowser}
-                      onSubblockChangeFocus={this.onSubblockChangeFocus}
                       onChangeFocus={this.onSubblockChangeFocus}
-                      isLast={this.state.subblocks.length - 1 === subindex}
+                      isLast={subindex === this.state.subblocks.length - 1}
                       isFirst={subindex === 0}
                       onFocusPreviousBlock={() => {
                         this.setState({

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock.jsx
@@ -149,6 +149,11 @@ class EditBlock extends SubblockEdit {
                 fieldName="text"
                 selected={this.props.selected && this.state.focusOn === 'text'}
                 setSelected={(f) => {
+                  if (!this.props.selected) {
+                    //a11y - per il focus del blocco da tastiera con navigazione inversa
+                    this.props.onSubblockChangeFocus(this.props.index);
+                    this.props.onSelectBlock(this.props.block);
+                  }
                   this.setState({ focusOn: f });
                 }}
                 onChangeBlock={(block, _data) => {

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock.jsx
@@ -54,13 +54,13 @@ class EditBlock extends SubblockEdit {
 
   componentDidMount() {
     // eslint-disable-next-line no-unused-expressions
-    this.subblock_ref?.current?.addEventListener('keydown', (e) => {
-      if (e.keyCode === 13) {
-        if (!(this.state.focusOn === 'text')) {
-          this.setState({ focusOn: 'text' });
-        }
-      }
-    });
+    // this.subblock_ref?.current?.addEventListener('keydown', (e) => {
+    //   if (e.keyCode === 13) {
+    //     if (!(this.state.focusOn === 'text')) {
+    //       this.setState({ focusOn: 'text' });
+    //     }
+    //   }
+    // });
   }
   /**
    * Render method.

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Edit.jsx
@@ -52,7 +52,10 @@ class Edit extends SubblocksEdit {
   UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.selected) {
       if (!this.props.selected) {
-        this.setState({ selectedField: 'title' });
+        if (!this.state.selectedField && this.state.subIndexSelected < 0) {
+          //a11y - test subIndexSelected<0 per gestire il focus con navigazione da tastiera al contrario (dal blocco successivo a questo blocco)
+          this.setState({ selectedField: 'title' });
+        }
       }
     } else {
       this.setState({ selectedField: null });
@@ -121,7 +124,11 @@ class Edit extends SubblocksEdit {
 
     return (
       <div className="public-ui" tabIndex="-1" ref={this.nodeF}>
-        <div className="full-width section py-5">
+        <div
+          className="full-width section py-5"
+          role="form"
+          aria-label={this.props.blocksConfig[this.props.type].title}
+        >
           {this.props.data.background?.[0] ? (
             <div className="background-image">
               <Image
@@ -151,6 +158,10 @@ class Edit extends SubblocksEdit {
                       selectedField: f,
                       subIndexSelected: -1,
                     });
+                    if (!this.props.selected) {
+                      //a11y - per il focus del blocco da tastiera
+                      this.props.onSelectBlock(this.props.block);
+                    }
                   }}
                   placeholder={this.props.intl.formatMessage(messages.title)}
                   focusNextField={() => {
@@ -200,7 +211,10 @@ class Edit extends SubblocksEdit {
                       isLast={subindex === this.state.subblocks?.length - 1}
                       openObjectBrowser={this.props.openObjectBrowser}
                       onFocusPreviousBlock={() => {
-                        this.setState({ selectedField: 'description' });
+                        this.setState({
+                          selectedField: 'description',
+                          subIndexSelected: -1,
+                        });
                       }}
                     />
                   </Col>

--- a/src/components/ItaliaTheme/Blocks/NumbersBlock/Block/EditBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/NumbersBlock/Block/EditBlock.jsx
@@ -80,9 +80,6 @@ class EditBlock extends SubblockEdit {
                 selected={this.props.selected && this.state.focusOn === 'title'}
                 setSelected={(f) => {
                   this.setState({ focusOn: f });
-                  if (!f) {
-                    this.props.onSubblockChangeFocus(-1);
-                  }
                 }}
                 block={this.props.block}
                 index={this.props.blockIndex}
@@ -120,11 +117,6 @@ class EditBlock extends SubblockEdit {
               fieldName="text"
               selected={this.props.selected && this.state.focusOn === 'text'}
               setSelected={(f) => {
-                this.setState({ focusOn: f });
-                if (!f) {
-                  this.props.onSubblockChangeFocus(-1);
-                }
-
                 if (!this.props.selected) {
                   //a11y - per il focus del blocco da tastiera con navigazione inversa
                   this.props.onSubblockChangeFocus(this.props.index);

--- a/src/components/ItaliaTheme/Blocks/NumbersBlock/Block/EditBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/NumbersBlock/Block/EditBlock.jsx
@@ -124,6 +124,13 @@ class EditBlock extends SubblockEdit {
                 if (!f) {
                   this.props.onSubblockChangeFocus(-1);
                 }
+
+                if (!this.props.selected) {
+                  //a11y - per il focus del blocco da tastiera con navigazione inversa
+                  this.props.onSubblockChangeFocus(this.props.index);
+                  this.props.onSelectBlock(this.props.block);
+                }
+                this.setState({ focusOn: f });
               }}
               block={this.props.block}
               index={this.props.blockIndex}

--- a/src/components/ItaliaTheme/Blocks/NumbersBlock/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/NumbersBlock/Edit.jsx
@@ -54,7 +54,10 @@ class Edit extends SubblocksEdit {
   UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.selected) {
       if (!this.props.selected) {
-        this.setState({ selectedField: 'title' });
+        if (!this.state.selectedField && this.state.subIndexSelected < 0) {
+          //a11y - test subIndexSelected<0 per gestire il focus con navigazione da tastiera al contrario (dal blocco successivo a questo blocco)
+          this.setState({ selectedField: 'title' });
+        }
       }
     } else {
       this.setState({ selectedField: null });
@@ -122,7 +125,11 @@ class Edit extends SubblocksEdit {
 
     return (
       <div className="public-ui" tabIndex="-1" ref={this.nodeF}>
-        <div className="full-width section py-5">
+        <div
+          className="full-width section py-5"
+          role="form"
+          aria-label={this.props.blocksConfig[this.props.type].title}
+        >
           {this.props.data?.background?.[0] ? (
             <div
               className="background-image"
@@ -186,7 +193,14 @@ class Edit extends SubblocksEdit {
                         fieldName="title"
                         selected={this.state.selectedField === 'title'}
                         setSelected={(f) => {
-                          this.setState({ selectedField: f });
+                          this.setState({
+                            selectedField: f,
+                            subIndexSelected: -1,
+                          });
+                          if (!this.props.selected) {
+                            //a11y - per il focus del blocco da tastiera
+                            this.props.onSelectBlock(this.props.block);
+                          }
                         }}
                         onChangeBlock={this.props.onChangeBlock}
                         placeholder={this.props.intl.formatMessage(

--- a/src/theme/ItaliaTheme/Blocks/_accordion.scss
+++ b/src/theme/ItaliaTheme/Blocks/_accordion.scss
@@ -43,10 +43,6 @@ $accordion-icon-color: #7fb2e5;
             top: -7px;
             right: 0;
             left: unset;
-
-            &:focus {
-              outline: 1px solid $focus-outline-color;
-            }
           }
 
           .accordion-header {

--- a/src/theme/ItaliaTheme/Blocks/_contacts.scss
+++ b/src/theme/ItaliaTheme/Blocks/_contacts.scss
@@ -3,18 +3,7 @@
     height: auto;
   }
 
-  .ui.basic.button.delete-button {
-    padding: 0.5rem;
-    text-align: center;
-
-    svg:not(:hover) {
-      fill: #fff !important;
-    }
-
-    &:hover {
-      border-radius: 100%;
-    }
-  }
+  @include blocks-with-bg-edit-buttons();
 
   .bg-primary {
     .block-header {
@@ -91,7 +80,6 @@
     }
 
     .contact-title {
-
       margin-bottom: 1rem;
       font-size: 1.35rem;
       font-weight: bold;

--- a/src/theme/ItaliaTheme/Blocks/_contacts.scss
+++ b/src/theme/ItaliaTheme/Blocks/_contacts.scss
@@ -64,10 +64,6 @@
     .card-wrapper {
       height: 100%;
     }
-
-    .ui.basic.button.delete-button {
-      padding: 0.36rem;
-    }
   }
 
   .button.add-element {

--- a/src/theme/ItaliaTheme/Blocks/_ctaBlock.scss
+++ b/src/theme/ItaliaTheme/Blocks/_ctaBlock.scss
@@ -133,12 +133,5 @@
 }
 
 .block.cta_block {
-  .ui.basic.button.delete-button {
-    color: #fff !important;
-
-    &:hover,
-    &:focus {
-      color: #000 !important;
-    }
-  }
+  @include blocks-with-bg-edit-buttons();
 }

--- a/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -3,21 +3,7 @@
     height: auto;
   }
 
-  .ui.basic.button.delete-button {
-    top: -0.2rem;
-    padding: 0.2rem;
-    border-radius: 100%;
-    line-height: 1rem;
-
-    svg:not(:hover) {
-      fill: #fff !important;
-    }
-
-    &:hover,
-    &:active {
-      background-color: #fff !important;
-    }
-  }
+  @include blocks-with-bg-edit-buttons();
 
   .background-image {
     position: absolute;

--- a/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -87,41 +87,6 @@
       transform: unset;
     }
 
-    .dragsubblock,
-    .ui.basic.button.delete-button {
-      z-index: 3;
-      padding: 0.3rem;
-      border-radius: 100%;
-      background-color: #8bb3b5 !important;
-      line-height: 1rem;
-
-      svg:not(:hover) {
-        fill: #fff !important;
-      }
-
-      &:hover,
-      &:active {
-        background-color: #a4dee1 !important;
-
-        svg {
-          fill: #000 !important;
-        }
-      }
-    }
-
-    .dragsubblock {
-      top: -0.75rem;
-      left: -0.55rem;
-    }
-
-    .ui.basic.button.delete-button {
-      top: -0.7rem;
-      width: unset;
-      height: unset;
-      padding: 0.36rem;
-      text-align: center;
-    }
-
     .link-form-container {
       .ui.input {
         > input {

--- a/src/theme/ItaliaTheme/Blocks/_numbers.scss
+++ b/src/theme/ItaliaTheme/Blocks/_numbers.scss
@@ -5,21 +5,7 @@
     height: auto;
   }
 
-  > .ui.basic.button.delete-button {
-    top: -0.2rem;
-    padding: 0.2rem;
-    border-radius: 100%;
-    line-height: 1rem;
-
-    svg:not(:hover) {
-      fill: #fff !important;
-    }
-
-    &:hover,
-    &:active {
-      background-color: #fff !important;
-    }
-  }
+  @include blocks-with-bg-edit-buttons();
 
   .background-image {
     position: absolute;

--- a/src/theme/ItaliaTheme/Blocks/_subblocks-edit.scss
+++ b/src/theme/ItaliaTheme/Blocks/_subblocks-edit.scss
@@ -26,7 +26,9 @@
 
   .ui.basic.button.delete-button {
     &:hover,
-    &:active {
+    &:active,
+    &:focus,
+    &:focus-within {
       background-color: #e40166 !important;
       color: #fff;
 

--- a/src/theme/_mixins.scss
+++ b/src/theme/_mixins.scss
@@ -5,3 +5,16 @@
 @mixin margin-size($key, $value) {
   #{$key}: calc($value / 18) + em;
 }
+
+@mixin blocks-with-bg-edit-buttons {
+  > .ui.basic.button.delete-button {
+    padding: 0.35rem;
+    text-align: center;
+    border-radius: 100%;
+    top: -0.25rem;
+
+    &:not(:hover):not(:focus):not(:focus-within) {
+      color: #fff !important;
+    }
+  }
+}


### PR DESCRIPTION
Migliorata l'accessibilità in edit (navigazione da tastiera) dei blocchi Contatti, Icone, Numeri

Allego video del risultato ottenuto con la navigazione da tastiera. 
Prima di questi fix non venivano correttamente selezionati i blocchi quando si passava da un blocco ad un altro. 


https://github.com/user-attachments/assets/7667a764-15ce-4109-98e2-62fb37905fa6







Richiesto dalla RER