### PR TITLE
fix: added h tags for icons and numbers block

### DIFF
--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -42,7 +42,11 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
           </div>
         )}
 
-        {data.title && <div className="iconblock-title">{data.title}</div>}
+        {data.title && (
+          <div className="iconblock-title">
+            <h3>{data.title}</h3>
+          </div>
+        )}
         {data.text && (
           <div className="iconblock-text">
             <TextBlockView data={{ value: data.text }} />

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -25,7 +25,7 @@ const messages = defineMessages({
  * @class ViewBlock
  * @extends Component
  */
-const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
+const ViewBlock = ({ data, isOpen, toggle, id, index, blockHasTitle }) => {
   const intl = useIntl();
 
   return (
@@ -44,7 +44,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
 
         {data.title && (
           <div className="iconblock-title">
-            <h3>{data.title}</h3>
+            {blockHasTitle ? <h3>{data.title}</h3> : data.title}
           </div>
         )}
         {data.text && (

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -40,7 +40,11 @@ const IconsBlockView = ({ data, block }) => {
           )}
           <Container className="px-md-4">
             <div className="block-header">
-              {data.title && <div className="title">{data.title}</div>}
+              {data.title && (
+                <div className="title">
+                  <h2>{data.title}</h2>
+                </div>
+              )}
               {data.description && (
                 <div className="description">
                   <TextBlockView data={{ value: data.description }} />

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -59,6 +59,7 @@ const IconsBlockView = ({ data, block }) => {
                     key={index}
                     id={id}
                     index={index}
+                    blockHasTitle={!!data.title}
                   />
                 </Col>
               ))}

--- a/src/components/ItaliaTheme/Blocks/NumbersBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/NumbersBlock/View.jsx
@@ -61,7 +61,11 @@ const NumbersView = ({ data, block }) => {
                     </div>
                   )}
 
-                  {data.title && <div className="title">{data.title}</div>}
+                  {data.title && (
+                    <div className="title">
+                      <h2>{data.title}</h2>
+                    </div>
+                  )}
                 </div>
               </Col>
 

--- a/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
+++ b/src/theme/ItaliaTheme/Blocks/_iconBlocks.scss
@@ -52,6 +52,10 @@
       font-weight: bold;
       line-height: 3rem;
       text-align: center;
+
+      h2 {
+        margin: 0px;
+      }
     }
 
     .description {
@@ -126,6 +130,10 @@
       font-weight: bold;
       line-height: 1.8rem;
       text-align: center;
+
+      h3 {
+        margin-bottom: 0px;
+      }
     }
 
     .iconblock-text {

--- a/src/theme/ItaliaTheme/Blocks/_numbers.scss
+++ b/src/theme/ItaliaTheme/Blocks/_numbers.scss
@@ -65,6 +65,10 @@
       font-size: 2.25rem;
       font-weight: bold;
       line-height: 2.8rem;
+
+      h2 {
+        margin: 0;
+      }
     }
   }
 


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/65546-titoli-blocco-icone-e-numeri

no pr for 11.x.x because it's for RER and therefore only on 3.3.x
Also, 11.x.x has redraft and it'd be a mess. Sooner or later they will all be migrated to 12.x.x, and no accessibility tool has ever pointed it out.