### PR TITLE
fix: lazyloading images in slick

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -70,6 +70,7 @@ const PhotogalleryTemplate = ({
     dots: true,
     infinite: true,
     autoplay: autoplay,
+    lazyLoad: true,
     speed: 500,
     slidesToShow: items.length < 3 ? items.length : 3,
     slidesToScroll: 1,

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -274,6 +274,7 @@ const SliderTemplate = ({
   const settings = {
     dots: show_dots,
     infinite: true,
+    lazyLoad: true,
     autoplay: autoplay,
     speed: 500,
     slidesToShow: nSlidesToShow,

--- a/src/components/ItaliaTheme/View/Commons/Gallery.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Gallery.jsx
@@ -47,6 +47,7 @@ const Gallery = ({
     return {
       dots: true,
       infinite: true,
+      lazyLoad: true,
       speed: 500,
       slidesToShow: nItems < 3 ? nItems : 3,
       slidesToScroll: slideToScroll ?? 3,


### PR DESCRIPTION
Messo in slick il lazyload delle immagini, per evitare che carichi tutte le immagini dello slider
Nel caso di slider con molte immagini (anche pesantucce) il server soffre molto. 


Arriverà anche la pr per la v3