### PR TITLE
fix: Card with image paths

### DIFF
--- a/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Edit.jsx
@@ -7,9 +7,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { SidebarPortal } from '@plone/volto/components';
-import Sidebar from './Sidebar.jsx';
-import BodyWrapper from './BodyWrapper.jsx';
-import Block from './Block';
+import Sidebar from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Sidebar';
+import BodyWrapper from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/TextCard/CardWithImage/BodyWrapper';
+import Block from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block';
 
 /**
  * Edit title block class.

--- a/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/View.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import BodyWrapper from './BodyWrapper';
-
-import Block from './Block';
+import BodyWrapper from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/TextCard/CardWithImage/BodyWrapper';
+import Block from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block';
 
 const TextCardWithImageView = ({ data, id }) => {
   return (


### PR DESCRIPTION
Now the paths to internal links use “design-comuni-plone-theme/components/ItaliaTheme” instead of “./NameOfTheComponent”. This is required for theme customizations to work properly.