### PR TITLE
fix: changed byweekday parameter management in recurrence widget

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,19 +55,6 @@
 
 - I campi link accettano url contenenti un "/" e altre parti di link dopo un carattere di tipo "#".
 - Il filtro di testo dei blocchi ricerca è ora dotato di una label che lo rende accessibile.
-
-## Versione X.X.X (dd/mm/yyyy)
-
-### Migliorie
-
-- ...
-
-### Novità
-
-- ...
-
-### Fix
-
 - Risolti dei problemi nella ricorrenza mensile del widget delle ricorrenze all'interno del CT Evento.
 
 ## Versione 11.29.2 (26/03/2025)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Risolti dei problemi nella ricorrenza mensile del widget delle ricorrenze all'interno del CT Evento.
+
 ## Versione 11.29.2 (26/03/2025)
 
 ### Fix

--- a/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -628,7 +628,9 @@ class RecurrenceWidget extends Component {
     const byweekday =
       this.state?.rruleSet?.rrules().length > 0
         ? this.state.rruleSet.rrules()[0].origOptions.byweekday
-        : null;
+        : formValues.byweekday
+          ? formValues.byweekday
+          : null;
     const currWeekday = this.getWeekday(moment().day() - 1);
     const currMonth = moment().month() + 1;
 


### PR DESCRIPTION
Changed the way **byweekday** is calculated.

If the state of the widget undergoes some changes for only some fields or the state of the widget is not updated correctly with the changes made, **byweekday** will always come out from that definition as null. (see the diff)

However, if we're using the byweekday parameter when setting a monthly recurrence, byweekday being null means that the form value for the weekday field is set as the current day (736-740):

`   case 'weekdayOfTheMonthIndex':
        var week_day = byweekday ? byweekday[0] : currWeekday; //get day from state. If not set get current day
        //set nth value
        formValues.byweekday = value ? [week_day.nth(value)] : null;
        break;` 

that creates an issue whenever the weekday is not changed, but the index of the weekday is.
e.g. first monday of each month --> third monday of each month
The index field is changed, but not the weekday one. But since the function rewrites the formValues.byweekday value, it overwrites the correct value that has been previously set with the "default" one as the state of the widget does not have any values for that field in this case.

This change sets the byweekday value if the state stores it, otherwise it checks if `formValues` contain any byweekday value. If it does, it will use said value, otherwise it will store it as null as the original version of the code did.