### PR TITLE
fix: fixed image focus of smallBlockLinkTemplate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,19 @@
 
 - ...
  -->
+ ## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Migliorata l'accessibilità nel blocco elenco Link solo Immagini, ora il focus si vede in tutte le immagini.
 
 ## Versione 12.2.2 (14/07/2025)
 

--- a/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
+++ b/src/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
@@ -3,6 +3,7 @@
     position: relative;
     display: flex;
     overflow: hidden;
+    padding: 0.2rem;
     height: 100%;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
[BUG69301](https://redturtle.tpondemand.com/entity/69301-blocco-link-con-immagine-in-una)

<img width="1712" height="612" alt="Screenshot 2025-07-28 alle 12 45 30" src="https://github.com/user-attachments/assets/4f69cb78-309c-411c-8ace-d032711874fb" />
