### PR TITLE
fix: Updated heading from H5 to H2 for improved hierarchy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,12 +45,27 @@
 
 ### Migliorie
 
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Aggiornata intestazione della sezione Argomento da H5 a H2 all’interno di una pagina per migliorare la gerarchia.
+  -->
+
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
 - Migliorata l'accessibilità sui campi di input quando vengono applicate delle label ai campi.
 - Il pulsante Stile bottone dentro all'editor Slate è ora disponibile soltanto quando si seleziona un link con href.
 - Migliorata la gestione del copia/incolla da Word e Word online. Ora vengono mantenuti stili e formattazione.
 - Migliorata l'accessibilità per gli input di tipo radio button, checkbox e select all'interno del blocco form.
 - Blocco form aggiornato con la possibilità di aggiungere il Messaggio di conferma invio insieme all'alert del Limite di iscrizioni superato
-  
+
 ### Novità
 
 - E' ora disponibile il blocco contatti: dal pannello di controllo è possibile impostare una lista di contatti da mostrare sopra al footer.
@@ -62,7 +77,6 @@
 - Blocco Elenco Card con testo animato: rimosso il focus dal card e dal pulsante “Vedi/Read More”, lasciando la navigazione solo sul titolo.
 - Blocco Elenco Card con testo animato: Aggiunto aria-hidden a “Vedi/Read More” per escluderlo dai lettori di schermo.
 - Migliorato la gestione del link "Vedi" nelle card: ora il titolo è sempre cliccabile e il link "Vedi" non viene più raggiunto dai lettori di schermo o dalla tastiera, garantendo un’esperienza più chiara e accessibile.
-
 
 ## Versione 12.4.0 (22/08/2025)
 

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti.jsx
@@ -24,7 +24,7 @@ const PageHeaderTassonomiaArgomenti = ({ content }) => {
 
   return content?.tassonomia_argomenti?.length > 0 ? (
     <div className="mt-4 mb-4 page-arguments">
-      <h2>
+      <h2 className="h5">
         <small>{intl.formatMessage(messages.topics)}</small>
       </h2>
       {content.tassonomia_argomenti.map((item, i) => (

--- a/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti.jsx
+++ b/src/components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti.jsx
@@ -24,9 +24,9 @@ const PageHeaderTassonomiaArgomenti = ({ content }) => {
 
   return content?.tassonomia_argomenti?.length > 0 ? (
     <div className="mt-4 mb-4 page-arguments">
-      <h5>
+      <h2>
         <small>{intl.formatMessage(messages.topics)}</small>
-      </h5>
+      </h2>
       {content.tassonomia_argomenti.map((item, i) => (
         <UniversalLink
           item={item}


### PR DESCRIPTION
Esempio: 
<img width="1357" height="533" alt="Screenshot 2025-10-03 at 11 32 31" src="https://github.com/user-attachments/assets/c2f2562d-8b96-4d71-8ca4-2fc989a5bd45" />
