### PR TITLE
Fix: slate button without href

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Il pulsante Stile bottone dentro all'editor Slate è ora disponibile soltanto quando si seleziona un link con href.
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
 ## Versione 12.4.0 (22/08/2025)
 
 ### Novità

--- a/src/config/Slate/Link/renderer.jsx
+++ b/src/config/Slate/Link/renderer.jsx
@@ -36,6 +36,11 @@ const ViewLink = ({
 export const LinkElement = (props) => {
   const { attributes, children, element, mode = 'edit' } = props;
 
+  // If no URL, just render children without wrapping in <a>/<button>
+  if (!element.data?.url) {
+    return <span {...attributes}>{children}</span>;
+  }
+
   let dataElementAttr = {};
   if (element.data.dataElement) {
     dataElementAttr['data-element'] = element.data.dataElement;

--- a/src/config/Slate/LinkButton/index.js
+++ b/src/config/Slate/LinkButton/index.js
@@ -11,6 +11,14 @@ import {
 } from 'design-comuni-plone-theme/config/Slate/dropdownUtils';
 import { insertToolbarButtons } from 'design-comuni-plone-theme/config/Slate/utils';
 import { LinkElement as ItaliaLinkElement } from 'design-comuni-plone-theme/config/Slate/Link/renderer';
+import { Editor } from 'slate';
+
+function isLinkWithHref(editor) {
+  const [match] = Editor.nodes(editor, {
+    match: (n) => n.type === 'link' && !!n.data?.url,
+  });
+  return !!match;
+}
 
 const LinkButtonButton = ({ icon, active, ...props }) => {
   const CLASSNAME = 'btn btn-primary inline-link';
@@ -22,6 +30,10 @@ const LinkButtonButton = ({ icon, active, ...props }) => {
       {...props}
       icon={icon}
       active={isActive}
+      disabled={
+        !editor.selection ||
+        (!isLinkStyleActive(editor, CLASSNAME) && !isLinkWithHref(editor))
+      }
       onMouseDown={(e) => {
         e.stopPropagation();
         e.preventDefault();


### PR DESCRIPTION
Aggiornato il pulsante Stile bottone nella toolbar di Slate
Il pulsante Stile bottone è ora abilitato solo quando il cursore si trova all’interno di un link che possiede un href.
Evitata la creazione di elementi <button> semanticamente non validi senza URL.

Info: Da parte mia lo farei, anche se modifica un po’ il modo in cui l’utente utilizza l’editor. Tuttavia, questo evita problemi di semantica nel codice, evitando di avere un pulsante privo di qualsiasi tipo di link.

Video con i test:

https://github.com/user-attachments/assets/4fe79c4d-8fb0-4109-8950-df8d65d9fc39

