### PR TITLE
feat!: testi della pagina di login configurabili via config.js

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,11 +45,7 @@
 
 ### Migliorie
 
-- ...
-
-### Novità
-
-- ...
+- I testi della pagina di login (titolo, descrizione, testo del pulsante SPID e link informativo) sono ora personalizzabili a livello di tema, permettendo ai sottotemi di adattarli alle proprie esigenze.
 
 ### Fix
 

--- a/src/components/ItaliaTheme/LoginAgid/LoginAgid.jsx
+++ b/src/components/ItaliaTheme/LoginAgid/LoginAgid.jsx
@@ -15,7 +15,6 @@ import { LoginAgidButtons } from 'design-comuni-plone-theme/components/ItaliaThe
 import { Button } from 'design-react-kit';
 import { useLocation } from 'react-router-dom';
 import { getBaseUrl } from '@plone/volto/helpers';
-import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   login: {

--- a/src/components/ItaliaTheme/LoginAgid/LoginAgid.jsx
+++ b/src/components/ItaliaTheme/LoginAgid/LoginAgid.jsx
@@ -15,6 +15,7 @@ import { LoginAgidButtons } from 'design-comuni-plone-theme/components/ItaliaThe
 import { Button } from 'design-react-kit';
 import { useLocation } from 'react-router-dom';
 import { getBaseUrl } from '@plone/volto/helpers';
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   login: {

--- a/src/components/ItaliaTheme/LoginAgid/LoginAgidButtons.jsx
+++ b/src/components/ItaliaTheme/LoginAgid/LoginAgidButtons.jsx
@@ -66,7 +66,7 @@ const LoginAuthButton = ({ spidLoginUrl, qs, intl }) => (
         <span>{getSiteProperty('loginAuthButtonText', intl.locale)}</span>
       </Button>
 
-      {config.settings.siteProperties.showSpidActivationInfo && (
+      {config.settings.siteProperties.loginShowSpidActivationInfo && (
         <div>
           <UniversalLink href="https://www.spid.gov.it/cos-e-spid/come-attivare-spid">
             <small>{intl.formatMessage(messages.loginSpidHelp)}</small>

--- a/src/components/ItaliaTheme/LoginAgid/LoginAgidButtons.jsx
+++ b/src/components/ItaliaTheme/LoginAgid/LoginAgidButtons.jsx
@@ -17,20 +17,13 @@ import {
 import { Icon as BaseIcon } from '@plone/volto/components';
 import { useLocation } from 'react-router-dom';
 import config from '@plone/volto/registry';
+import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 import cieSVG from 'design-comuni-plone-theme/icons/entra_con_cie.svg';
 
 const messages = defineMessages({
   loginSpid: {
     id: 'login_spid',
     defaultMessage: 'SPID',
-  },
-  loginSpidDescription: {
-    id: 'login_spid_description',
-    defaultMessage: 'Log in with SPID, the public digital identity system.',
-  },
-  loginSpidButton: {
-    id: 'login_with_spid',
-    defaultMessage: 'Login with SPID',
   },
   loginSpidHelp: {
     id: 'login_spid_help',
@@ -39,14 +32,6 @@ const messages = defineMessages({
   loginCie: {
     id: 'login_cie',
     defaultMessage: 'CIE',
-  },
-  loginCieDescription: {
-    id: 'login_cie_description',
-    defaultMessage: 'Log in with CIE.',
-  },
-  loginCieButton: {
-    id: 'login_with_cie',
-    defaultMessage: 'Login with CIE',
   },
   loginCieHelp: {
     id: 'login_cie_help',
@@ -60,11 +45,11 @@ function useQueryV5() {
   return React.useMemo(() => new URLSearchParams(search), [search]);
 }
 
-const SpidButton = ({ spidLoginUrl, qs, intl }) => (
+const LoginAuthButton = ({ spidLoginUrl, qs, intl }) => (
   <div className="login-method">
-    <h2>{intl.formatMessage(messages.loginSpid)}</h2>
+    <h2>{getSiteProperty('loginAuthPage', intl.locale)}</h2>
     <p className="description">
-      {intl.formatMessage(messages.loginSpidDescription)}
+      {getSiteProperty('loginAuthDescription', intl.locale)}
     </p>
     <div className="authorized-spid-login mb-4">
       <Button
@@ -78,13 +63,16 @@ const SpidButton = ({ spidLoginUrl, qs, intl }) => (
         <span className="rounded-icon">
           <Icon color="primary" icon="it-user" padding={false} size="" />
         </span>
-        <span>{intl.formatMessage(messages.loginSpidButton)}</span>
+        <span>{getSiteProperty('loginAuthButtonText', intl.locale)}</span>
       </Button>
-      <div>
-        <UniversalLink href="https://www.spid.gov.it/cos-e-spid/come-attivare-spid">
-          <small>{intl.formatMessage(messages.loginSpidHelp)}</small>
-        </UniversalLink>
-      </div>
+
+      {config.settings.siteProperties.showSpidActivationInfo && (
+        <div>
+          <UniversalLink href="https://www.spid.gov.it/cos-e-spid/come-attivare-spid">
+            <small>{intl.formatMessage(messages.loginSpidHelp)}</small>
+          </UniversalLink>
+        </div>
+      )}
     </div>
   </div>
 );
@@ -93,7 +81,7 @@ const CieButton = ({ cieLoginUrl, qs, intl }) => (
   <div className="login-method">
     <h2>{intl.formatMessage(messages.loginCie)}</h2>
     <p className="description">
-      {intl.formatMessage(messages.loginCieDescription)}
+      {getSiteProperty('loginAuthDescription', intl.locale)}
     </p>
     <div className="authorized-spid-login mb-4">
       <Button
@@ -106,7 +94,7 @@ const CieButton = ({ cieLoginUrl, qs, intl }) => (
         style={{
           padding: 0,
         }}
-        title={intl.formatMessage(messages.loginCieButton)}
+        title={getSiteProperty('loginAuthButtonText', intl.locale)}
       >
         <BaseIcon name={cieSVG} style={{ width: '100%', height: '100%' }} />
       </Button>
@@ -123,7 +111,7 @@ const ArButton = ({ arLoginUrl, intl }) => (
   <div className="login-method">
     <h2>{intl.formatMessage(messages.loginSpid)}</h2>
     <p className="description">
-      {intl.formatMessage(messages.loginSpidDescription)}
+      {getSiteProperty('loginAuthDescription', intl.locale)}
     </p>
     <div className="authorized-spid-login mb-4">
       <LoginButton baseLoginUrl={arLoginUrl}>
@@ -131,7 +119,7 @@ const ArButton = ({ arLoginUrl, intl }) => (
           <Icon color="primary" icon="it-user" padding={false} size="" />
         </span>
         <span className="d-none d-lg-block">
-          {intl.formatMessage(messages.loginSpidButton)}
+          {getSiteProperty('loginAuthButtonText', intl.locale)}
         </span>
       </LoginButton>
     </div>
@@ -155,7 +143,7 @@ const LoginAgidButtons = ({ origin }) => {
   return (
     <>
       {spidLoginUrl && (
-        <SpidButton intl={intl} qs={qs} spidLoginUrl={spidLoginUrl} />
+        <LoginAuthButton intl={intl} qs={qs} spidLoginUrl={spidLoginUrl} />
       )}
       {cieLoginUrl && (
         <CieButton intl={intl} qs={qs} cieLoginUrl={cieLoginUrl} />

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -243,15 +243,15 @@ export default function applyConfig(voltoConfig) {
 
       // PROPS PER LOGIN AGID
       loginAuthPage: {
-        it: 'Autenticazione',
+        it: 'Autenticazione', //titolo della sessione di login autenticato (SPID/CIE/CNS/default="Autenticazione")
         en: 'Authentication',
       },
       loginAuthDescription: {
-        it: 'Accedi con SPID o CIE, i sistemi Pubblici di Identità Digitale.',
+        it: 'Accedi con SPID o CIE, i sistemi Pubblici di Identità Digitale.', // SPID/CIE/CNS
         en: 'Log in with SPID or CIE, the public digital identity systems.',
       },
       loginAuthButtonText: {
-        it: 'Accedi con SPID o CIE',
+        it: 'Accedi con SPID o CIE', //SPID/CIE/CNS
         en: 'Login with SPID or CIE',
       },
       loginShowSpidActivationInfo: true, //se true, nella pagina di login mostra il testo con le indicazioni per attivare SPID.

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -237,9 +237,9 @@ export default function applyConfig(voltoConfig) {
       subsiteParentSiteTitle: 'io-Comune', //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'Nome del sito padre', 'en':'Parent site name'}. Se multilingua il default è comunque la stringa.
       amministrazioneTrasparenteUrl: '/amministrazione-trasparente',
       showNextGenerationEU: true,
-      arLoginUrl: '/login?e=1',
-      arLogoutUrl: '/logout?e=1',
-      spidLogin: true, //se true, nella pagina di errore Unauthorized, mostra il pulsante per il login a Spid.
+      // arLoginUrl: '/login?e=1',
+      // arLogoutUrl: '/logout?e=1',
+      // spidLogin: true, //se true, nella pagina di errore Unauthorized, mostra il pulsante per il login a Spid.
 
       // PROPS PER LOGIN AGID
       loginAuthPage: {

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -237,9 +237,25 @@ export default function applyConfig(voltoConfig) {
       subsiteParentSiteTitle: 'io-Comune', //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'Nome del sito padre', 'en':'Parent site name'}. Se multilingua il default è comunque la stringa.
       amministrazioneTrasparenteUrl: '/amministrazione-trasparente',
       showNextGenerationEU: true,
-      // arLoginUrl: '/login?e=1',
-      // arLogoutUrl: '/logout?e=1',
-      // spidLogin: true, //se true, nella pagina di errore Unauthorized, mostra il pulsante per il login a Spid.
+      arLoginUrl: '/login?e=1',
+      arLogoutUrl: '/logout?e=1',
+      spidLogin: true, //se true, nella pagina di errore Unauthorized, mostra il pulsante per il login a Spid.
+
+      // PROPS PER LOGIN AGID
+      loginAuthPage: {
+        it: 'Autenticazione',
+        en: 'Authentication',
+      },
+      loginAuthDescription: {
+        it: 'Accedi con SPID o CIE, i sistemi Pubblici di Identità Digitale.',
+        en: 'Log in with SPID or CIE, the public digital identity systems.',
+      },
+      loginAuthButtonText: {
+        it: 'Accedi con SPID o CIE',
+        en: 'Login with SPID or CIE',
+      },
+      loginShowSpidActivationInfo: true, //se true, nella pagina di login mostra il testo con le indicazioni per attivare SPID.
+
       headerslimTertiaryMenu: {
         default: [
           //{ title: 'Contatti', url: '/it/contatti' },

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -247,12 +247,12 @@ export default function applyConfig(voltoConfig) {
         en: 'Authentication',
       },
       loginAuthDescription: {
-        it: 'Accedi con SPID o CIE, i sistemi Pubblici di Identità Digitale.', // SPID/CIE/CNS
-        en: 'Log in with SPID or CIE, the public digital identity systems.',
+        it: 'Accedi con SPID, il sistema Pubblico di Identità Digitale.', // SPID/CIE/CNS
+        en: 'Log in with SPID, the public digital identity system.',
       },
       loginAuthButtonText: {
-        it: 'Accedi con SPID o CIE', //SPID/CIE/CNS
-        en: 'Login with SPID or CIE',
+        it: 'Accedi con SPID', //SPID/CIE/CNS
+        en: 'Login with SPID',
       },
       loginShowSpidActivationInfo: true, //se true, nella pagina di login mostra il testo con le indicazioni per attivare SPID.
 


### PR DESCRIPTION
Request: Si richiede di poter personalizzare via config la frase ed il pulsante evidenziati.
<img width="418" height="375" alt="Screenshot 2026-04-10 at 12 45 53" src="https://github.com/user-attachments/assets/b1e059f9-cbc3-4961-9dc3-fb5555bbcc86" />

**BREAKING: Il componente LoginAgidButtons, se personalizzato, necessita essere aggiornato per includere le seguenti novità, gestite tramite getSiteProperty e siteProperties. I valori di default sono configurati in italiaConfig.js:**

- Titolo della sezione di autenticazione (loginAuthPage)
- Testo della descrizione (loginAuthDescription)
- Testo del pulsante (loginAuthButtonText)
- Visualizzazione del link di attivazione SPID (showSpidActivationInfo)