### PR TITLE
chore: updated warning form block message and configured alert with thank-you message

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@
 - Il pulsante Stile bottone dentro all'editor Slate è ora disponibile soltanto quando si seleziona un link con href.
 - Migliorata la gestione del copia/incolla da Word e Word online. Ora vengono mantenuti stili e formattazione.
 - Migliorata l'accessibilità per gli input di tipo radio button, checkbox e select all'interno del blocco form.
+- Blocco form aggiornato con la possibilità di aggiungere il Messaggio di conferma invio insieme all'alert del Limite di iscrizioni superato
   
 ### Novità
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2514,12 +2514,12 @@ msgid "form_set_limit"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: Sei stato inserito in lista d'attesa
+# defaultMessage: La tua iscrizione è in lista d'attesa
 msgid "form_submit_success_warning"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.
+# defaultMessage: I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.
 msgid "form_submit_success_warning_description"
 msgstr ""
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2499,14 +2499,14 @@ msgid "form_set_limit"
 msgstr "Set a submission limit"
 
 #: overrideTranslations
-# defaultMessage: Sei stato inserito in lista d'attesa
+# defaultMessage: La tua iscrizione è in lista d'attesa
 msgid "form_submit_success_warning"
-msgstr "You've been added to the waiting list"
+msgstr "Your registration is on the waiting list."
 
 #: overrideTranslations
-# defaultMessage: I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.
+# defaultMessage: I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.
 msgid "form_submit_success_warning_description"
-msgstr "Your data has been submitted, but the subscription limit has been reached and you've been added to the waiting list."
+msgstr "Your data has been submitted successfully. However, the maximum number of registrations has been reached: your request has been placed on the waiting list."
 
 #: components/ItaliaTheme/View/PersonaView/PersonaRuolo
 # defaultMessage: Foto dell'attività politica

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2508,12 +2508,12 @@ msgid "form_set_limit"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: Sei stato inserito in lista d'attesa
+# defaultMessage: La tua iscrizione è in lista d'attesa
 msgid "form_submit_success_warning"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.
+# defaultMessage: I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.
 msgid "form_submit_success_warning_description"
 msgstr ""
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2516,12 +2516,12 @@ msgid "form_set_limit"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: Sei stato inserito in lista d'attesa
+# defaultMessage: La tua iscrizione è in lista d'attesa
 msgid "form_submit_success_warning"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.
+# defaultMessage: I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.
 msgid "form_submit_success_warning_description"
 msgstr ""
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2499,14 +2499,14 @@ msgid "form_set_limit"
 msgstr "Imposta un limite iscrizioni"
 
 #: overrideTranslations
-# defaultMessage: Sei stato inserito in lista d'attesa
+# defaultMessage: La tua iscrizione è in lista d'attesa
 msgid "form_submit_success_warning"
-msgstr "Sei stato inserito in lista d'attesa"
+msgstr "La tua iscrizione è in lista d'attesa"
 
 #: overrideTranslations
-# defaultMessage: I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.
+# defaultMessage: I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.
 msgid "form_submit_success_warning_description"
-msgstr "I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa."
+msgstr "I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa."
 
 #: components/ItaliaTheme/View/PersonaView/PersonaRuolo
 # defaultMessage: Foto dell'attività politica

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-09-25T14:39:17.351Z\n"
+"POT-Creation-Date: 2025-09-28T22:46:26.948Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2501,12 +2501,12 @@ msgid "form_set_limit"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: Sei stato inserito in lista d'attesa
+# defaultMessage: La tua iscrizione è in lista d'attesa
 msgid "form_submit_success_warning"
 msgstr ""
 
 #: overrideTranslations
-# defaultMessage: I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.
+# defaultMessage: I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.
 msgid "form_submit_success_warning_description"
 msgstr ""
 

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -299,6 +299,7 @@ export default function applyConfig(voltoConfig) {
       markSpecialLinks: true, // se impostato a false, non marca con icona i link esterni
       markFooterLinks: true, // se impostato a true, viene aggiunta un'icona ai link del footer per renderli riconoscibili
       showContentDateInListingFor: ['Modulo', 'Documento'], // elenco dei content types per i quali mostrare la data di pubblicazione/modifica in listing
+      showExtraMessageFormBlock: false, // imposta a true quando vuoi mostrare il ThankYou message con l'alert del limite di iscrizioni
       fallbackImageSrc: FALLBACK_IMAGE_SRC,
       fallbackImageSrcMaxW: FALLBACK_IMAGE_SRC_MAX_W,
     },

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -299,7 +299,7 @@ export default function applyConfig(voltoConfig) {
       markSpecialLinks: true, // se impostato a false, non marca con icona i link esterni
       markFooterLinks: true, // se impostato a true, viene aggiunta un'icona ai link del footer per renderli riconoscibili
       showContentDateInListingFor: ['Modulo', 'Documento'], // elenco dei content types per i quali mostrare la data di pubblicazione/modifica in listing
-      showExtraMessageFormBlock: false, // imposta a true quando vuoi mostrare il ThankYou message con l'alert del limite di iscrizioni
+      displayThankYouInAlertMessageFormBlock: false, // imposta a true quando vuoi mostrare il ThankYou message con l'alert del limite di iscrizioni
       fallbackImageSrc: FALLBACK_IMAGE_SRC,
       fallbackImageSrcMaxW: FALLBACK_IMAGE_SRC_MAX_W,
     },

