### PR TITLE
chore: updated volto-blocks-widget v3.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "typeface-lora": "0.0.72",
     "typeface-roboto-mono": "0.0.75",
     "typeface-titillium-web": "0.0.72",
-    "volto-blocks-widget": "3.4.5",
+    "volto-blocks-widget": "3.4.6",
     "volto-data-grid-widget": "2.3.1",
     "volto-dropdownmenu": "4.1.3",
     "volto-editablefooter": "5.1.7",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "typeface-lora": "0.0.72",
     "typeface-roboto-mono": "0.0.75",
     "typeface-titillium-web": "0.0.72",
-    "volto-blocks-widget": "3.4.1",
+    "volto-blocks-widget": "3.4.5",
     "volto-data-grid-widget": "2.3.1",
     "volto-dropdownmenu": "4.1.3",
     "volto-editablefooter": "5.1.7",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "typeface-lora": "0.0.72",
     "typeface-roboto-mono": "0.0.75",
     "typeface-titillium-web": "0.0.72",
-    "volto-blocks-widget": "3.4.6",
+    "volto-blocks-widget": "3.4.7",
     "volto-data-grid-widget": "2.3.1",
     "volto-dropdownmenu": "4.1.3",
     "volto-editablefooter": "5.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8246,7 +8246,7 @@ __metadata:
     typeface-lora: 0.0.72
     typeface-roboto-mono: 0.0.75
     typeface-titillium-web: 0.0.72
-    volto-blocks-widget: 3.4.5
+    volto-blocks-widget: 3.4.6
     volto-data-grid-widget: 2.3.1
     volto-dropdownmenu: 4.1.3
     volto-editablefooter: 5.1.7
@@ -16118,12 +16118,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-blocks-widget@npm:3.4.5":
-  version: 3.4.5
-  resolution: "volto-blocks-widget@npm:3.4.5"
+"volto-blocks-widget@npm:3.4.6":
+  version: 3.4.6
+  resolution: "volto-blocks-widget@npm:3.4.6"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: b9317ffecf82b1ee4655466805b1450135b59d545fe78e665781bf602a06b4bf28e96add96760242e9104e27f6ce9518833e5d149cd900eab760a1cd31105217
+  checksum: d48810238bd342571230608556fdf65c8772233a074d19faeabc775ce29adad244fa9ab1b012e2fc2523fcd363d65ecd050aba86ab0078c2184fa752b2cb2a2c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8246,7 +8246,7 @@ __metadata:
     typeface-lora: 0.0.72
     typeface-roboto-mono: 0.0.75
     typeface-titillium-web: 0.0.72
-    volto-blocks-widget: 3.4.1
+    volto-blocks-widget: 3.4.5
     volto-data-grid-widget: 2.3.1
     volto-dropdownmenu: 4.1.3
     volto-editablefooter: 5.1.7
@@ -16118,12 +16118,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-blocks-widget@npm:3.4.1":
-  version: 3.4.1
-  resolution: "volto-blocks-widget@npm:3.4.1"
+"volto-blocks-widget@npm:3.4.5":
+  version: 3.4.5
+  resolution: "volto-blocks-widget@npm:3.4.5"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: 4f5c183698e38edd40f24d7f35d3d59745c67b77ffaf0b2e448d8c7696453e9c83bbcd1b3c91599e6ccb77d64177fd7923d9ad36607dc1a41cba7fa9b20029b2
+  checksum: b9317ffecf82b1ee4655466805b1450135b59d545fe78e665781bf602a06b4bf28e96add96760242e9104e27f6ce9518833e5d149cd900eab760a1cd31105217
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8265,7 +8265,7 @@ __metadata:
     typeface-lora: 0.0.72
     typeface-roboto-mono: 0.0.75
     typeface-titillium-web: 0.0.72
-    volto-blocks-widget: 3.4.6
+    volto-blocks-widget: 3.4.7
     volto-data-grid-widget: 2.3.1
     volto-dropdownmenu: 4.1.3
     volto-editablefooter: 5.1.7
@@ -16137,12 +16137,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-blocks-widget@npm:3.4.6":
-  version: 3.4.6
-  resolution: "volto-blocks-widget@npm:3.4.6"
+"volto-blocks-widget@npm:3.4.7":
+  version: 3.4.7
+  resolution: "volto-blocks-widget@npm:3.4.7"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: d48810238bd342571230608556fdf65c8772233a074d19faeabc775ce29adad244fa9ab1b012e2fc2523fcd363d65ecd050aba86ab0078c2184fa752b2cb2a2c
+  checksum: 4350a9c54be770674961e507c96c5c56ffd3b8690f610a01c2390efcf30157fdf8ff590b80903225041dbe65b535b232a3d80767bcbe29d2b8c15fe4d3e2d646
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Riferimento alla [us68303](https://redturtle.tpondemand.com/entity/68303-nelle-pubblicazioni-il-campo-abstract-non) per filtrare i blocchi nei CT di tipo form
<img width="886" height="401" alt="Screenshot 2025-07-22 alle 22 35 05" src="https://github.com/user-attachments/assets/fc21c6b1-07cb-4378-9509-a0baad547d7a" />

!In attesa dell'ultima release con questa [fix](https://github.com/collective/volto-blocks-widget/pull/10) di volto-blocks-widget
