### PR TITLE
fix: added bold style to strong tag in accordion header

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- I titoli degli elementi del blocco Accordion hanno ora tutti lo stesso stile.
+
 ## Versione 11.30.1 (14/04/2025)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Blocks/_accordion.scss
+++ b/src/theme/ItaliaTheme/Blocks/_accordion.scss
@@ -63,6 +63,10 @@ $accordion-icon-color: #7fb2e5;
             font-size: 1.2rem;
             font-weight: bold;
 
+            strong {
+              font-weight: bold;
+            }
+
             & > div {
               width: 100%;
             }


### PR DESCRIPTION
From RE

Only in 11.x.x, when pasting a bold text from another document, it automatically converts it to text inside the <strong> tag.
Added the style to even out all styles and make them like the one intended for ioComune.

