### PR TITLE
fix:  toggle accordion on link inside click

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock.jsx
@@ -68,7 +68,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
           aria-labelledby={`${id}-${index}`}
           hidden={!isOpen}
         >
-          <div className="accordion-inner" onFocus={toggle()}>
+          <div className="accordion-inner">
             <TextBlockView id={id} data={{ value: data.text }} />
           </div>
           {data.href && (


### PR DESCRIPTION
rimosso il toggle sull'onfocus del contenuto dell'accordion. 
In visualizzazione, al click su un link presente nell'accordion, l'accordion si chiudeva 