### PR TITLE
fix: render of nome_alternativo for Venue view

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Condizione per la Label per i select ripristinata.
+- Sistemata la visualizzazione del sottotitolo nel content-type Luogo (in alcuni casi non si vedeva).
 
 ## Versione 11.26.5 (06/02/2025)
 

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeader.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeader.jsx
@@ -56,6 +56,7 @@ const PageHeader = (props) => {
   } = props;
   const intl = useIntl();
   const Image = config.getComponent({ name: 'Image' }).component;
+  const subtitle = content.subtitle || content.sottotitolo;
   return (
     <div className="PageHeaderWrapper mb-4">
       <div className="row mb-2 mb-lg-0 page-header">
@@ -75,10 +76,8 @@ const PageHeader = (props) => {
           >
             {content.title}
           </h1>
-          <p className="h2">
-            {content.subtitle && `${content.subtitle}`}
-            {content.sottotitolo && `${content.sottotitolo}`}
-          </p>
+
+          {subtitle && <p className="h2">{subtitle}</p>}
 
           <PageHeaderEventDates content={content} />
 

--- a/src/components/ItaliaTheme/View/VenueView/VenueView.jsx
+++ b/src/components/ItaliaTheme/View/VenueView/VenueView.jsx
@@ -58,21 +58,15 @@ const VenueView = ({ content }) => {
   const documentBody = createRef();
   const { sideMenuElements, SideMenu } = useSideMenu(content, documentBody);
 
-  useEffect(() => {
-    if (
-      content.nome_alternativo &&
-      !content.title?.includes(content.nome_alternativo)
-    ) {
-      content.subtitle = content.nome_alternativo;
-    }
-  });
-
   return (
     <>
       <div className="container px-4 my-4 luogo-view">
         <SkipToMainContent />
         <PageHeader
-          content={content}
+          content={{
+            ...content,
+            subtitle: content.nome_alternativo,
+          }}
           readingtime={null}
           showreadingtime={false}
           showdates={false}


### PR DESCRIPTION
Sistemata la visualizzazione del campo 'nome alternativo' del content-type luogo. 

In visualizzazione si vedeva per un attimo poi spariva, con un effetto di "sfarfallio". 
Vedi un esempio qui: 
https://v3.io-prenoto.redturtle.it/luogo-di-giulia

Segnalato dalla RER