### PR TITLE
feat: optionally hide Site Title from control panel

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (x/x/x)
+
+### Novità
+
+- E' ora possibile nascondere il titolo del sito nella testa del sito, spuntando l'apposita opzione del Pannello di contorllo del Sito.
+
 ## Versione 11.29.2 (26/03/2025)
 
 ### Fix

--- a/src/components/ItaliaTheme/BrandText/BrandText.jsx
+++ b/src/components/ItaliaTheme/BrandText/BrandText.jsx
@@ -27,14 +27,13 @@ const BrandText = ({ mobile = false, subsite }) => {
     </React.Fragment>
   ));
 
-  const visuallyHidden =
-    !subsite &&
-    SiteProperty({
-      property: 'hide_title',
-      defaultValue: false,
-      getValue: true,
-      getParent: false,
-    });
+  const hide_title = SiteProperty({
+    property: 'hide_title',
+    defaultValue: false,
+    getValue: true,
+    getParent: false,
+  });
+  const visuallyHidden = !subsite && hide_title;
 
   return (
     <div className={cx('it-brand-text', { 'visually-hidden': visuallyHidden })}>

--- a/src/components/ItaliaTheme/BrandText/BrandText.jsx
+++ b/src/components/ItaliaTheme/BrandText/BrandText.jsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { SiteProperty } from 'volto-site-settings';
 import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 
-const BrandText = ({ mobile = false }) => {
+const BrandText = ({ mobile = false, subsite }) => {
   const intl = useIntl();
   let title = SiteProperty({
     property: 'site_title',
@@ -27,8 +27,17 @@ const BrandText = ({ mobile = false }) => {
     </React.Fragment>
   ));
 
+  const visuallyHidden =
+    !subsite &&
+    SiteProperty({
+      property: 'hide_title',
+      defaultValue: false,
+      getValue: true,
+      getParent: false,
+    });
+
   return (
-    <div className="it-brand-text">
+    <div className={cx('it-brand-text', { 'visually-hidden': visuallyHidden })}>
       {title && <div className="it-brand-title">{title}</div>}
       {description && (
         <div


### PR DESCRIPTION
è necessario avere anche questa parte sul BE
https://github.com/collective/collective.volto.sitesettings/pull/3

Nel pannello di controllo è stata aggiunta l'opzione 'Nascondi il titolo' che permette di nascondere il titolo (come fatto su Nuovo Circondario Imolese) nell'header del sito principale. 

Per i sottositi il titolo continua a funzionare con le stesse regole di prima. 


<img width="1292" alt="Screenshot 2025-03-27 alle 12 48 38" src="https://github.com/user-attachments/assets/474af82c-eb9f-4111-bfbf-43a01d317468" />


us: 66434
