### PR TITLE
fix: adjusted link and blockquote colors inside the table block

### DIFF
--- a/src/theme/extras/_tables.scss
+++ b/src/theme/extras/_tables.scss
@@ -50,19 +50,19 @@
   &.inverted {
     @extend .table-dark;
     a {
-      color: $white;
+      color: color-contrast($primary);
       &:hover {
         text-decoration: none;
       }
     }
     .blockquote,
     .blockquote-card {
-      border-color: $white !important;
+      border-color: color-contrast($primary) !important;
     }
     .blockquote-card {
       box-shadow: 0 2px 4px rgba(255, 255, 255, 0.2);
       &.dark {
-        background-color: $white;
+        background-color: color-contrast($primary);
         color: $text-color;
         a {
           color: $link-color;


### PR DESCRIPTION
Adjusted link and blockquote colors inside the table block to improve visibility and maintain design consistency.

<img width="906" alt="Screenshot 2025-07-08 at 14 37 17" src="https://github.com/user-attachments/assets/73907f72-23e7-4bb2-8571-5307e053f7ad" />
