### PR TITLE
fix: a11y link file size

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (xx/xx/xxxx)
+
+### Migliorie
+
+- a11y: Migliorata la lettura dei lettori di schermo della dimensione di un file: il separatore dei decimali è ora una virgola.
+
 ## Versione 11.29.1 (24/03/2025)
 
 ### Migliorie

--- a/src/helpers/EnhanceLink.js
+++ b/src/helpers/EnhanceLink.js
@@ -2,6 +2,7 @@ import React from 'react';
 import prettybytes from 'pretty-bytes';
 import cx from 'classnames';
 import { getFileViewFormat } from 'design-comuni-plone-theme/helpers';
+import { useIntl } from 'react-intl';
 
 const EnhanceLink = ({
   enhanced_link_infos,
@@ -9,11 +10,15 @@ const EnhanceLink = ({
   className,
   aria_label,
 }) => {
+  const intl = useIntl();
   let children = <></>;
   let aria_label_extended = null;
+
   let size =
-    enhanced_link_infos.getObjSize ??
-    prettybytes(enhanced_link_infos.size)?.toUpperCase();
+    enhanced_link_infos.getObjSize?.replaceAll('.', ',') ??
+    prettybytes(enhanced_link_infos.size, {
+      locale: intl.locale,
+    })?.toUpperCase();
 
   if (enhanced_link_infos) {
     const viewFormat = getFileViewFormat(enhanced_link_infos);


### PR DESCRIPTION
mimigliorato il formato della dimensione dei link a file / immagini per i lettori di schermo .

Con il formato con il punto, es: "19.2", il lettore leggeva "19", poi faceva una pausa (il punto) e poi leggeva "2".
Ora invece il lettore legge "diciannove virgola due"gliorato il formato della dimensione dei link a file / immagini per i lettori di schermo .

Con il formato con il punto, es: "19.2", il lettore leggeva "19", poi faceva una pausa (il punto) e poi leggeva "2".
Ora invece il lettore legge "diciannove virgola due"