### PR TITLE
perf: lazyloading images in all slick slider

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (xx/xx/xx)
+
+### Migliorie
+
+- Le immagini negli slider vengono ora caricate in modalità 'lazy', in modo da alleggerire il caricamento iniziale della pagina.
+
 ## Versione 12.1.4 (22/05/2025)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -69,6 +69,7 @@ const PhotogalleryTemplate = ({
   const settings = {
     dots: true,
     infinite: true,
+    lazyLoad: true,
     autoplay: autoplay,
     speed: 500,
     slidesToShow: items.length < 3 ? items.length : 3,
@@ -160,8 +161,8 @@ const PhotogalleryTemplate = ({
                     items.length === 1
                       ? '1300'
                       : items.length === 2
-                      ? '650'
-                      : '450'
+                        ? '650'
+                        : '450'
                   }px`,
                   noWrapLink: true,
                   showDefault: true,

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -160,6 +160,7 @@ const SliderTemplate = ({
     infinite: true,
     autoplay: autoplay,
     speed: 500,
+    lazyLoad: true,
     slidesToShow: nSlidesToShow,
     slidesToScroll: nSlidesToShow,
     autoplaySpeed: autoplay_speed * 1000,

--- a/src/components/ItaliaTheme/Blocks/VideoGallery/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/VideoGallery/Body.jsx
@@ -32,6 +32,7 @@ const Body = ({ data, children, nItems = 0, reactSlick }) => {
     prevArrow: <PrevArrow />,
     infinite: true,
     speed: 500,
+    lazyLoad: true,
     slidesToShow: nItems < 3 ? nItems : 3,
     slidesToScroll: 1,
     responsive: [

--- a/src/components/ItaliaTheme/View/Commons/Gallery.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Gallery.jsx
@@ -59,6 +59,7 @@ const Gallery = ({
       dots: true,
       infinite: true,
       speed: 500,
+      lazyLoad: true,
       slidesToShow: nItems < 3 ? nItems : 3,
       slidesToScroll: slideToScroll ?? 3,
       nextArrow: <SliderNextArrow intl={intl} />,


### PR DESCRIPTION
Negli slider creati con Slick, è stata aggiunta la prop di configurazione 
lazyLoad:true

in modo da caricare in maniera lazy le immagini dello slider che ancora non vengono visualizzate. 
Il problema era che senza quella prop, venivano caricate dal browser anche le immagini ancora nascoste, e se lo slider aveva molte immagini, anche di grosse dimensioni, la pagina era molto lenta con conseguente sovraccarico inutile del server (la gdf ad esempio è andata giu quando hanno provato ad accedere ad una pagina con lo slider :-D)

Non cambia nulla per lo slider che si mette in home page, dove era forzato il fetch priority "high" (su quella immagine non viene applicato il lazyload). 

Con quest pr, solo per farvi capire,  sulla home page dello staging di iocomune, vengono fatte una 40ina di request in meno al caricamento della pagina.... 