### PR TITLE
fix: a11y accordion block

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (x/x/x)
+
+### Migliorie
+
+- a11y - migliorata l'accessibilità nel blocco Accordion
+
 ## Versione 11.26.5 (06/02/2025)
 
 ### Migliorie

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,7 @@
 
 ### Migliorie
 
-- a11y - migliorata l'accessibilità nel blocco Accordion
+- Migliorata l'accessibilità del blocco Accordion.
 
 ## Versione 11.26.5 (06/02/2025)
 

--- a/src/components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock.jsx
@@ -66,6 +66,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
           id={`content-${id}-${index}`}
           role="region"
           aria-labelledby={`${id}-${index}`}
+          hidden={!isOpen}
         >
           <div className="accordion-inner" onFocus={toggle()}>
             <TextBlockView id={id} data={{ value: data.text }} />


### PR DESCRIPTION
Durante un'analisi di a11y su io-sanità è venuto fuori questo fix da fare che ripropongo anche qui. 

Se nel testo dell'accordion ci sono dei link, questi sono navigabili da tastiera anche quando l'accordion è chiuso, e non deve poter succedere. 

Questo fix risolve il problema