### PR TITLE
Didascalia per l'immagine di testata CT Argomento

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,7 @@
 - L'altezza delle immagini all'interno del blocco 'link solo immagini' è stata aumentata e non ha più un limite massimo. Ora tutte le card avranno la stessa altezza.
 - Sistemato stile del blocco callout per la versione mobile.
 - Sistemati i formati 'A pieno schermo' e 'Allineamento al centro' del blocco Video, l'immagine in anteprima dava problemi nella visualizzazione di video di Youtube.
+- Corretta la descrizione per la didascalia per l'immagine di testata dentro al CT Argomento.
 
 ## Versione 12.1.1 (14/04/2025)
 

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
@@ -130,7 +130,6 @@ const PaginaArgomentoView = ({ content }) => {
                 })}
             </div>
           )}
-          {console.log('content', content)}
           {content?.image && (
             <>
               <Portal

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
@@ -130,6 +130,7 @@ const PaginaArgomentoView = ({ content }) => {
                 })}
             </div>
           )}
+          {console.log('content', content)}
           {content?.image && (
             <>
               <Portal
@@ -140,8 +141,8 @@ const PaginaArgomentoView = ({ content }) => {
                 <div>
                   <Image
                     item={content}
-                    alt={content.caption ?? content.title}
-                    title={content.caption ?? content.title}
+                    alt={content.image_caption ?? content.title}
+                    title={content.image_caption ?? content.title}
                     key={content.image.download}
                     responsive={true}
                     sizes="100vw"


### PR DESCRIPTION
Sostituito `content.caption` a `content.image_caption`