### PR TITLE
fix: avoid bullet points overlapping with images

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Quando un blocco elenco viene affiancato a un blocco immagine allineato a sinistra, l'immagine e l'elenco puntato vengono visualizzati correttamente senza sovrapporsi.
+
 ## Versione 12.11.4 (02/04/2026)
 
 ### Migliorie

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -18,8 +18,6 @@
   }
 }
 
-//
-
 .documentFirstHeading {
   border: none;
 
@@ -127,6 +125,12 @@ iframe {
   .text-larger {
     //.text-larger: stile applicabile da editor Slate
     font-size: 1.75em;
+  }
+
+  // fix to avoid overlapping of list marker with images when in float: left
+  #page-document > ul,
+  .richtext-blocks > ul {
+    display: flow-root;
   }
 }
 


### PR DESCRIPTION
<img width="475" height="217" alt="image" src="https://github.com/user-attachments/assets/19766a2c-e8f7-4380-8812-32bb6401d017" />

https://v3.io-comune.redturtle.it/amministrazione

When a block image with left alignment + a bullet list is added to a page, the bullet points overlap with the image

Added `display: flow-root` to avoid this problem.
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/display#flow-root

The style has been applied to all `<ul>` elements inside `#page-document` (i.e. CT Page) or `.richtext-blocks` (blocks section in other CTs). 
This style does not affect <ul> elements that are not near or affected by a float state in a problematic way, but it does solve the problems for those that are.

The choice was to change this rather than add margin to the image as that would have not prevented problems of indentation with nested lists, and it would've also moved any "normal" text:
<img width="439" height="196" alt="image" src="https://github.com/user-attachments/assets/47b7107e-7a46-4dcc-ad4b-5b734718d3de" />

Result with `display: flow-root`
<img width="490" height="208" alt="image" src="https://github.com/user-attachments/assets/bd0dc654-fefe-46b7-b25b-8063ba706e24" />
