### PR TITLE
feat: allow ct document to contains also File content types 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,21 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Nel CT Documento ora è possibile gestire anche il CT File tramite taglia/incolla, la dove serva spostare dei File dentro uno specifico documento
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
+
 ## Versione 11.28.0 (04/03/2025)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/View/Commons/Module.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Module.jsx
@@ -40,6 +40,13 @@ const Module = ({ item }) => {
         {item.description && <p>{item.description}</p>}
         <div className="download-formats">
           <DownloadFileFormat
+            file={item.file}
+            showLabel={true}
+            title={item.title ?? item.file.filename}
+            hideFileFormatLabel={true}
+            className="mb-4"
+          />
+          <DownloadFileFormat
             file={item.file_principale}
             showLabel={true}
             title={item.title ?? item.file_principale.filename}


### PR DESCRIPTION
and show as a Modulo content type; editors request to handle file cut/paste into ct documento

blocked by:
https://github.com/RedTurtle/design.plone.contenttypes/pull/299 (merged)
design.plone.contenttypes 6.3.4 [to be released]
