### PR TITLE
fix: rollback volto-blocks-editor to a compatible version, fix volto-blocks-editor text block is always slate in it's block chooser

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,13 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Risolto un problema con l'aggiunta di un blocco di testo attraverso il selettore dei blocchi all'interno dei campi a blocchi delle form dei Content Type che li prevedono.
+- Risolto un problema che impediva la visualizzazione della sidebar dei blocchi all'interno di alcuni campi a blocchi delle form dei Content Type che li prevedono, impattandone l'utilizzo e la modifica.
+
 ## Versione 11.29.1 (24/03/2025)
 
 ### Migliorie

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "typeface-lora": "0.0.72",
     "typeface-roboto-mono": "0.0.75",
     "typeface-titillium-web": "0.0.72",
-    "volto-blocks-widget": "3.4.3",
+    "volto-blocks-widget": "3.4.1",
     "volto-data-grid-widget": "2.3.1",
     "volto-dropdownmenu": "4.1.3",
     "volto-editablefooter": "5.1.7",

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -333,20 +333,6 @@ export default function applyConfig(voltoConfig) {
         component: SiteSettingsExtras,
       },
     ],
-    'volto-blocks-widget': {
-      allowedBlocks: [
-        ...(config.settings['volto-blocks-widget']?.allowedBlocks ?? []).filter(
-          (block) => block !== 'maps',
-        ),
-        'break',
-        'testo_riquadro_semplice',
-        'testo_riquadro_immagine',
-        'rssBlock',
-        //se si aggiunge un nuovo blocco, verificare che in edit non ci siano bottoni che provocano il submit della form. Se succede, gestirli con e.prevenDefault() e.stopPropagation().
-      ],
-
-      showRestricted: false,
-    },
 
     'volto-gdpr-privacy': {
       ...config.settings['volto-gdpr-privacy'],
@@ -384,6 +370,24 @@ export default function applyConfig(voltoConfig) {
     },
     videoAllowExternalsDefault: false,
     showTrasparenzaFields: false,
+  };
+  // Moved outside as config.settings.defaultBlockType keeps default value (slate) until object spread is concluded
+  config.settings['volto-blocks-widget'] = {
+    ...config.settings['volto-blocks-widget'],
+    allowedBlocks: [
+      ...(config.settings['volto-blocks-widget']?.allowedBlocks ?? []).filter(
+        (block) => !['maps', 'text', 'slate'].includes(block),
+      ),
+      'break',
+      'testo_riquadro_semplice',
+      'testo_riquadro_immagine',
+      'rssBlock',
+      config.settings.defaultBlockType,
+      //se si aggiunge un nuovo blocco, verificare che in edit non ci siano bottoni che provocano il submit della form. Se succede, gestirli con e.prevenDefault() e.stopPropagation().
+      // Se sono bottoni semantic basta mettere type="button"
+    ],
+
+    showRestricted: false,
   };
 
   config.settings.nonContentRoutes = config.settings.nonContentRoutes.filter(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8211,7 +8211,7 @@ __metadata:
     typeface-lora: 0.0.72
     typeface-roboto-mono: 0.0.75
     typeface-titillium-web: 0.0.72
-    volto-blocks-widget: 3.4.3
+    volto-blocks-widget: 3.4.1
     volto-data-grid-widget: 2.3.1
     volto-dropdownmenu: 4.1.3
     volto-editablefooter: 5.1.7
@@ -16076,12 +16076,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-blocks-widget@npm:3.4.3":
-  version: 3.4.3
-  resolution: "volto-blocks-widget@npm:3.4.3"
+"volto-blocks-widget@npm:3.4.1":
+  version: 3.4.1
+  resolution: "volto-blocks-widget@npm:3.4.1"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: 68490569a49d79c4a7921af19d00225325b206992faf7d94b96a320266cf4679341e65e9472993039302aecaeceacfce4804f9ca12abe9222605438281ad2898
+  checksum: 4f5c183698e38edd40f24d7f35d3d59745c67b77ffaf0b2e448d8c7696453e9c83bbcd1b3c91599e6ccb77d64177fd7923d9ad36607dc1a41cba7fa9b20029b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[v11] Risolve 
https://redturtle.tpondemand.com/restui/board.aspx?#page=bug/66740
Risolto un problema con l'aggiunta di un blocco di testo attraverso il selettore dei blocchi all'interno dei campi a blocchi delle form dei Content Type che li prevedono.
https://redturtle.tpondemand.com/restui/board.aspx?#page=bug/66535
Risolto un problema che impediva la visualizzazione della sidebar dei blocchi all'interno di alcuni campi a blocchi delle form dei Content Type che li prevedono, impattandone l'utilizzo e la modifica.