### PR TITLE
fix: focus management in block edit

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Migliorata la gestione del focus tra i blocchi in modalità di modifica.
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
 ## Versione 12.5.2 (03/10/2025)
 
 ### Fix

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1922,6 +1922,11 @@ msgstr ""
 msgid "deleghe"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: delete {type} block
+msgid "delete_block"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/ContactsWidget/ContactsConfigWidget
 # defaultMessage: Delete
 msgid "delete_button"
@@ -2081,6 +2086,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: Download and Play video
 msgid "downloadPlayVideo"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: drag {type} block
+msgid "drag_block"
 msgstr ""
 
 #: components/SelectInput/SelectInput

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1907,6 +1907,11 @@ msgstr "Term effective date"
 msgid "deleghe"
 msgstr "Delegations"
 
+#: overrideTranslations
+# defaultMessage: delete {type} block
+msgid "delete_block"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/ContactsWidget/ContactsConfigWidget
 # defaultMessage: Delete
 msgid "delete_button"
@@ -2066,6 +2071,11 @@ msgstr "Download"
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: Download and Play video
 msgid "downloadPlayVideo"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: drag {type} block
+msgid "drag_block"
 msgstr ""
 
 #: components/SelectInput/SelectInput

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1916,6 +1916,11 @@ msgstr "Fecha límite"
 msgid "deleghe"
 msgstr "Delegaciones"
 
+#: overrideTranslations
+# defaultMessage: delete {type} block
+msgid "delete_block"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/ContactsWidget/ContactsConfigWidget
 # defaultMessage: Delete
 msgid "delete_button"
@@ -2075,6 +2080,11 @@ msgstr "Descargar"
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: Download and Play video
 msgid "downloadPlayVideo"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: drag {type} block
+msgid "drag_block"
 msgstr ""
 
 #: components/SelectInput/SelectInput

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1924,6 +1924,11 @@ msgstr "Date effective"
 msgid "deleghe"
 msgstr "Déléghe"
 
+#: overrideTranslations
+# defaultMessage: delete {type} block
+msgid "delete_block"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/ContactsWidget/ContactsConfigWidget
 # defaultMessage: Delete
 msgid "delete_button"
@@ -2083,6 +2088,11 @@ msgstr "Télécharger"
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: Download and Play video
 msgid "downloadPlayVideo"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: drag {type} block
+msgid "drag_block"
 msgstr ""
 
 #: components/SelectInput/SelectInput

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1907,6 +1907,11 @@ msgstr "Decorrenza termine"
 msgid "deleghe"
 msgstr "Deleghe"
 
+#: overrideTranslations
+# defaultMessage: delete {type} block
+msgid "delete_block"
+msgstr "Elimina blocco {type}"
+
 #: components/ItaliaTheme/manage/Widgets/ContactsWidget/ContactsConfigWidget
 # defaultMessage: Delete
 msgid "delete_button"
@@ -2067,6 +2072,11 @@ msgstr "Scarica"
 # defaultMessage: Download and Play video
 msgid "downloadPlayVideo"
 msgstr "Scarica e riproduci video"
+
+#: overrideTranslations
+# defaultMessage: drag {type} block
+msgid "drag_block"
+msgstr "Trascina blocco {type}"
 
 #: components/SelectInput/SelectInput
 # defaultMessage: Apri il menu

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-10-02T13:26:14.817Z\n"
+"POT-Creation-Date: 2025-10-07T10:55:00.063Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1909,6 +1909,11 @@ msgstr ""
 msgid "deleghe"
 msgstr ""
 
+#: overrideTranslations
+# defaultMessage: delete {type} block
+msgid "delete_block"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/ContactsWidget/ContactsConfigWidget
 # defaultMessage: Delete
 msgid "delete_button"
@@ -2068,6 +2073,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/EmbeddedVideo
 # defaultMessage: Download and Play video
 msgid "downloadPlayVideo"
+msgstr ""
+
+#: overrideTranslations
+# defaultMessage: drag {type} block
+msgid "drag_block"
 msgstr ""
 
 #: components/SelectInput/SelectInput

