### PR TITLE
fix: adjust btn link color to white when callout color is blue 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Quando un blocco elenco viene affiancato a un blocco immagine allineato a sinistra, l'immagine e l'elenco puntato vengono visualizzati correttamente senza sovrapporsi.
+- Sistemato il colore del testo di un link con stile bottone all'interno di un Callout di colore blu, mostrando il link di colore bianco e non blu.
 
 ## Versione 12.11.4 (02/04/2026)
 

--- a/src/theme/ItaliaTheme/Blocks/_callout.scss
+++ b/src/theme/ItaliaTheme/Blocks/_callout.scss
@@ -21,11 +21,24 @@ body.cms-ui {
         }
 
         p {
+
           &,
           * {
             font-family: 'Lora', Georgia, serif !important; //as bootstrap-italia says
           }
         }
+      }
+    }
+  }
+}
+
+.public-ui {
+  .callout.note {
+    .btn-primary {
+      &,
+      * {
+        color: $primary-text;
+        fill: $primary-text;
       }
     }
   }

--- a/src/theme/ItaliaTheme/Blocks/_callout.scss
+++ b/src/theme/ItaliaTheme/Blocks/_callout.scss
@@ -21,7 +21,6 @@ body.cms-ui {
         }
 
         p {
-
           &,
           * {
             font-family: 'Lora', Georgia, serif !important; //as bootstrap-italia says


### PR DESCRIPTION
[US: #74852](https://redturtle.tpondemand.com/RestUI/Board.aspx#page=profile&appConfig=eyJhY2lkIjoiMThENUVDNkNBQzgxQ0NGRTUyOTIxMDgyNUI5NUM4QTQifQ==&boardPopup=userstory/74852/silent)

When you select blue for the callout color, and in the text insert a link making it a button, the color link inside the button is blue, not white. Adjusted the button link color to white

