### PR TITLE
fix: add aria-label and title to autoplay toggle buttons for accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,5 +258,6 @@
   },
   "volta": {
     "node": "16.18.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -258,6 +258,5 @@
   },
   "volta": {
     "node": "16.18.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/NextArrow.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/NextArrow.jsx
@@ -4,7 +4,7 @@ export default function NextArrow(props) {
   const { className, style, onClick } = props;
   return (
     <div className={className} style={{ ...style }} onClick={onClick}>
-      <Icon icon="chevron-right" key="chevron-right" />
+      <Icon icon="chevron-right" key="chevron-right" aria-hidden={true} />
     </div>
   );
 }

--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/PrevArrow.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/PrevArrow.jsx
@@ -4,7 +4,7 @@ export default function PrevArrow(props) {
   const { className, style, onClick } = props;
   return (
     <div className={className} style={{ ...style }} onClick={onClick}>
-      <Icon icon="chevron-left" key="chevron-left-prev" />
+      <Icon icon="chevron-left" key="chevron-left-prev" aria-hidden={true} />
     </div>
   );
 }

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -121,10 +121,20 @@ const PhotogalleryTemplate = ({
                 ? intl.formatMessage(messages.pause)
                 : intl.formatMessage(messages.play)
             }
+            aria-label={
+              autoplay
+                ? intl.formatMessage(messages.pause)
+                : intl.formatMessage(messages.play)
+            }
           >
             <Icon
               key={autoplay ? 'pause' : 'play'}
               icon={autoplay ? 'pause' : 'play'}
+              title={
+                autoplay
+                  ? intl.formatMessage(messages.pause)
+                  : intl.formatMessage(messages.play)
+              }
             />
           </button>
         </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -116,11 +116,6 @@ const PhotogalleryTemplate = ({
         <div className="play-pause-wrapper">
           <button
             onClick={() => toggleAutoplay()}
-            title={
-              autoplay
-                ? intl.formatMessage(messages.pause)
-                : intl.formatMessage(messages.play)
-            }
             aria-label={
               autoplay
                 ? intl.formatMessage(messages.pause)
@@ -130,11 +125,6 @@ const PhotogalleryTemplate = ({
             <Icon
               key={autoplay ? 'pause' : 'play'}
               icon={autoplay ? 'pause' : 'play'}
-              title={
-                autoplay
-                  ? intl.formatMessage(messages.pause)
-                  : intl.formatMessage(messages.play)
-              }
               aria-hidden={true}
             />
           </button>

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -135,6 +135,7 @@ const PhotogalleryTemplate = ({
                   ? intl.formatMessage(messages.pause)
                   : intl.formatMessage(messages.play)
               }
+              aria-hidden={true}
             />
           </button>
         </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -349,6 +349,7 @@ const SliderTemplate = ({
                         ? intl.formatMessage(messages.pause)
                         : intl.formatMessage(messages.play)
                     }
+                    aria-hidden={true}
                   />
                   <span>{userAutoplay ? 'pause' : 'play'}</span>
                 </button>

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -334,11 +334,21 @@ const SliderTemplate = ({
                       ? intl.formatMessage(messages.pause)
                       : intl.formatMessage(messages.play)
                   }
+                  aria-label={
+                    userAutoplay
+                      ? intl.formatMessage(messages.pause)
+                      : intl.formatMessage(messages.play)
+                  }
                   tabIndex={0}
                 >
                   <Icon
                     key={userAutoplay ? 'pause' : 'play'}
                     icon={userAutoplay ? 'pause' : 'play'}
+                    title={
+                      autoplay
+                        ? intl.formatMessage(messages.pause)
+                        : intl.formatMessage(messages.play)
+                    }
                   />
                   <span>{userAutoplay ? 'pause' : 'play'}</span>
                 </button>

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -78,7 +78,7 @@ function NextArrow(props) {
       onKeyDown={handleKeyboardUsers}
       id="sliderNextArrow"
     >
-      <Icon icon="chevron-right" key="chevron-right" />
+      <Icon icon="chevron-right" key="chevron-right" aria-hidden={true} />
       <span class="sr-only">{intl.formatMessage(messages.successivo)}</span>
     </button>
   );
@@ -121,7 +121,7 @@ function PrevArrow(props) {
       id="sliderPrevArrow"
       onKeyDown={handleKeyboardUsers}
     >
-      <Icon icon="chevron-left" key="chevron-left-prev" />
+      <Icon icon="chevron-left" key="chevron-left-prev" aria-hidden={true} />
       <span class="sr-only">{intl.formatMessage(messages.precedente)}</span>
     </button>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -115,7 +115,6 @@ function PrevArrow(props) {
       className={className}
       style={{ ...style }}
       onClick={handleClick}
-      title={intl.formatMessage(messages.precedente)}
       aria-label={intl.formatMessage(messages.precedente)}
       aria-hidden={false}
       id="sliderPrevArrow"
@@ -329,11 +328,6 @@ const SliderTemplate = ({
               <div className="play-pause-wrapper">
                 <button
                   onClick={toggleAutoplay}
-                  title={
-                    userAutoplay
-                      ? intl.formatMessage(messages.pause)
-                      : intl.formatMessage(messages.play)
-                  }
                   aria-label={
                     userAutoplay
                       ? intl.formatMessage(messages.pause)
@@ -344,11 +338,6 @@ const SliderTemplate = ({
                   <Icon
                     key={userAutoplay ? 'pause' : 'play'}
                     icon={userAutoplay ? 'pause' : 'play'}
-                    title={
-                      autoplay
-                        ? intl.formatMessage(messages.pause)
-                        : intl.formatMessage(messages.play)
-                    }
                     aria-hidden={true}
                   />
                   <span>{userAutoplay ? 'pause' : 'play'}</span>

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -33,6 +33,25 @@ import {
 
 import { getDropdownMenuNavitems, getItemsByPath } from 'volto-dropdownmenu';
 
+const messages = defineMessages({
+  CloseMenu: {
+    id: 'close-menu',
+    defaultMessage: 'Chiudi menu',
+  },
+  toggleMenu: {
+    id: 'toggle-menu',
+    defaultMessage: '{action} il menu',
+  },
+  toggleMenu_open: {
+    id: 'toggleMenu_open',
+    defaultMessage: 'Apri',
+  },
+  toggleMenu_close: {
+    id: 'toggleMenu_close',
+    defaultMessage: 'Chiudi',
+  },
+});
+
 const Navigation = ({ pathname }) => {
   const intl = useIntl();
   const [collapseOpen, setCollapseOpen] = useState(false);
@@ -176,25 +195,6 @@ const Navigation = ({ pathname }) => {
     </Header>
   );
 };
-
-const messages = defineMessages({
-  CloseMenu: {
-    id: 'close-menu',
-    defaultMessage: 'Chiudi menu',
-  },
-  toggleMenu: {
-    id: 'toggle-menu',
-    defaultMessage: '{action} il menu',
-  },
-  toggleMenu_open: {
-    id: 'toggleMenu_open',
-    defaultMessage: 'Apri',
-  },
-  toggleMenu_close: {
-    id: 'toggleMenu_close',
-    defaultMessage: 'Chiudi',
-  },
-});
 
 Navigation.propTypes = {
   pathname: PropTypes.string.isRequired,


### PR DESCRIPTION
Adds aria-label and title attributes to the play/pause autoplay buttons in PhotogalleryTemplate and SliderTemplate, improving accessibility for screen readers and assistive technologies. The labels are already translated via intl, so they follow the page locale correctly.