### PR TITLE
fix: search block focus styles and scroll into view results when apply filters

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 ### Migliorie
 
 - Tutti i bottoni della sezione "Accedi al servizio" hanno lo stesso font.
+- Nel blocco 'Cerca' ora viene fatto lo scroll automatico nel punto dove iniziano i risultati di ricerca quando vengono modificati dei filtri
 
 ### Novità
 
@@ -55,6 +56,7 @@
 ### Fix
 
 - I campi del CT Servizio - sezione Accedi al Servizio funzionano correttamente.
+- Sistemato lo stile del focus nelle select del blocco 'Cerca'
 
 ## Versione 11.27.0 (26/02/2025)
 

--- a/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
@@ -101,10 +101,6 @@ const SearchBlockView = (props) => {
     dataListingBodyVariation,
   );
 
-  const [defaultListingBodyData, setDefaultListingBodyData] = React.useState(
-    applyDefaults(searchData, root, data.usePloneRanking),
-  );
-
   // in the block edit you can change the used listing block variation,
   // but it's cached here in the state. So we reset it.
   React.useEffect(() => {
@@ -114,6 +110,9 @@ const SearchBlockView = (props) => {
   }, [dataListingBodyVariation, mode]);
 
   const root = useSelector((state) => state.breadcrumbs.root);
+  const [defaultListingBodyData] = React.useState(
+    applyDefaults(searchData, root, data.usePloneRanking),
+  );
   const listingBodyData = applyDefaults(searchData, root, data.usePloneRanking);
 
   const { variations } = config.blocks.blocksConfig.listing;

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -1,5 +1,6 @@
 /* CUSTOMIZATIONS:
   - Agid styling
+  - added resultsRef
 */
 import React from 'react';
 import {
@@ -33,6 +34,7 @@ const LeftColumnFacets = (props) => {
     isEditMode,
     querystring = {},
     searchData,
+    resultsRef,
     // mode = 'view',
     // variation,
   } = props;
@@ -117,24 +119,26 @@ const LeftColumnFacets = (props) => {
               </div>
             )}
 
-            <div className="search-results-count-sort d-flex align-center flex-wrap">
-              <SearchDetails
-                text={searchedText}
-                total={totalItems}
-                data={data}
-              />
-              <FilterList
-                {...props}
-                isEditMode={isEditMode}
-                setFacets={(f) => {
-                  flushSync(() => {
-                    setFacets(f);
-                    onTriggerSearch(searchedText || '', f);
-                  });
-                }}
-              />
+            <div ref={resultsRef} className="results-wrapper">
+              <div className="search-results-count-sort d-flex align-center flex-wrap">
+                <SearchDetails
+                  text={searchedText}
+                  total={totalItems}
+                  data={data}
+                />
+                <FilterList
+                  {...props}
+                  isEditMode={isEditMode}
+                  setFacets={(f) => {
+                    flushSync(() => {
+                      setFacets(f);
+                      onTriggerSearch(searchedText || '', f);
+                    });
+                  }}
+                />
+              </div>
+              {children}
             </div>
-            {children}
           </div>
         </Row>
       </Container>

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -1,5 +1,6 @@
 /* CUSTOMIZATIONS:
   - Agid styling
+  - added resultsRef
 */
 import React from 'react';
 import {
@@ -35,6 +36,7 @@ const RightColumnFacets = (props) => {
     isEditMode,
     querystring = {},
     searchData,
+    resultsRef,
     // mode = 'view',
     // variation,
   } = props;
@@ -72,24 +74,26 @@ const RightColumnFacets = (props) => {
               </div>
             )}
 
-            <div className="search-results-count-sort d-flex align-center flex-wrap">
-              <SearchDetails
-                text={searchedText}
-                total={totalItems}
-                data={data}
-              />
-              <FilterList
-                {...props}
-                isEditMode={isEditMode}
-                setFacets={(f) => {
-                  flushSync(() => {
-                    setFacets(f);
-                    onTriggerSearch(searchedText || '', f);
-                  });
-                }}
-              />
+            <div ref={resultsRef} className="results-wrapper">
+              <div className="search-results-count-sort d-flex align-center flex-wrap">
+                <SearchDetails
+                  text={searchedText}
+                  total={totalItems}
+                  data={data}
+                />
+                <FilterList
+                  {...props}
+                  isEditMode={isEditMode}
+                  setFacets={(f) => {
+                    flushSync(() => {
+                      setFacets(f);
+                      onTriggerSearch(searchedText || '', f);
+                    });
+                  }}
+                />
+              </div>
+              {children}
             </div>
-            {children}
           </div>
 
           {showColumn && (

--- a/src/theme/ItaliaTheme/Blocks/_search.scss
+++ b/src/theme/ItaliaTheme/Blocks/_search.scss
@@ -258,6 +258,18 @@
       }
     }
   }
