### PR TITLE
chore: updated text, select and date input filter with label props

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,17 +40,12 @@
 
 - ...
  -->
- ## Versione X.X.X (dd/mm/yyyy)
-
-### Migliorie
-
-- Migliorata l'accessibilità sui campi di input quando vengono applicate delle label ai campi.
-
-
 
 ## Versione X.X.X (dd/mm/yyyy)
 
 ### Migliorie
+
+- Migliorata l'accessibilità sui campi di input quando vengono applicate delle label ai campi.
 
 - Il pulsante Stile bottone dentro all'editor Slate è ora disponibile soltanto quando si seleziona un link con href.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,13 @@
 
 - ...
  -->
+ ## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Migliorata l'accessibilità sui campi di input quando vengono applicate delle label ai campi.
+
+
 
 ## Versione 12.4.0 (22/08/2025)
 

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
@@ -217,7 +217,6 @@ const DateFilter = (props) => {
     defaultStart,
     defaultEnd,
     blockID,
-    activeTopLabel = false,
     legendLabel = '',
     ...rest
   } = props;
@@ -289,57 +288,57 @@ const DateFilter = (props) => {
     };
   }, []);
 
+  const WrapperDate = legendLabel ? 'fielset' : 'div';
+
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper date-filter">
-      <fieldset>
-      {activeTopLabel && legendLabel && (
-        <legend>{legendLabel}</legend>
-      )}
-      <DateRangePicker
-        {...rest}
-        startDate={value?.startDate || defaultStart}
-        startDateId={`start-date-filter-${blockID}`}
-        startDatePlaceholderText={
-          startLabel ?? intl.formatMessage(messages.eventSearchStartDate)
-        }
-        endDate={value?.endDate || defaultEnd}
-        endDateId={`end-date-filter-${blockID}`}
-        endDatePlaceholderText={
-          endLabel ?? intl.formatMessage(messages.eventSearchEndDate)
-        }
-        onDatesChange={({ startDate, endDate }) => {
-          let start = startDate || defaultStart;
-          let end = endDate || defaultEnd;
-          onChange(id, { start, end });
-        }}
-        noBorder={true}
-        numberOfMonths={isMobile ? 1 : 2}
-        minimumNights={0}
-        focusedInput={focusedDateInput}
-        onFocusChange={(focusedInput) => {
-          setFocusedDateInput(focusedInput);
-        }}
-        displayFormat="DD/MM/YYYY"
-        hideKeyboardShortcutsPanel={true}
-        showClearDates
-        phrases={getDateRangePickerPhrases(intl)}
-        dayAriaLabelFormat="dddd, DD MMMM YYYY"
-        customArrowIcon={
-          <Icon
-            icon="it-arrow-right"
-            color="white"
-            title={intl.formatMessage(messages.roleDescription)}
-          />
-        }
-        customCloseIcon={
-          <Icon
-            icon="it-close"
-            color="black"
-            title={intl.formatMessage(messages.clearDates)}
-          />
-        }
-      />
-      </fieldset>
+      <WrapperDate>
+        {legendLabel && <legend>{legendLabel}</legend>}
+        <DateRangePicker
+          {...rest}
+          startDate={value?.startDate || defaultStart}
+          startDateId={`start-date-filter-${blockID}`}
+          startDatePlaceholderText={
+            startLabel ?? intl.formatMessage(messages.eventSearchStartDate)
+          }
+          endDate={value?.endDate || defaultEnd}
+          endDateId={`end-date-filter-${blockID}`}
+          endDatePlaceholderText={
+            endLabel ?? intl.formatMessage(messages.eventSearchEndDate)
+          }
+          onDatesChange={({ startDate, endDate }) => {
+            let start = startDate || defaultStart;
+            let end = endDate || defaultEnd;
+            onChange(id, { start, end });
+          }}
+          noBorder={true}
+          numberOfMonths={isMobile ? 1 : 2}
+          minimumNights={0}
+          focusedInput={focusedDateInput}
+          onFocusChange={(focusedInput) => {
+            setFocusedDateInput(focusedInput);
+          }}
+          displayFormat="DD/MM/YYYY"
+          hideKeyboardShortcutsPanel={true}
+          showClearDates
+          phrases={getDateRangePickerPhrases(intl)}
+          dayAriaLabelFormat="dddd, DD MMMM YYYY"
+          customArrowIcon={
+            <Icon
+              icon="it-arrow-right"
+              color="white"
+              title={intl.formatMessage(messages.roleDescription)}
+            />
+          }
+          customCloseIcon={
+            <Icon
+              icon="it-close"
+              color="black"
+              title={intl.formatMessage(messages.clearDates)}
+            />
+          }
+        />
+      </WrapperDate>
     </div>
   );
 };

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
@@ -217,6 +217,8 @@ const DateFilter = (props) => {
     defaultStart,
     defaultEnd,
     blockID,
+    activeTopLabel = false,
+    legendLabel = '',
     ...rest
   } = props;
   const { DateRangePicker } = reactDates;
