### PR TITLE
fix: HtmlSlateWidget to link files

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Sistemato un problema nell’editor di testo sulla barra laterale delle pagine. Adesso è possibile inserire correttamente link a file ed immagini interni al sito senza errori.
+
 ## Versione 12.4.0 (22/08/2025)
 
 ### Novità

--- a/src/components/ItaliaTheme/manage/Widgets/HtmlSlateWidget.jsx
+++ b/src/components/ItaliaTheme/manage/Widgets/HtmlSlateWidget.jsx
@@ -12,6 +12,7 @@ import configureStore from 'redux-mock-store';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider, useSelector } from 'react-redux';
 import { defineMessages, injectIntl } from 'react-intl';
+import { IntlProvider } from 'react-intl';
 
 import { FormFieldWrapper } from '@plone/volto/components';
 import SlateEditor from '@plone/volto-slate/editor/SlateEditor';
@@ -63,7 +64,11 @@ const HtmlSlateWidget = (props) => {
       const mockStore = configureStore();
       const html = ReactDOMServer.renderToStaticMarkup(
         <Provider store={mockStore({ userSession: { token } })}>
-          <MemoryRouter>{serializeNodes(value || [])}</MemoryRouter>
+          <MemoryRouter>
+            <IntlProvider locale={intl.locale}>
+              {serializeNodes(value || [])}
+            </IntlProvider>
+          </MemoryRouter>
         </Provider>,
       );
       //console.log('toHtml', value, ' ----> ', html);


### PR DESCRIPTION
Risolto un errore nel widget HtmlSlateWidget che impediva l’inserimento corretto dei link quando si usavano percorsi interni per file e immagine.