--- a/src/customizations/volto-form-block/components/FormResult.jsx
+++ b/src/customizations/volto-form-block/components/FormResult.jsx
@@ -16,12 +16,12 @@ const messages = defineMessages({
   },
   success_warning: {
     id: 'form_submit_success_warning',
-    defaultMessage: "Your registration is on the waiting list.",
+    defaultMessage: 'Your registration is on the waiting list.',
   },
   success_warning_description: {
     id: 'form_submit_success_warning_description',
     defaultMessage:
-      "Your data has been submitted successfully. However, the maximum number of registrations has been reached: your request has been placed on the waiting list.",
+      'Your data has been submitted successfully. However, the maximum number of registrations has been reached: your request has been placed on the waiting list.',
   },
   reset: {
     id: 'form_reset',
@@ -57,8 +57,8 @@ const replaceMessage = (text, sent_data) => {
 
 const FormResult = ({ formState, data, resetFormState }) => {
   const intl = useIntl();
-  const showExtraMessageFormBlock =
-    config.settings.siteProperties.showExtraMessageFormBlock;
+  const displayThankYouInAlertMessageFormBlock =
+    config.settings.siteProperties.displayThankYouInAlertMessageFormBlock;
 
   return (
     <Alert
@@ -83,7 +83,7 @@ const FormResult = ({ formState, data, resetFormState }) => {
       {/* Custom message */}
       {!formState.warning ||
         (formState.warning &&
-          showExtraMessageFormBlock &&
+          displayThankYouInAlertMessageFormBlock &&
           data.send_message && (
             <>
               <p

--- a/src/customizations/volto-form-block/components/FormResult.jsx
+++ b/src/customizations/volto-form-block/components/FormResult.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { useIntl, defineMessages } from 'react-intl';
 import { Button, Alert } from 'design-react-kit';
 import { getFieldName } from 'volto-form-block/components/utils';
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   success: {
@@ -15,12 +16,12 @@ const messages = defineMessages({
   },
   success_warning: {
     id: 'form_submit_success_warning',
-    defaultMessage: "You've been added to the waiting list",
+    defaultMessage: "Your registration is on the waiting list.",
   },
   success_warning_description: {
     id: 'form_submit_success_warning_description',
     defaultMessage:
-      "Your data has been submitted, but the subscription limit has been reached and you've been added to the waiting list.",
+      "Your data has been submitted successfully. However, the maximum number of registrations has been reached: your request has been placed on the waiting list.",
   },
   reset: {
     id: 'form_reset',
@@ -56,6 +57,9 @@ const replaceMessage = (text, sent_data) => {
 
 const FormResult = ({ formState, data, resetFormState }) => {
   const intl = useIntl();
+  const showExtraMessageFormBlock =
+    config.settings.siteProperties.showExtraMessageFormBlock;
+
   return (
     <Alert
       color={!formState.warning ? 'success' : 'warning'}
@@ -70,26 +74,29 @@ const FormResult = ({ formState, data, resetFormState }) => {
           : intl.formatMessage(messages.success_warning)}
       </h4>
       <br />
-      {/* Custom message */}
-      {!formState.warning ? (
-        data.send_message && (
-          <>
-            <p
-              dangerouslySetInnerHTML={{
-                __html: replaceMessage(
-                  data.send_message,
-                  formState.result.data,
-                ),
-              }}
-            />
-            <br />
-          </>
-        )
-      ) : (
+      {/* Warning submit limit  */}
+      {formState.warning && (
         <>
           <p>{intl.formatMessage(messages.success_warning_description)}</p>
         </>
       )}
+      {/* Custom message */}
+      {!formState.warning ||
+        (formState.warning &&
+          showExtraMessageFormBlock &&
+          data.send_message && (
+            <>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: replaceMessage(
+                    data.send_message,
+                    formState.result.data,
+                  ),
+                }}
+              />
+              <br />
+            </>
+          ))}
 
       <Button
         color="primary"

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -101,12 +101,12 @@ defineMessages({
   },
   success_warning: {
     id: 'form_submit_success_warning',
-    defaultMessage: "Sei stato inserito in lista d'attesa",
+    defaultMessage: "La tua iscrizione è in lista d'attesa",
   },
   success_warning_description: {
     id: 'form_submit_success_warning_description',
     defaultMessage:
-      "I tuoi dati sono stati inviati, ma è già stato raggiunto il limite di iscrizioni, sei stato inserito in lista d'attesa.",
+      'I tuoi dati sono stati inviati correttamente. Tuttavia, è stato raggiunto il limite massimo di iscrizioni: la tua richiesta è stata inserita in lista d’attesa.',
   },
   field_unique_title: {
     id: 'field_unique_title',


### PR DESCRIPTION
[US69506](https://redturtle.tpondemand.com/entity/69506-blocco-form-messaggio-con-limite-di)

Aggiunta configurazione per mostrare il messaggio di ringraziamenti insieme al messaggio di notifica del limite di iscrizioni superate del blocco form, i messaggi inoltre sono stati resi generici

<img width="1283" height="444" alt="Screenshot 2025-09-29 alle 00 54 10" src="https://github.com/user-attachments/assets/d30f0f33-16a5-4bd2-94f7-53c6acb26a9f" />