@@ -289,6 +291,10 @@ const DateFilter = (props) => {
 
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper date-filter">
+      <fieldset>
+      {activeTopLabel && legendLabel && (
+        <legend>{legendLabel}</legend>
+      )}
       <DateRangePicker
         {...rest}
         startDate={value?.startDate || defaultStart}
@@ -333,6 +339,7 @@ const DateFilter = (props) => {
           />
         }
       />
+      </fieldset>
     </div>
   );
 };

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/SelectFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/SelectFilter.jsx
@@ -9,10 +9,9 @@ const SelectFilter = ({
   value,
   id,
   onChange,
+  placeholder,
   isSearchable = false,
   optionsQuerySize = 25,
-  activeTopLabel = false,
-  selectLabel = '',
 }) => {
   const dispatch = useDispatch();
 
@@ -66,8 +65,8 @@ const SelectFilter = ({
   const select_options = options?.choices
     ? options.choices
     : options?.vocabulary
-    ? vocabularies?.[options.vocabulary]?.items
-    : selectOptions;
+      ? vocabularies?.[options.vocabulary]?.items
+      : selectOptions;
 
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper select-filter">
@@ -78,7 +77,7 @@ const SelectFilter = ({
         onChange={(opt) => {
           onChange(id, opt);
         }}
-        label={activeTopLabel && selectLabel}
+        label={placeholder}
         options={select_options?.filter((opt) => !!opt.value?.toString()) ?? []}
         isClearable={options?.isClearable ?? true}
         isSearchable={isSearchable}

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/SelectFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/SelectFilter.jsx
@@ -9,9 +9,10 @@ const SelectFilter = ({
   value,
   id,
   onChange,
-  placeholder,
   isSearchable = false,
   optionsQuerySize = 25,
+  activeTopLabel = false,
+  selectLabel = '',
 }) => {
   const dispatch = useDispatch();
 
@@ -77,6 +78,7 @@ const SelectFilter = ({
         onChange={(opt) => {
           onChange(id, opt);
         }}
+        label={activeTopLabel && selectLabel}
         options={select_options?.filter((opt) => !!opt.value?.toString()) ?? []}
         isClearable={options?.isClearable ?? true}
         isSearchable={isSearchable}

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useIntl, defineMessages } from 'react-intl';
+import { Input } from 'design-react-kit';
 
 const messages = defineMessages({
   text_filter_placeholder: {
@@ -8,26 +9,52 @@ const messages = defineMessages({
   },
 });
 
-const TextFilter = ({ value, id, onChange, placeholder, blockID }) => {
+const TextFilter = ({
+  value,
+  id,
+  onChange,
+  placeholder,
+  blockID,
+  activeTopLabel = false,
+  infoText = '',
+}) => {
   const intl = useIntl();
+  const placeholderText =
+    placeholder || intl.formatMessage(messages.text_filter_placeholder);
 
   return (
     <div className="me-lg-3 my-2 my-lg-1 filter-wrapper text-filter">
-      <label htmlFor={`${blockID}-${id}`} className="visually-hidden">
-        {placeholder}
-      </label>
-      <input
-        type="text"
-        placeholder={
-          placeholder || intl.formatMessage(messages.text_filter_placeholder)
-        }
-        value={value}
-        onChange={(e, data) => {
-          onChange(id, e.target.value ?? '');
-        }}
-        autocomplete="off"
-        id={`${blockID}-${id}`}
-      />
+      {!activeTopLabel ? (
+        <>
+          {/* Input con label NACOSTA */}
+          <label htmlFor={`${blockID}-${id}`} className="visually-hidden">
+            {placeholderText}
+          </label>
+          <input
+            type="text"
+            placeholder={placeholderText}
+            value={value}
+            onChange={(e, data) => {
+              onChange(id, e.target.value ?? '');
+            }}
+            id={`${blockID}-${id}`}
+          />
+          {infoText && <small className="form-text d-block">{infoText}</small>}
+        </>
+      ) : (
+        <>
+          {/* Input con label VISIBILE */}
+          <Input
+            type="text"
+            label={placeholderText}
+            infoText={infoText} // small text
+            value={value}
+            onChange={(e, data) => {
+              onChange(id, e.target.value ?? '');
+            }}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter.jsx
@@ -52,6 +52,7 @@ const TextFilter = ({
             onChange={(e, data) => {
               onChange(id, e.target.value ?? '');
             }}
+            id={`${blockID}-${id}`}
           />
         </>
       )}

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -327,7 +327,11 @@ const SelectInput = ({
 
   return (
     <div className="bootstrap-select-wrapper">
-      {label && <label className="active" htmlFor={id}>{label}</label>}
+      {label && (
+        <label className="active" htmlFor={!labelledby ? id : undefined}>
+          {label}
+        </label>
+      )}
       <Select
         components={{
           MenuList,

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -324,9 +324,10 @@ const SelectInput = ({
   const labelDefined =
     label || intl.formatMessage(messages.SelectInput_default_label);
   const Select = reactSelect.default;
+
   return (
     <div className="bootstrap-select-wrapper">
-      {label && <label htmlFor={!labelledby ? id : undefined}>{label}</label>}
+      {label && <label className="active" htmlFor={id}>{label}</label>}
       <Select
         components={{
           MenuList,
@@ -338,7 +339,7 @@ const SelectInput = ({
           IndicatorSeparator: null,
           ...components,
         }}
-        id={id}
+        inputId={id}
         value={value}
         onChange={onChange}
         options={options}

--- a/src/theme/ItaliaTheme/Blocks/common/_searchBlockFilters.scss
+++ b/src/theme/ItaliaTheme/Blocks/common/_searchBlockFilters.scss
@@ -9,6 +9,10 @@
 
       &.text-filter {
         min-width: 35%;
+        
+        .form-group {
+          margin-bottom: 0;
+        }
       }
 
       &.select-filter {
@@ -177,6 +181,57 @@
           .DateRangePickerInput_clearDates svg {
             fill: $secondary-text !important;
           }
+        }
+      }
+    }
+  }
+}
+
+.search-container {
+  .filter-wrapper {
+    &.text-filter {  
+      input.focus--mouse {
+        outline: 2px solid $inner-focus-shadow !important;
+        outline-offset: 2px;
+        border: none !important;
+        box-shadow: 0 0 0 2px $outer-focus-outline !important;
+      }
+  
+      .form-group {
+        margin-bottom: 0;
+      }
+
+      .form-text {
+        display: block;
+      }
+    }
+
+    &.date-filter {
+      position: relative;
+
+      legend {
+        line-height: 1.2rem;
+        font-weight: 600;
+        position: absolute;
+        top: -22px;
+      }
+    }
+  }
+}
+
+.bg-primary {
+  .search-container {
+    .filter-wrapper {
+      &.text-filter,
+      &.select-filter {
+        label.active {
+          color: color-contrast($primary);
+        }
+      }
+      
+      &.date-filter {
+        legend {
+          color: color-contrast($primary);
         }
       }
     }

--- a/src/theme/ItaliaTheme/Blocks/common/_searchBlockFilters.scss
+++ b/src/theme/ItaliaTheme/Blocks/common/_searchBlockFilters.scss
@@ -211,6 +211,7 @@
 
       legend {
         line-height: 1.2rem;
+        font-size: $select-label-size;
         font-weight: 600;
         position: absolute;
         top: -22px;


### PR DESCRIPTION
Migliorati i campi di input Text, Select e DateRange con la possibilità di applicare una label sempre visibile.
[US 69727](https://redturtle.tpondemand.com/entity/69727-a11y-label-sempre-visibile-blocco-ricerca)

[PRIMA]
<img width="1298" height="293" alt="Screenshot 2025-09-02 alle 19 13 28" src="https://github.com/user-attachments/assets/e1f307e7-958a-452a-b392-54520cc35b0d" />

[DOPO]
<img width="1345" height="354" alt="Screenshot 2025-09-02 alle 20 02 48" src="https://github.com/user-attachments/assets/9d625986-9ed7-48e7-a94a-c2f19942af14" />

Aggiunto anche alcuni fix per quanto riguarda la label che già c'era sul campo di input text

<img width="927" height="95" alt="Screenshot 2025-09-02 alle 18 58 09" src="https://github.com/user-attachments/assets/8ff7ebc9-6455-4c46-be06-c6566cf82cbd" />

->
<img width="927" height="186" alt="Screenshot 2025-09-02 alle 18 58 57" src="https://github.com/user-attachments/assets/f0e4a84b-8b4b-4170-8a98-eaeb6d353ea0" />
