### PR TITLE
fix: fixed a11y titles and images attributes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,7 @@
 ### Fix
 
 - Migliorata l'accessibilità rimuovendo la visibilità delle immagini di presentazione nei blocchi elenco.
-- Sistemata la semantica dei titoli nei blocchi Card Semplice ed elenco migliorando così l'accessibilità della pagina.
+- Sistemata la semantica dei titoli nei blocchi elenco migliorando così l'accessibilità della pagina.
 
 
 ## Versione 12.2.2 (14/07/2025)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,13 @@
 
 - ...
  -->
+ ## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Migliorata l'accessibilità rimuovendo la visibilità delle immagini di presentazione nei blocchi elenco.
+- Sistemata la semantica dei titoli nei blocchi Card Semplice ed elenco migliorando così l'accessibilità della pagina.
+
 
 ## Versione 12.2.2 (14/07/2025)
 

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -92,7 +92,7 @@ const BandiInEvidenceTemplate = ({
               <Col lg={4} sm={6} xs={12} key={index} className="pb-3">
                 <Card key={index} className="listing-item card-bg mt-2">
                   <CardBody>
-                    <CardTitle tag="h3" className="title">
+                    <CardTitle tag={title ? 'h3' : 'h2'} className="title">
                       <UniversalLink
                         className="bando-title"
                         item={!isEditMode ? item : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
@@ -128,7 +128,7 @@ const CardWithImageDefault = (props) => {
               tag={title ? 'h3' : 'h2'}
               className={cx('', {
                 'rassegna-appointment-title': isEventAppointment,
-                'line-height-title': !title,
+                h3: !title,
               })}
             >
               <UniversalLink

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
@@ -51,6 +51,7 @@ const CardWithImageDefault = (props) => {
     natural_image_size = false,
     id_lighthouse,
     rrule,
+    title, // title of entire block
   } = props;
 
   const imagesToShow = set_four_columns ? 4 : 3;
@@ -124,10 +125,11 @@ const CardWithImageDefault = (props) => {
               </CardCategory>
             )}
             <CardTitle
-              tag="h3"
-              className={`${
-                isEventAppointment ? 'rassegna-appointment-title' : ''
-              }`}
+              tag={title ? 'h3' : 'h2'}
+              className={cx('', {
+                'rassegna-appointment-title': isEventAppointment,
+                'line-height-title': !title,
+              })}
             >
               <UniversalLink
                 item={!isEditMode ? item : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -62,7 +62,7 @@ const CardWithSlideUpTextTemplate = (props) => {
             const date = hide_dates
               ? null
               : getCalendarDate(item, rrule.rrulestr);
-            const title = item?.title || '';
+            const itemTitle = item?.title || '';
 
             const BlockExtraTags = getComponentWithFallback({
               name: 'BlockExtraTags',
@@ -95,14 +95,25 @@ const CardWithSlideUpTextTemplate = (props) => {
                     'auto-margin-link': !category && !date,
                   })}
                 >
-                  <h3
-                    className={cx('title', {
-                      ellipsis: title.length > 50,
-                    })}
-                    title={title.length > 50 ? title : undefined}
-                  >
-                    {title.substring(0, 50)}
-                  </h3>
+                  {title ? (
+                    <h3
+                      className={cx('title', {
+                        ellipsis: itemTitle.length > 50,
+                      })}
+                      title={itemTitle.length > 50 ? itemTitle : undefined}
+                    >
+                      {itemTitle.substring(0, 50)}
+                    </h3>
+                  ) : (
+                    <h2
+                      className={cx('title h3', {
+                        ellipsis: itemTitle.length > 50,
+                      })}
+                      title={itemTitle.length > 50 ? itemTitle : undefined}
+                    >
+                      {itemTitle.substring(0, 50)}
+                    </h2>
+                  )}
                 </UniversalLink>
                 <div className="box-slide-up">
                   {show_description && item.description && (

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -45,6 +45,8 @@ const CardWithSlideUpTextTemplate = (props) => {
     rrule,
   } = props;
 
+  const TitleTag = title ? 'h3' : 'h2';
+
   return (
     <div className="card-slide-text-template">
       <Container className="px-4 mt-3">
@@ -95,25 +97,15 @@ const CardWithSlideUpTextTemplate = (props) => {
                     'auto-margin-link': !category && !date,
                   })}
                 >
-                  {title ? (
-                    <h3
-                      className={cx('title', {
-                        ellipsis: itemTitle.length > 50,
-                      })}
-                      title={itemTitle.length > 50 ? itemTitle : undefined}
-                    >
-                      {itemTitle.substring(0, 50)}
-                    </h3>
-                  ) : (
-                    <h2
-                      className={cx('title h3', {
-                        ellipsis: itemTitle.length > 50,
-                      })}
-                      title={itemTitle.length > 50 ? itemTitle : undefined}
-                    >
-                      {itemTitle.substring(0, 50)}
-                    </h2>
-                  )}
+                  <TitleTag
+                    className={cx('title', {
+                      h3: !title,
+                      ellipsis: itemTitle.length > 50,
+                    })}
+                    title={itemTitle.length > 50 ? itemTitle : undefined}
+                  >
+                    {itemTitle.substring(0, 50)}
+                  </TitleTag>
                 </UniversalLink>
                 <div className="box-slide-up">
                   {show_description && item.description && (

--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingImage.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingImage.jsx
@@ -32,7 +32,6 @@ const ListingImage = ({
             src={DefaultImageSVG}
             alt=""
             sizes={sizes}
-            aria-hidden={true}
             role="presentation"
             className="listing-image responsive"
             style={{
@@ -55,9 +54,9 @@ const ListingImage = ({
 
   let commonImageProps = {
     item,
-    'aria-hidden': imageProps.alt || item.title ? false : true,
+    'aria-hidden': imageProps.alt || imageCaption ? '' : true,
     alt: imageProps.alt ?? imageCaption ?? '',
-    role: imageProps.alt || item.title ? '' : 'presentation',
+    role: imageProps.alt || imageCaption ? '' : 'presentation',
     className,
     loading,
     responsive,

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -92,7 +92,12 @@ const CompleteBlockLinksTemplate = (props) => {
                       )}
                       <div>
                         <CardBody>
-                          <CardTitle tag="h3" className="text-secondary">
+                          <CardTitle
+                            tag={title ? 'h3' : 'h2'}
+                            className={cx('text-secondary', {
+                              h3: !title,
+                            })}
+                          >
                             {item.title}
                             {item['@type'] === 'Link' &&
                               !isInternalURL(

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -130,10 +130,11 @@ const InEvidenceTemplate = (props) => {
                     </CardCategory>
                   )}
                   <CardTitle
-                    tag="h3"
-                    className={`${
-                      isEventAppointment ? 'rassegna-appointment-title' : ''
-                    }`}
+                    tag={title ? 'h3' : 'h2'}
+                    className={cx('', {
+                      'rassegna-appointment-title': isEventAppointment,
+                      h3: !title,
+                    })}
                   >
                     <UniversalLink
                       item={!isEditMode ? item : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -140,10 +140,11 @@ const RibbonCardTemplate = (props) => {
                   >
                     {date && <div className="dates">{date}</div>}
                     <CardTitle
-                      tag="h3"
-                      className={`${
-                        isEventAppointment ? 'rassegna-appointment-title' : ''
-                      }`}
+                      tag={title ? 'h3' : 'h2'}
+                      className={cx('', {
+                        'rassegna-appointment-title': isEventAppointment,
+                        h3: !title,
+                      })}
                     >
                       <UniversalLink
                         item={!isEditMode ? item : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault.jsx
@@ -127,7 +127,7 @@ const SimpleCardDefault = (props) => {
           tag={title ? 'h3' : 'h2'}
           className={cx('', {
             'rassegna-appointment-title': isEventAppointment,
-            'line-height-title': !title,
+            h3: !title,
           })}
         >
           <UniversalLink

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault.jsx
@@ -58,6 +58,7 @@ const SimpleCardDefault = (props) => {
     id_lighthouse,
     rrule,
     index,
+    title,
   } = props;
 
   const getItemClass = (item) => {
@@ -123,10 +124,11 @@ const SimpleCardDefault = (props) => {
           </CardCategory>
         )}
         <CardTitle
-          tag="h3"
-          className={`${
-            isEventAppointment ? 'rassegna-appointment-title' : ''
-          }`}
+          tag={title ? 'h3' : 'h2'}
+          className={cx('', {
+            'rassegna-appointment-title': isEventAppointment,
+            'line-height-title': !title,
+          })}
         >
           <UniversalLink
             item={!isEditMode ? item : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -67,7 +67,12 @@ const SimpleCardTemplateCompact = ({
               </div>
             )}
             <CardBody>
-              <CardTitle tag="h3">
+              <CardTitle
+                tag={title ? 'h3' : 'h2'}
+                className={cx('', {
+                  'line-height-title': !title,
+                })}
+              >
                 <UniversalLink
                   item={!isEditMode ? item : null}
                   href={isEditMode ? '#' : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -70,7 +70,7 @@ const SimpleCardTemplateCompact = ({
               <CardTitle
                 tag={title ? 'h3' : 'h2'}
                 className={cx('', {
-                  'line-height-title': !title,
+                  h3: !title,
                 })}
               >
                 <UniversalLink

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow.jsx
@@ -218,7 +218,12 @@ const SimpleCardTemplateDefaultOneForRow = (props) => {
                     )}
                   </CardCategory>
                 )}
-                <CardTitle tag="h3">
+                <CardTitle
+                  tag={title ? 'h3' : 'h2'}
+                  className={cx('', {
+                    'line-height-title': !title,
+                  })}
+                >
                   <UniversalLink
                     item={!isEditMode ? item : null}
                     href={isEditMode ? '#' : null}

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow.jsx
@@ -221,7 +221,7 @@ const SimpleCardTemplateDefaultOneForRow = (props) => {
                 <CardTitle
                   tag={title ? 'h3' : 'h2'}
                   className={cx('', {
-                    'line-height-title': !title,
+                    h3: !title,
                   })}
                 >
                   <UniversalLink

--- a/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Edit.jsx
@@ -55,7 +55,7 @@ const Edit = (props) => {
         >
           <CardBody>
             <div className="simple-text-card cms-ui">
-              <CardTitle tag="h3" className="h4">
+              <CardTitle tag="h2" className="h4">
                 <TextEditorWidget
                   {...otherProps}
                   showToolbar={false}

--- a/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/View.jsx
@@ -27,7 +27,7 @@ const TextCardView = ({ data, id, block }) => {
           tag="div"
         >
           <CardBody>
-            <CardTitle tag="h3" className="h4" id={id + '-title'}>
+            <CardTitle tag="h2" className="h4" id={id + '-title'}>
               {data.simple_card_title}
             </CardTitle>
             <hr />

--- a/src/theme/ItaliaTheme/Components/_card.scss
+++ b/src/theme/ItaliaTheme/Components/_card.scss
@@ -185,15 +185,12 @@
       &.rassegna-appointment-title {
         margin-bottom: 0px !important;
       }
-      &.line-height-title {
-        line-height: 0.8em;
-      }
     }
 
     .rassegna-info {
-      font-size: 0.9rem;
       display: inline-flex;
       column-gap: 0.3rem;
+      font-size: 0.9rem;
 
       a {
         text-decoration: none;

--- a/src/theme/ItaliaTheme/Components/_card.scss
+++ b/src/theme/ItaliaTheme/Components/_card.scss
@@ -185,6 +185,9 @@
       &.rassegna-appointment-title {
         margin-bottom: 0px !important;
       }
+      &.line-height-title {
+        line-height: 0.8em;
+      }
     }
 
     .rassegna-info {


### PR DESCRIPTION
Risolto vari problemi di accessibilità

1. [bug66918](https://redturtle.tpondemand.com/entity/66918-a11y-titolo-blocco-card-semplice) sostituito tag h3 con h2 per la card semplice, semanticamente non era corretto all'interno della pagina
2. [bug66915](https://redturtle.tpondemand.com/entity/66915-a11y-titoli-blocchi-elenco) sistemato titoli per le card dei blocchi elenco che se non mostravano alcun titolo del blocco semanticamente non andavano bene
3. [bug66919](https://redturtle.tpondemand.com/entity/66919-a11y-immagini-decorative) sistemati i conflitti per le immagini decorative dei listing