--- a/src/customizations/volto/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Icon } from '@plone/volto/components';
+import {
+  blockHasValue,
+  buildStyleClassNamesFromData,
+} from '@plone/volto/helpers';
+import dragSVG from '@plone/volto/icons/drag.svg';
+import { Button } from 'semantic-ui-react';
+import includes from 'lodash/includes';
+import isBoolean from 'lodash/isBoolean';
+import { defineMessages, injectIntl } from 'react-intl';
+import cx from 'classnames';
+import config from '@plone/volto/registry';
+import { BlockChooserButton } from '@plone/volto/components';
+
+import trashSVG from '@plone/volto/icons/delete.svg';
+
+const messages = defineMessages({
+  delete_block: {
+    id: 'delete_block',
+    defaultMessage: 'delete {type} block',
+  },
+  drag_block: {
+    id: 'drag_block',
+    defaultMessage: 'drag {type} block',
+  },
+});
+
+const EditBlockWrapper = (props) => {
+  const hideHandler = (data) => {
+    return (
+      !!data.fixed ||
+      (!config.experimental.addBlockButton.enabled &&
+        !(blockHasValue(data) && props.blockProps.editable))
+    );
+  };
+
+  const { intl, blockProps, draginfo, children } = props;
+  const {
+    allowedBlocks,
+    block,
+    blocksConfig,
+    selected,
+    type,
+    onChangeBlock,
+    onDeleteBlock,
+    onInsertBlock,
+    onSelectBlock,
+    onMutateBlock,
+    data,
+    editable,
+    properties,
+    showBlockChooser,
+  } = blockProps;
+  const visible = selected && !hideHandler(data);
+
+  const required = isBoolean(data.required)
+    ? data.required
+    : includes(config.blocks.requiredBlocks, type);
+
+  const styles = buildStyleClassNamesFromData(data.styles);
+
+  return (
+    <div
+      ref={draginfo.innerRef}
+      {...draginfo.draggableProps}
+      // Right now, we can have the alignment information in the styles property or in the
+      // block data root, we inject the classname here for having control over the whole
+      // Block Edit wrapper
+      className={cx(`block-editor-${data['@type']}`, styles, {
+        [data.align]: data.align,
+      })}
+    >
+      <div style={{ position: 'relative' }}>
+        <div
+          style={{
+            visibility: visible ? 'visible' : 'hidden',
+            display: 'inline-block',
+          }}
+          {...draginfo.dragHandleProps}
+          className="drag handle wrapper"
+          aria-label={intl.formatMessage(messages.drag_block, { type })}
+        >
+          <Icon name={dragSVG} size="18px" />
+        </div>
+        <div
+          className={`ui drag block inner ${type}`}
+          onFocus={(e) => {
+            if (!selected) {
+              onSelectBlock(block);
+            }
+          }}
+        >
+          {children}
+          {selected && !required && editable && (
+            <Button
+              icon
+              basic
+              onClick={() => onDeleteBlock(block, true)}
+              className="delete-button"
+              aria-label={intl.formatMessage(messages.delete_block, { type })}
+            >
+              <Icon name={trashSVG} size="18px" />
+            </Button>
+          )}
+          {config.experimental.addBlockButton.enabled && showBlockChooser && (
+            <BlockChooserButton
+              data={data}
+              block={block}
+              onInsertBlock={(id, value) => {
+                if (blockHasValue(data)) {
+                  onSelectBlock(onInsertBlock(id, value));
+                } else {
+                  onChangeBlock(id, value);
+                }
+              }}
+              onMutateBlock={onMutateBlock}
+              allowedBlocks={allowedBlocks}
+              blocksConfig={blocksConfig}
+              size="24px"
+              properties={properties}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default injectIntl(EditBlockWrapper);

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -37,6 +37,15 @@ defineMessages({
     id: 'rrule_weekday',
     defaultMessage: 'giorno feriale',
   },
+  // blocks
+  delete_block: {
+    id: 'delete_block',
+    defaultMessage: 'delete {type} block',
+  },
+  drag_block: {
+    id: 'drag_block',
+    defaultMessage: 'drag {type} block',
+  },
   //---- Volto-form-block ----//
   reset: {
     id: 'form_reset',


### PR DESCRIPTION
La navigazione tra i blocchi in edit si fa con le frecce su/giu
con il tab ci si sposta sugli elementi focusabili. 
 
L'unico problema che vedo è che quando si è in edit e si fa tab e si entra in un blocco elenco (viene selezionato il primo elemento focusabile nel blocco elenco), il blocco rimane deselezionato.
Quindi quello che c'è da fare qui è: 
se un elemento all'interno del blocco elenco riceve il focus, metto selected il blocco stesso.

Su Volto i blocchi elenco non hanno link, viene utilizzato Conditional Link con la condizione di renderizzare un link solo se non si è in edit. 
Se non ci sono link, nei blocchi elenco non risultano elementi focussabili. 
Solo su io-comune abbiamo i blocchi elenco con link anche in edit (poi magari il click non fa nulla ed è disattivato da onClick ma link rimangono)

--> cambiare selected quando il wrapper interno viene focussato