+
+  @media (max-width: #{map-get($grid-breakpoints, md)}) {
+    //i filtri della colonna di destra vengono mostrati sotto alla barra di ricerca, prima dei risultati, perchè altrimenti su mobile verrebbero mostrati dopo i risultati.
+    .searchBlock-facets.right-column-facets {
+      > .row > :first-child {
+        order: 1;
+      }
+      .sideColumn {
+        order: 0;
+      }
+    }
+  }
 }
 
 .cms-ui .block.search .sideColumn .columnText .draftjs-buttons a {

--- a/src/theme/bootstrap-override/_bootstrap-italia-site.scss
+++ b/src/theme/bootstrap-override/_bootstrap-italia-site.scss
@@ -81,7 +81,6 @@
   @import './bootstrap-italia/borders';
   @import './bootstrap-italia/form-toggles';
   @import './bootstrap-italia/form';
-  @import './bootstrap-italia/form-select';
   @import './bootstrap-italia/footer';
   @import './bootstrap-italia/brand-text';
 }
@@ -110,6 +109,7 @@
   @import 'bootstrap-italia/src/scss/custom/form-toggles';
   @import 'bootstrap-italia/src/scss/custom/form-password';
   @import 'bootstrap-italia/src/scss/custom/form-select';
+  @import './bootstrap-italia/form-select';
   @import 'bootstrap-italia/src/scss/custom/form-transfer';
   @import './bootstrap-italia/forms';
   @import 'bootstrap-italia/src/scss/custom/dropdown';

--- a/src/theme/bootstrap-override/_bootstrap-italia-site.scss
+++ b/src/theme/bootstrap-override/_bootstrap-italia-site.scss
@@ -81,6 +81,7 @@
   @import './bootstrap-italia/borders';
   @import './bootstrap-italia/form-toggles';
   @import './bootstrap-italia/form';
+  @import './bootstrap-italia/form-select';
   @import './bootstrap-italia/footer';
   @import './bootstrap-italia/brand-text';
 }

--- a/src/theme/bootstrap-override/bootstrap-italia/_form-select.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_form-select.scss
@@ -1,0 +1,17 @@
+.bootstrap-select-wrapper {
+  //prevent focus input style, and add focus styles to all select wrapper, because input has a variable width depending on text inputed and if there's no text inside, when it has focus a double vertical lines are displayed.
+  input:focus,
+  input:focus-within {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+
+  &:has(input:focus),
+  &:has(input:focus-within) {
+    outline: 2px solid $outer-focus-outline !important;
+    outline-offset: 2px;
+
+    border: none !important;
+    box-shadow: 0 0 0 2px $inner-focus-shadow !important;
+  }
+}


### PR DESCRIPTION
Sistemati gli stili del focus delle select nel blocco 'Cerca'.
Le select hanno infatti al loro interno un input per fare la ricerca dei valori della tendina, che inizialmente ha larghezza quasi nulla, e al focus appariva una doppia linea verticale ravvicinata.

Aggiunto inoltre lo scroll automatico all'inizio dei risultati quando vengono applicati dei filtri da parte dell'utente.