### PR TITLE
fix: card with slide text a11y

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,21 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Blocco Elenco Card con testo animato: rimosso il focus dal card e dal pulsante “Vedi/Read More”, lasciando la navigazione solo sul titolo.
+- Blocco Elenco Card con testo animato: Aggiunto aria-hidden a “Vedi/Read More” per escluderlo dai lettori di schermo.
+
 ## Versione 12.4.0 (22/08/2025)
 
 ### Novità

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -79,6 +79,7 @@ const CardWithSlideUpTextTemplate = (props) => {
                     backgroundImage: `url(${image})`,
                   }
                 }
+                tabIndex={-1}
               >
                 <div className="bg-gradient"></div>
                 {(category || date) && (
@@ -119,6 +120,8 @@ const CardWithSlideUpTextTemplate = (props) => {
                     href={isEditMode ? '#' : null}
                     text={intl.formatMessage(messages.vedi)}
                     className="justify-content-end"
+                    tabIndex={-1}
+                    aria-hidden="true"
                   />
                 </div>
                 <UniversalLink


### PR DESCRIPTION
Nel blocco CardWithSlideUpTextTemplate è stato modificato il comportamento della navigazione con il lettore di schermo.
Ora il focus non passa più sull’intero card né sul pulsante “Vedi/Read More”, ma soltanto sul titolo.

In questo modo, il titolo viene letto correttamente e, se necessario, il lettore di schermo può leggere anche i testi circostanti, senza perdita di informazioni.

Inoltre, è stato aggiunto un attributo aria-hidden all’elemento “Vedi/Read More”, che quindi non viene preso in considerazione dagli screen reader.