### PR TITLE
fix: read more a11y

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,6 @@
 
 ### Migliorie
 
-- ...
 - Il pulsante Stile bottone dentro all'editor Slate è ora disponibile soltanto quando si seleziona un link con href.
 
 ### Novità

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Migliorato la gestione del link "Vedi" nelle card: ora il titolo è sempre cliccabile e il link "Vedi" non viene più raggiunto dai lettori di schermo o dalla tastiera, garantendo un’esperienza più chiara e accessibile.
+
 ## Versione 12.4.0 (22/08/2025)
 
 ### Novità

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -237,6 +237,8 @@ const BandiInEvidenceTemplate = ({
                           item={!isEditMode ? item : null}
                           href={isEditMode ? '#' : null}
                           text={intl.formatMessage(messages.vedi)}
+                          aria-hidden="true"
+                          tabindex="-1"
                         />
                       </div>
                     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -119,6 +119,8 @@ const CardWithSlideUpTextTemplate = (props) => {
                     href={isEditMode ? '#' : null}
                     text={intl.formatMessage(messages.vedi)}
                     className="justify-content-end"
+                    aria-hidden="true"
+                    tabindex="-1"
                   />
                 </div>
                 <UniversalLink

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -172,6 +172,7 @@ const RibbonCardTemplate = (props) => {
                           intl.formatMessage(messages.default_detail_link)
                         }
                         aria-hidden="true"
+                        tabindex="-1"
                       />
                     )}
                   </CardBody>

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault.jsx
@@ -178,6 +178,7 @@ const SimpleCardDefault = (props) => {
               intl.formatMessage(messages.card_detail_label)
             }
             aria-hidden="true"
+            tabindex="-1"
           />
         )}
       </CardBody>

--- a/src/components/ItaliaTheme/Blocks/Listing/TemplatesSkeletons/BandiInEvidenceTemplateSkeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/TemplatesSkeletons/BandiInEvidenceTemplateSkeleton.jsx
@@ -49,6 +49,8 @@ const BandiInEvidenceTemplateSkeleton = ({
                           tag={Link}
                           to={'#'}
                           text=""
+                          aria-hidden="true"
+                          tabindex="-1"
                         />
                       </div>
                     </CardBody>


### PR DESCRIPTION
### Questo PR migliora l’accessibilità delle card:
- Il titolo è sempre reso cliccabile.
- Il link "Vedi" è contrassegnato con aria-hidden="true" e tabindex="-1", in modo da non essere più raggiungibile da tastiera o screen reader.

**Motivazione**
- In questo modo si evita la duplicazione dei link e si garantisce un comportamento coerente e accessibile.