### PR TITLE
fix: byweekday value added in getFormValues

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Se su un evento si imposta una ricorrenza mensile per eventi che avvengono in uno specifico giorno della settimana, la ricorrenza viene calcolata correttamente.
+
 ## Versione 11.26.5 (06/02/2025)
 
 ### Migliorie

--- a/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -409,8 +409,8 @@ class RecurrenceWidget extends Component {
                 formValues['freq'] = FREQUENCES.MONDAYFRIDAY;
               } else
                 formValues[option] = value.map((d) => {
-                      return this.getWeekday(d);
-                    });
+                  return this.getWeekday(d);
+                });
             }
             break;
           case 'bymonthday':
@@ -441,8 +441,11 @@ class RecurrenceWidget extends Component {
               if (freq === FREQUENCES.YEARLY) {
                 formValues['yearly'] = 'byday';
               }
+              const weekday = this.getWeekday(value[0][0]);
+              weekday.n = value[0][1];
               formValues['weekdayOfTheMonth'] = value[0][0];
               formValues['weekdayOfTheMonthIndex'] = value[0][1];
+              formValues['byweekday'] = weekday;
             }
             break;
           case 'bymonth':


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/64779-eventi-bug-su-ricorrenze

The recurrence was saved correctly when first setting it. When re-opening the widget modal, it would retrieve the formValues by getFormValues which did not add the byweekday field therefore not saving that field upon saving again