### PR TITLE
fix: contentHasImage function + showImage conditions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Ripristinata la funzionalità per mostrare tutte le immagini del blocco elenco o solo quelle della prima fila, se presenti.
+
 ## Versione 11.32.0 (31/07/2025)
 
 ### Novità

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImage/CardWithImageDefault.jsx
@@ -62,10 +62,8 @@ const CardWithImageDefault = (props) => {
     : getEventRecurrenceMore(item, isEditMode);
   const listingText = show_description ? <ListingText item={item} /> : null;
 
-  const showImage = contentHasImage(
-    item,
-    index < imagesToShow || always_show_image,
-  );
+  const showImage =
+    contentHasImage(item) && (index < imagesToShow || always_show_image);
   const category = getCategory(item, show_type, show_section, props);
   const topics = show_topics ? item.tassonomia_argomenti : null;
 


### PR DESCRIPTION
Venivano passate le condizioni `index < imagesToShow || always_show_image` dentro la funzione contentHasImage invece che esternamente.
contentHasImage non accetta quei parametri e effettivamente non se ne fa di niente

```
const contentHasImage = (item) => {
  if (!item) return false;
  const isFromRealObject = !item.image_scales;
  const imageFieldWithDefault = item.image_field || 'image';

  const image = isFromRealObject
    ? item[imageFieldWithDefault]
    : item.image_scales[imageFieldWithDefault]?.[0];

  return Boolean(image);
};
```

