### PR TITLE
fix: a11y - Landmarks for header and aria-hidden elements must no be …

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -125,6 +125,7 @@ const CardWithSlideUpTextTemplate = (props) => {
                   item={!isEditMode ? item : null}
                   className="card-link"
                   aria-hidden="true"
+                  tabIndex="-1"
                 ></UniversalLink>
               </div>
             );

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -36,21 +36,24 @@ const Header = ({ pathname }) => {
   return (
     <>
       <div className="public-ui">
-        {/* <div
+        <header>
+          {/* <div
         className="sticky-placeholder"
         style={{ paddingTop: mini ? '50px' : '120px' }}
       /> */}
-        {/* <Headers sticky={true} className={mini ? 'is-sticky' : undefined}> */}
-        <Headers>
-          <HeaderSlim />
+          {/* <Headers sticky={true} className={mini ? 'is-sticky' : undefined}> */}
+          <Headers>
+            <HeaderSlim />
 
-          <div className="it-nav-wrapper">
-            <HeaderCenter />
-            <Navigation pathname={pathname} />
-          </div>
-        </Headers>
-        <SubsiteHeader />
+            <div className="it-nav-wrapper">
+              <HeaderCenter />
+              <Navigation pathname={pathname} />
+            </div>
+          </Headers>
+          <SubsiteHeader />
+        </header>
       </div>
+
       <div id="portal-header-image"></div>
     </>
   );


### PR DESCRIPTION
AXE dev tools, segnalava alcuni problemi di accessibilità:
- il blocco listing "Slide up template", ha due link al suo interno, di cui uno è aria-hidden, ma è focusabile. Gli elementi aria-hidden non devono essere focusabili. 
- alcuni elementi presenti nell'header non hanno un landmark assegnato. E' sufficiente wrappare il contenuto dell'header dentro il tag <header> (oppure l'alternativa era andare a mettere il role su ogni singolo elemento.