### PR TITLE
fix: Fix grid listing on mobile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (x/x/x)
+
+### Fix
+
+- sistemata la visualizzazione su mobile dei blocchi elenco inseriti all'interno dei blocchi griglia
+
 ## Versione 11.28.0 (04/03/2025)
 
 ### Migliorie

--- a/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
+++ b/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
@@ -19,36 +19,38 @@
       width: auto !important;
     }
 
-    &.listing {
-      &.simpleCard,
-      &.attachmentCardTemplate {
-        .card-teaser-block-3 {
-          > .card-teaser {
-            flex: 0 0 49%; //invece di 3 elementi per riga, ne mostro due perchè c'è poco spazio
+    @media (min-width: #{map-get($grid-breakpoints, md)}) {
+      &.listing {
+        &.simpleCard,
+        &.attachmentCardTemplate {
+          .card-teaser-block-3 {
+            > .card-teaser {
+              flex: 0 0 49%; //invece di 3 elementi per riga, ne mostro due perchè c'è poco spazio
+            }
           }
         }
-      }
 
-      &.cardWithImageTemplate,
-      &.ribbonCardTemplate,
-      &.completeBlockLinksTemplate {
-        .col-lg-4,
-        .col-xl-4,
-        .col-lg-3 {
-          width: 50%; //invece di 3 elementi per riga, ne mostro due perchè c'è poco spazio
+        &.cardWithImageTemplate,
+        &.ribbonCardTemplate,
+        &.completeBlockLinksTemplate {
+          .col-lg-4,
+          .col-xl-4,
+          .col-lg-3 {
+            width: 50%; //invece di 3 elementi per riga, ne mostro due perchè c'è poco spazio
+          }
         }
-      }
 
-      &.cardSlideUpTextTemplate,
-      &.quaresImageTemplate {
-        .grid {
-          grid-template-columns: 1fr 1fr;
+        &.cardSlideUpTextTemplate,
+        &.quaresImageTemplate {
+          .grid {
+            grid-template-columns: 1fr 1fr;
+          }
         }
-      }
 
-      &.bandiInEvidenceTemplate {
-        .bandi-in-evidence-cards-wrapper {
-          grid-template-columns: 1fr 1fr;
+        &.bandiInEvidenceTemplate {
+          .bandi-in-evidence-cards-wrapper {
+            grid-template-columns: 1fr 1fr;
+          }
         }
       }
     }


### PR DESCRIPTION
sistemata la visualizzazione su mobile dei template dei blocchi listing dentro ai blocchi griglia. 
Su mobile non venivano linearizzate le card, che se hanno testi lunghi o sono un po' piene di info non si capiva molto bene

Per semplicità metto lo screenshot del template card semplice, ma ho verificato anche gli altri template che erano gestiti nel blocco griglia.

Come era prima: 
<img width="541" alt="Screenshot 2025-03-06 alle 10 53 38" src="https://github.com/user-attachments/assets/de6f98e5-f405-43d9-b304-30dc37fb4742" />


Come è ora:
<img width="536" alt="Screenshot 2025-03-06 alle 10 55 29" src="https://github.com/user-attachments/assets/79e60d7a-3fe6-44b7-ab85-827cb5385a4b" />


us: 65441
