### PR TITLE
Slate link deserializer convert <a> without href attribute into …

### DIFF
--- a/src/config/Slate/Link/deserializer.js
+++ b/src/config/Slate/Link/deserializer.js
@@ -4,12 +4,16 @@ import { SIMPLELINK } from '@plone/volto-slate/constants';
 
 export const simpleLinkDeserializer = (editor, el) => {
   let parent = el;
-
   let children = Array.from(parent.childNodes)
     .map((el) => deserialize(editor, el))
     .flat();
 
   if (!children.length) children = [{ text: '' }];
+
+  if (el.getAttribute('href') === null) {
+    return jsx('text', {}, children);
+  }
+
   const attrs = {
     type: SIMPLELINK,
     data: {


### PR DESCRIPTION
…simple text.

We had this issue with some text pasted from Word that included hidden <a> tags without href attributes.
The editor interpreted them as links, but we don't want them treated as such since they're not real links.