### PR TITLE
fix: rollback label selectinput

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Condizione per la Label per i select ripristinata.
+
 ## Versione 11.26.5 (06/02/2025)
 
 ### Migliorie

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -348,7 +348,7 @@ const SelectInput = ({
         isMulti={isMulti}
         isClearable={isClearable}
         aria-label={labelDefined}
-        aria-labelledby={!label ? labelledby : null}
+        aria-labelledby={!label ? labelledby : undefined}
         aria-live="polite"
         ariaLiveMessages={getSelectAriaLiveMessages(intl)}
         noOptionsMessage={() =>

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -98,19 +98,18 @@ const messages = defineMessages({
   },
 });
 
-const SelectContainer = injectLazyLibs('reactSelect')(({
-  children,
-  ...props
-}) => {
-  const components = props.reactSelect.components;
-  return (
-    <div>
-      <components.SelectContainer {...props}>
-        {children}
-      </components.SelectContainer>
-    </div>
-  );
-});
+const SelectContainer = injectLazyLibs('reactSelect')(
+  ({ children, ...props }) => {
+    const components = props.reactSelect.components;
+    return (
+      <div>
+        <components.SelectContainer {...props}>
+          {children}
+        </components.SelectContainer>
+      </div>
+    );
+  },
+);
 
 SelectContainer.propTypes = {
   children: PropTypes.node,
@@ -326,6 +325,7 @@ const SelectInput = ({
   const Select = reactSelect.default;
   return (
     <div className="bootstrap-select-wrapper">
+      {label && <label>{label}</label>}
       <Select
         components={{
           MenuList,

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -98,18 +98,19 @@ const messages = defineMessages({
   },
 });
 
-const SelectContainer = injectLazyLibs('reactSelect')(
-  ({ children, ...props }) => {
-    const components = props.reactSelect.components;
-    return (
-      <div>
-        <components.SelectContainer {...props}>
-          {children}
-        </components.SelectContainer>
-      </div>
-    );
-  },
-);
+const SelectContainer = injectLazyLibs('reactSelect')(({
+  children,
+  ...props
+}) => {
+  const components = props.reactSelect.components;
+  return (
+    <div>
+      <components.SelectContainer {...props}>
+        {children}
+      </components.SelectContainer>
+    </div>
+  );
+});
 
 SelectContainer.propTypes = {
   children: PropTypes.node,
@@ -325,7 +326,7 @@ const SelectInput = ({
   const Select = reactSelect.default;
   return (
     <div className="bootstrap-select-wrapper">
-      {label && <label>{label}</label>}
+      {label && <label htmlFor={id}>{label}</label>}
       <Select
         components={{
           MenuList,
@@ -347,7 +348,7 @@ const SelectInput = ({
         isMulti={isMulti}
         isClearable={isClearable}
         aria-label={labelDefined}
-        aria-labelledby={labelledby}
+        aria-labelledby={!label ? labelledby : ''}
         aria-live="polite"
         ariaLiveMessages={getSelectAriaLiveMessages(intl)}
         noOptionsMessage={() =>

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -326,7 +326,7 @@ const SelectInput = ({
   const Select = reactSelect.default;
   return (
     <div className="bootstrap-select-wrapper">
-      {label && <label htmlFor={!labelledby?id:null}>{label}</label>}
+      {label && <label htmlFor={!labelledby ? id : undefined}>{label}</label>}
       <Select
         components={{
           MenuList,

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -348,7 +348,7 @@ const SelectInput = ({
         isMulti={isMulti}
         isClearable={isClearable}
         aria-label={labelDefined}
-        aria-labelledby={!label ? labelledby : ''}
+        aria-labelledby={!label ? labelledby : null}
         aria-live="polite"
         ariaLiveMessages={getSelectAriaLiveMessages(intl)}
         noOptionsMessage={() =>

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -326,7 +326,7 @@ const SelectInput = ({
   const Select = reactSelect.default;
   return (
     <div className="bootstrap-select-wrapper">
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && <label htmlFor={!labelledby?id:null}>{label}</label>}
       <Select
         components={{
           MenuList,


### PR DESCRIPTION
Condizione per la Label per i select ripristinata. La select non può rimanere senza label visibile, basta non essere collegata al componente via aria-labeledby.
 
Il merge con la cancellazione:
https://github.com/RedTurtle/design-comuni-plone-theme/pull/856

Il problema attuale, con i select senza label: 
https://www.regione.emilia-romagna.it/search?SearchableText=agevolazioni&group=bandi