### PR TITLE
fix: shift+enter in testo_riquadro_* blocks

### DIFF
--- a/src/config/Blocks/blocks.js
+++ b/src/config/Blocks/blocks.js
@@ -230,6 +230,7 @@ const italiaBlocks = {
       addPermission: [],
       view: [],
     },
+    blockHasOwnFocusManagement: true,
   },
   testo_riquadro_immagine: {
     id: 'testo_riquadro_immagine',
@@ -246,6 +247,7 @@ const italiaBlocks = {
       view: [],
     },
     sidebarTab: 1,
+    blockHasOwnFocusManagement: true,
   },
   accordion: {
     id: 'accordion',


### PR DESCRIPTION
Segnalato da Modena:
i blocchi 'Card semplice' e 'Card con immagine' (testo_riquadro_semplice, testo_riquadro_immagine), non permettevano di andare a capo all'interno di un paragrafo con shift+invio