### PR TITLE
Small blocks links image height

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,7 +53,7 @@
 
 ### Fix
 
-- L’altezza delle immagini all’interno del blocco ‘link solo immagini’ è stata aumentata fino a un massimo di 300px. Ora tutte le card avranno la stessa altezza.
+L'altezza delle immagini all'interno del blocco 'link solo immagini' è stata aumentata e non ha più un limite massimo. Ora tutte le card avranno la stessa altezza.
 
 ## Versione 12.1.1 (14/04/2025)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- L’altezza delle immagini all’interno del blocco ‘link solo immagini’ è stata aumentata fino a un massimo di 300px. Ora tutte le card avranno la stessa altezza.
+
 ## Versione 12.1.1 (14/04/2025)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
@@ -9,7 +9,8 @@
     position: relative;
     display: flex;
     overflow: hidden;
-    height: 100px;
+    height: 100%;
+    max-height: 300px;
     align-items: center;
     justify-content: center;
     border: 8px solid $white;

--- a/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
@@ -10,7 +10,6 @@
     display: flex;
     overflow: hidden;
     height: 100%;
-    max-height: 300px;
     align-items: center;
     justify-content: center;
     border: 8px solid $white;


### PR DESCRIPTION
height 100% set for better visualization .

<img width="1599" alt="Screenshot 2025-04-15 at 14 35 27" src="https://github.com/user-attachments/assets/271e9baa-12e6-4384-85a4-68f939fac08c" />
