### PR TITLE
fix: bandisearch

### DIFF
--- a/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
@@ -86,7 +86,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
     if (data.defaultQuerystring) {
       query.push(
         ...data.defaultQuerystring.filter(
-          (el) => !query.map((q) => q.i).includes(el.i) && el.i !=='portal_type'
+          (el) => !query.map((q) => q.i).includes(el.i)
         ),
       );
     }

--- a/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
@@ -58,7 +58,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
   const resultsRef = createRef();
 
   const doRequest = (page = currentPage) => {
-    let query = [
+    const query = [
       {
         i: 'portal_type',
         o: 'plone.app.querystring.operation.selection.any',
@@ -75,12 +75,6 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
       }
     });
 
-    if (data.defaultQuerystring) {
-      query.push(
-        ...data.defaultQuerystring.filter((el) => el.i !== 'portal_type'),
-      );
-    }
-
     if (data.location && data.location[0]) {
       query.push({
         i: 'path',
@@ -88,6 +82,15 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
         v: flattenToAppURL(data.location[0]['@id']),
       });
     }
+
+    if (data.defaultQuerystring) {
+      query.push(
+        ...data.defaultQuerystring.filter(
+          (el) => !query.map((q) => q.i).includes(el.i)
+        ),
+      );
+    }
+
 
     dispatch(
       getQueryStringResults(

--- a/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/BandiSearch/Body.jsx
@@ -86,7 +86,7 @@ const Body = ({ data, id, inEditMode, path, onChangeBlock }) => {
     if (data.defaultQuerystring) {
       query.push(
         ...data.defaultQuerystring.filter(
-          (el) => !query.map((q) => q.i).includes(el.i)
+          (el) => !query.map((q) => q.i).includes(el.i) && el.i !=='portal_type'
         ),
       );
     }


### PR DESCRIPTION
In v2 è possibile definire nel blocco bandisearch dei filtri iniziale, se i filtri iniziali hanno dei valori, il menu in pagina dell'utenet viene completamente ignorato, perchè al backend venivano mandati sia i filtri dell'utente che quelli del filtro iniziale.

Con questa modifica, i filtri dell'utente sovrascrivono quelli iniziali, sul singolo ndice