### PR TITLE
fix: added cards to show files uploaded in ct persona trasparenza folders

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- Per caricare documenti per "Dichiarazioni di insussistenza e incompatibilità" e per "Emolumenti a carico della finanza pubblica" è ora possibile caricare anche documenti multipli dalle cartelle contenute nel CT Persona, non solo dai campi specifici.
+
+### Fix
+
+- ...
+
 ## Versione 11.27.0 (26/02/2025)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/View/PersonaView/PersonaDocumenti.jsx
+++ b/src/components/ItaliaTheme/View/PersonaView/PersonaDocumenti.jsx
@@ -215,7 +215,11 @@ const PersonaDocumenti = ({ content }) => {
           />
         </RichTextSection>
       )}
-      {content.dichiarazioni_di_insussistenza_e_incompatibilita?.download && (
+      {(content.dichiarazioni_di_insussistenza_e_incompatibilita?.download ||
+        contentFolderHasItems(
+          content,
+          'dichiarazione-insussistenza-cause-di-inconferibilita-e-incompatibilita',
+        )) && (
         <RichTextSection
           tag_id="dichiarazioni_di_insussistenza_e_incompatibilita"
           title={intl.formatMessage(
@@ -223,20 +227,39 @@ const PersonaDocumenti = ({ content }) => {
           )}
         >
           <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
-            <Attachment
-              download_url={
-                content.dichiarazioni_di_insussistenza_e_incompatibilita
-                  .download
-              }
-              title={
-                content.dichiarazioni_di_insussistenza_e_incompatibilita
-                  .filename
-              }
-            />
+            {content.dichiarazioni_di_insussistenza_e_incompatibilita
+              ?.download && (
+              <Attachment
+                download_url={
+                  content.dichiarazioni_di_insussistenza_e_incompatibilita
+                    .download
+                }
+                title={
+                  content.dichiarazioni_di_insussistenza_e_incompatibilita
+                    .filename
+                }
+              />
+            )}
+            {contentFolderHasItems(
+              content,
+              'dichiarazione-insussistenza-cause-di-inconferibilita-e-incompatibilita',
+            ) && (
+              <Attachments
+                content={content}
+                folder_name={
+                  'dichiarazione-insussistenza-cause-di-inconferibilita-e-incompatibilita'
+                }
+                as_section={false}
+              />
+            )}
           </div>
         </RichTextSection>
       )}
-      {content.emolumenti_a_carico_della_finanza_pubblica?.download && (
+      {(content.emolumenti_a_carico_della_finanza_pubblica?.download ||
+        contentFolderHasItems(
+          content,
+          'emolumenti-complessivi-percepiti-a-carico-della-finanza-pubblica',
+        )) && (
         <RichTextSection
           tag_id="emolumenti_a_carico_della_finanza_pubblica"
           title={intl.formatMessage(
@@ -244,14 +267,28 @@ const PersonaDocumenti = ({ content }) => {
           )}
         >
           <div className="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
-            <Attachment
-              download_url={
-                content.emolumenti_a_carico_della_finanza_pubblica.download
-              }
-              title={
-                content.emolumenti_a_carico_della_finanza_pubblica.filename
-              }
-            />
+            {content.emolumenti_a_carico_della_finanza_pubblica?.download && (
+              <Attachment
+                download_url={
+                  content.emolumenti_a_carico_della_finanza_pubblica.download
+                }
+                title={
+                  content.emolumenti_a_carico_della_finanza_pubblica.filename
+                }
+              />
+            )}
+            {contentFolderHasItems(
+              content,
+              'emolumenti-complessivi-percepiti-a-carico-della-finanza-pubblica',
+            ) && (
+              <Attachments
+                content={content}
+                folder_name={
+                  'emolumenti-complessivi-percepiti-a-carico-della-finanza-pubblica'
+                }
+                as_section={false}
+              />
+            )}
           </div>
         </RichTextSection>
       )}


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/64998-saltata-la-modifica-del-ct-persona

I did not remove any content set from the specific CT Persona fields as some Comuni might have already uploaded them, and those fields can still be used.

Before merging this, make sure the BE is merged too:
us64998
