### PR TITLE
fix: focus of buttons + focus of inputs + contrast of buttons

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- I bottoni presentano un contrasto corretto quando selezionati, e il bottone "scroll to top" può essere selezionato tramite navigazione da tastiera.
+
 ## Versione 11.29.0 (07/03/2025)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ItaliaTheme/ScrollToTop/ScrollToTop.jsx
@@ -50,7 +50,6 @@ const ScrollToTop = () => {
             title={intl.formatMessage(messages.scrollToTop)}
             onClick={scrollToTop}
             aria-hidden="true"
-            tabIndex={-1}
           >
             <Icon icon="it-arrow-up" padding={false} size="sm" />
           </Button>

--- a/src/theme/ItaliaTheme/_common.scss
+++ b/src/theme/ItaliaTheme/_common.scss
@@ -10,8 +10,10 @@
       outline: 2px solid $outer-focus-outline !important;
       outline-offset: 2px;
 
-      border: none !important;
       box-shadow: 0 0 0 2px $inner-focus-shadow !important;
+
+      // adds additional internal black border to buttons
+      border: 2px solid $outer-focus-outline !important;
     }
   }
 
@@ -40,6 +42,9 @@
         0 1px 1px $focus-outline-color,
         0 0 0 0.2rem $focus-outline-color;
       outline: none;
+
+      // adds additional black internal border to tertiary buttons
+      border: 2px solid $focus-outline-color !important;
     }
   }
 

--- a/src/theme/bootstrap-override/bootstrap-italia/_buttons.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_buttons.scss
@@ -6,3 +6,21 @@ button.btn.btn-primary:focus-visible,
     }
   }
 }
+
+button.btn.btn-primary:focus-visible {
+  // fix for primary buttons to ensure contrast upon focus
+  background-color: darken($color: $primary, $amount: 5%);
+  color: color-contrast($primary);
+}
+
+button.btn.btn-secondary:focus-visible {
+  // fix for secondary buttons to ensure contrast upon focus
+  background-color: darken($color: $secondary, $amount: 5%);
+  color: color-contrast($secondary);
+}
+
+button.btn.btn-tertiary:focus-visible {
+  // fix for tertiary buttons to ensure contrast upon focus
+  background-color: darken($color: $tertiary, $amount: 5%);
+  color: color-contrast($tertiary);
+}

--- a/src/theme/bootstrap-override/bootstrap-italia/_focus.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_focus.scss
@@ -7,6 +7,20 @@
   box-shadow: 0 0 0 2px $inner-focus-shadow !important;
 }
 
+input:focus:not(.focus--mouse) {
+  // only add border to input besides default double outline
+  border: 2px solid $outer-focus-outline !important;
+}
+
 .skiplinks a:focus:not(.focus--mouse) {
   border: 2px solid;
+}
+
+.gdpr-privacy-show-banner:focus:not(.focus--mouse) {
+  // invert general :focus rule since button is always white
+  outline: 2px solid $inner-focus-shadow !important;
+  outline-offset: 2px;
+
+  border: none !important;
+  box-shadow: 0 0 0 2px $outer-focus-outline !important;
 }

--- a/src/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_headercenter.scss
@@ -23,6 +23,11 @@
 
             border: none !important;
             box-shadow: 0 0 0 2px $inner-focus-shadow !important;
+
+            //adds border to ensure correct contrast on all bg
+            // dark bg + light button --> internal dark border + outer white shadow
+            // light bg + dark button --> external dark border + inner white shadow
+            border: 2px solid $outer-focus-outline !important;
           }
         }
       }


### PR DESCRIPTION
https://redturtle.tpondemand.com/entity/64956-contrasto-colore-e-focus-nel-form

fixes:
1. made ScrollToTop button tabbable
2. added border to buttons and to search button in header to create triple outline on focus
--> dark bg - light button = inner dark border + outer light shadow
--> light bg - dark button = outer dark outline + inner light shadow
--> dark bg - dark button = inner light shadow
--> light bg - light button = outer dark outline + middle light shadow + inner dark border

3. styles for buttons on focus-within for correct color and correct contrast with text
