### PR TITLE
fix: added label to TextFilter component

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Il filtro di testo dei blocchi ricerca è ora dotato di una label che lo rende accessibile.
+
 ## Versione 11.29.0 (07/03/2025)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useIntl, defineMessages } from 'react-intl';
+import { v4 as uuid } from 'uuid';
 
 const messages = defineMessages({
   text_filter_placeholder: {
@@ -10,8 +11,12 @@ const messages = defineMessages({
 
 const TextFilter = ({ value, id, onChange, placeholder }) => {
   const intl = useIntl();
+  const filterID = uuid();
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper text-filter">
+      <label for={filterID} className="visually-hidden">
+        {placeholder}
+      </label>
       <input
         type="text"
         placeholder={
@@ -22,6 +27,7 @@ const TextFilter = ({ value, id, onChange, placeholder }) => {
           onChange(id, e.target.value ?? '');
         }}
         autocomplete="off"
+        id={filterID}
       />
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useIntl, defineMessages } from 'react-intl';
-import { v4 as uuid } from 'uuid';
 
 const messages = defineMessages({
   text_filter_placeholder: {
@@ -9,12 +8,12 @@ const messages = defineMessages({
   },
 });
 
-const TextFilter = ({ value, id, onChange, placeholder }) => {
+const TextFilter = ({ value, id, onChange, placeholder, blockID }) => {
   const intl = useIntl();
-  const filterID = uuid();
+
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper text-filter">
-      <label for={filterID} className="visually-hidden">
+      <label htmlFor={`${blockID}-${id}`} className="visually-hidden">
         {placeholder}
       </label>
       <input
@@ -27,7 +26,7 @@ const TextFilter = ({ value, id, onChange, placeholder }) => {
           onChange(id, e.target.value ?? '');
         }}
         autocomplete="off"
-        id={filterID}
+        id={`${blockID}-${id}`}
       />
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/UOSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/UOSearch/Body.jsx
@@ -162,6 +162,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
                 <>
                   {React.createElement(filterOne.widget.component, {
                     ...filterOne.widget?.props,
+                    blockID: id,
                     id: 'filterOne',
                     onChange: (filter, value) => {
                       dispatchFilter({
@@ -175,6 +176,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
               {filterTwo &&
                 React.createElement(filterTwo.widget?.component, {
                   ...filterTwo.widget?.props,
+                  blockID: id,
                   id: 'filterTwo',
                   onChange: (filter, value) =>
                     dispatchFilter({
@@ -185,6 +187,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
               {filterThree &&
                 React.createElement(filterThree.widget?.component, {
                   ...filterThree.widget?.props,
+                  blockID: id,
                   id: 'filterThree',
                   onChange: (filter, value) =>
                     dispatchFilter({


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/64948-label-form-di-ricerca-solr-mancante

did not use the id of the component as the search components pass it as "filterOne", etc. which might be repeated within the page if there's more than one search block