### PR TITLE
fix: add role='menuitem' to links inside dropdown to fix menubar role hierarchy

### DIFF
--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -261,6 +261,7 @@ const MegaMenu = ({ item, pathname }) => {
           toggle={() => setMenuStatus(!menuStatus)}
         >
           <DropdownToggle
+            role="menuitem"
             aria-haspopup
             color="secondary"
             nav


### PR DESCRIPTION
This commit fixes the ARIA role hierarchy inside the main navigation menu.

The "ul" element uses role="menubar", which requires its direct children to be elements with role="menuitem" (or wrapped in elements with role="none" containing menuitem). Previously, the links inside dropdown menus were missing the correct role, triggering accessibility errors in tools like Lighthouse and axe.

Changes made:
	•	Added role="menuitem" to all "a" elements inside dropdowns that are part of the navigation bar
	•	Kept role="none" on the surrounding "li" elements, as recommended by the WAI-ARIA specification

All that to add this to the dropdown menu:
<img width="1092" height="119" alt="Screenshot 2025-07-16 at 12 14 31" src="https://github.com/user-attachments/assets/5f1c819e-8472-4442-af2d-29d9f8e901e2" />

ERROR:
<img width="1117" height="493" alt="Screenshot 2025-07-16 at 12 11 11" src="https://github.com/user-attachments/assets/38e2cace-f733-4af9-853b-ee04d098155d" />
