### PR TITLE
fix: added a gap between the lines if the completeBlockLinks has 2+ rows of content

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Spazio aggiunto tra le righe se il blocco ‘completeBlockLinks’ ha più di due righe di contenuto.
+
 ## Versione 12.1.3 (20/05/2025)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
@@ -3,6 +3,10 @@
     text-decoration: none;
   }
 
+  .row {
+    row-gap: 22px;
+  }
+
   .image-container {
     display: flex;
     overflow: hidden;


### PR DESCRIPTION
Before:
<img width="1402" alt="Screenshot 2025-05-22 at 15 27 59" src="https://github.com/user-attachments/assets/79d3f587-b7dd-432d-b53e-895abee469bf" />

After:
<img width="1382" alt="Screenshot 2025-05-22 at 15 28 06" src="https://github.com/user-attachments/assets/14ca2f29-2344-483d-bda7-e3cf616f498a" />
