### PR TITLE
fix: added state to close the date picker modal after endDate loses focus (Tab exit)

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useIntl, defineMessages } from 'react-intl';
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
@@ -226,6 +226,31 @@ const DateFilter = (props) => {
     }
   }, []);
 
+  const endDateInputRef = useRef(null);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const endDateInput = document.querySelector(
+        `#end-date-filter-${blockID}`,
+      );
+      if (endDateInput && !endDateInputRef.current) {
+        endDateInputRef.current = endDateInput;
+        endDateInput.addEventListener('blur', handleEndDateBlur);
+      }
+    }, 100);
+
+    return () => {
+      clearInterval(interval);
+      if (endDateInputRef.current) {
+        endDateInputRef.current.removeEventListener('blur', handleEndDateBlur);
+      }
+    };
+  }, []);
+
+  const handleEndDateBlur = () => {
+    setFocusedDateInput(null);
+  };
+
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper date-filter">
       <DateRangePicker
@@ -264,7 +289,7 @@ const DateFilter = (props) => {
         customCloseIcon={
           <Icon
             icon="it-close"
-            color="white"
+            color="black"
             title={intl.formatMessage(messages.clearDates)}
           />
         }


### PR DESCRIPTION
Problem
When navigating the date fields using the keyboard, after selecting the endDate and pressing Tab, the date picker modal remained open. This caused accessibility and UX issues, as the modal should close when leaving the last input field.

Solution
Added a blur event listener to detect when the user exits the endDate field (e.g., pressing Tab), and then updated the focusedInput state to null, which closes the date picker modal.

EXTRA:
- color for the cancel button changed to black

https://github.com/user-attachments/assets/4bb81012-4834-4ba3-b985-68568f05f059


EXTRA 2: 
- Questo select ha ancora tanti problemi. La data di fine non è selezionabili dalla tastiera, in nessun modo, e era già così. 
- Non è una buona pratica che la modale si apra con il focus, questo comportamento è anche sconsigliato.
- Il comportamento tornando indietro usando la tastiera è completamente sbagliato.

@pnicolli aria-components non ci aiuterebbe in questo caso?

