### PR TITLE
fix: image in template "Blocco link completo" 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Sistemata la visualizzazione delle immagini all’interno della card del blocco Link completo quando sono in landscape.
+
 ## Versione 12.2.2 (14/07/2025)
 
 ### Fix

--- a/src/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
@@ -17,14 +17,6 @@
     margin: 18px 0px 0px 18px;
 
     background-color: $white;
-
-    .volto-image {
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-    }
   }
 
   .card.card-bg {

--- a/src/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_completeBlockLinkstemplate.scss
@@ -52,4 +52,9 @@
   .no-external-if-link > .external-link {
     display: none;
   }
+
+  img.responsive {
+    height: 100%;
+    object-fit: cover;
+  }
 }


### PR DESCRIPTION
https://v3.io-comune.redturtle.it/test-giulia/blocco-link-completo-con-img

<img width="1402" height="557" alt="Screenshot 2025-07-23 at 12 57 09" src="https://github.com/user-attachments/assets/9501ffeb-f88b-42e5-a290-6dd839c60297" />
