### PR TITLE
fix: fixed mobile style of callout block

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Sistemato stile del blocco callout per la versione mobile.
+
 ## Versione 12.1.1 (14/04/2025)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/Callout/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/Callout/Edit.jsx
@@ -66,6 +66,7 @@ const Edit = (props) => {
               onSelectBlock={onSelectBlock}
             />
           </div>
+          {data.style !== 'highlight' && <div className="text-line"></div>}
         </CalloutTitle>
         <CalloutText>
           <TextEditorWidget

--- a/src/components/ItaliaTheme/Blocks/Callout/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/Callout/View.jsx
@@ -25,6 +25,7 @@ const View = ({ data, id }) => {
         <CalloutTitle>
           {data.icon && <Icon icon={data.icon} padding={false} aria-hidden />}
           <span className="text">{data.title}</span>
+          {data.style !== 'highlight' && <span className="text-line"></span>}
         </CalloutTitle>
         <CalloutText>
           <TextBlockView id={id} data={{ value: data.text }} />

--- a/src/theme/bootstrap-override/bootstrap-italia/_callout.scss
+++ b/src/theme/bootstrap-override/bootstrap-italia/_callout.scss
@@ -1,8 +1,61 @@
 div.callout {
   max-width: none;
-  padding: 0; //override volto's style
+  padding: 0; // override volto's style
   border: none;
   border-radius: unset;
   margin: 0;
   box-shadow: none;
+
+  .callout-title {
+    display: flex;
+    width: calc(100% + 1.389rem * 2 + 1.4rem); // padding + icon
+    margin-right: 0;
+
+    svg.icon {
+      min-width: 1.4rem;
+    }
+
+    .text {
+      width: auto;
+      padding-right: 1rem;
+
+      &::after {
+        display: none;
+      }
+    }
+
+    .text-line {
+      position: relative;
+      top: 0.8rem;
+      width: 100%;
+      min-width: 3rem;
+      height: 2px;
+      flex: 1;
+      background-color: $color-border-secondary;
+    }
+  }
+
+  &.danger {
+    .text-line {
+      background-color: $danger;
+    }
+  }
+
+  &.success {
+    .text-line {
+      background-color: $success;
+    }
+  }
+
+  &.warning {
+    .text-line {
+      background-color: $warning;
+    }
+  }
+
+  &.note {
+    .text-line {
+      background-color: $primary;
+    }
+  }
 }


### PR DESCRIPTION
[US66862](https://redturtle.tpondemand.com/entity/66862-visualizzazione-mobile-del-blocco-callout)

Il problema qua è che anche sul layout di Bootstrap Italia questo blocco è fatto male
<img width="375" alt="Screenshot 2025-04-16 alle 12 50 05" src="https://github.com/user-attachments/assets/1e422248-2c89-498d-b541-73602496e59f" />

Per cui ho cambiato View ed Edit del blocco aggiungendo la linea di decorazione come un ulteriore span.

[DESKTOP]
<img width="1368" alt="Screenshot 2025-04-16 alle 16 16 20" src="https://github.com/user-attachments/assets/bc1b5677-1260-4dba-a40d-4d2233a158de" />

[MOBILE]
<img width="347" alt="Screenshot 2025-04-16 alle 16 16 42" src="https://github.com/user-attachments/assets/9bdcded3-0b2a-428f-b14b-6f9e22e86666" />
