### PR TITLE
fix: Blockquote a11y

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (x.x.x)
+
+### Migliorie
+
+- accessibilità: migliorata l'accessibilità per gli elementi di tipo blockquote
+
 ## Versione 11.28.0 (04/03/2025)
 
 ### Migliorie

--- a/src/config/Slate/Blockquote/index.js
+++ b/src/config/Slate/Blockquote/index.js
@@ -3,10 +3,16 @@ import BlockquoteMenu from './BlockquoteMenu';
 
 export default function install(config) {
   const { slate } = config.settings;
+  console.log(slate);
 
-  slate.buttons.blockquote = (props) => (
-    <BlockquoteMenu {...props} title="Blockquote" />
-  );
+  (slate.elements.blockquote = ({ children }) => (
+    <blockquote>
+      <p>{children}</p>
+    </blockquote>
+  )),
+    (slate.buttons.blockquote = (props) => (
+      <BlockquoteMenu {...props} title="Blockquote" />
+    ));
 
   return config;
 }

--- a/src/config/Slate/Blockquote/index.js
+++ b/src/config/Slate/Blockquote/index.js
@@ -3,7 +3,6 @@ import BlockquoteMenu from './BlockquoteMenu';
 
 export default function install(config) {
   const { slate } = config.settings;
-  console.log(slate);
 
   (slate.elements.blockquote = ({ children }) => (
     <blockquote>

--- a/src/config/Slate/Blockquote/index.js
+++ b/src/config/Slate/Blockquote/index.js
@@ -4,14 +4,14 @@ import BlockquoteMenu from './BlockquoteMenu';
 export default function install(config) {
   const { slate } = config.settings;
 
-  (slate.elements.blockquote = ({ children }) => (
+  slate.elements.blockquote = ({ children }) => (
     <blockquote>
       <p>{children}</p>
     </blockquote>
-  )),
-    (slate.buttons.blockquote = (props) => (
-      <BlockquoteMenu {...props} title="Blockquote" />
-    ));
+  );
+  slate.buttons.blockquote = (props) => (
+    <BlockquoteMenu {...props} title="Blockquote" />
+  );
 
   return config;
 }

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -91,7 +91,9 @@ iframe {
     }
 
     ul:last-child,
-    ol:last-child {
+    ol:last-child,
+    p:last-child,
+    p:last-of-type {
       margin-bottom: 0;
     }
 


### PR DESCRIPTION
sistemata l'accessibilità dei blockquote. 
In particolare, alcuni screenreader non riconoscono il tag blockquote, quindi leggono il testo al suo interno tutto appiccicato al testo che lo precede e lo segue. 

Alcune indicazioni sull'accessibilità per i blockquote suggeriscono di wrappare il testo al suo interno in un <p> 

us: 65254