### PR TITLE
chore: updated imageCardText block with draft formatting

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Nel blocco Card con Immagine ora è possibile formattare il testo al suo interno
+
 ## Versione 7.40.0 (12/05/2025)
 
 ### Novità

--- a/theme/ItaliaTheme/Blocks/_imageCardTextBlock.scss
+++ b/theme/ItaliaTheme/Blocks/_imageCardTextBlock.scss
@@ -2,7 +2,7 @@
   .card {
     .card-body {
       .card-text {
-        .DraftEditor-root * {
+        .DraftEditor-root {
           font-family: 'Lora, Georgia, serif';
           font-size: 0.875rem;
         }


### PR DESCRIPTION
[US64104](https://redturtle.tpondemand.com/entity/64104-rivalutare-dal-punto-di-vista-delle)
Ho rimosso una regola che impediva alla card di formattare il testo con draft 
<img width="1170" alt="Screenshot 2025-06-20 alle 18 25 13" src="https://github.com/user-attachments/assets/3198b8ff-ef55-448a-b583-5bdd1110289c" />
