### PR TITLE
fix: removed title from img inside ListingImage for better a11y

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingImage.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingImage.jsx
@@ -27,7 +27,6 @@ const ListingImage = ({
         }
         aria-hidden="true"
         alt=""
-        title={item.title}
         role="presentation"
         imageField={item.image_field}
         useOriginal={useOriginal}


### PR DESCRIPTION
- Removed the title prop from the <Image> component inside ListingImage.jsx                                                                                                                                     
                  
Images used purely for decoration (with aria-hidden="true", alt="", and role="presentation") should not have a title attribute. Screen readers may still announce the title even when the image is marked as presentational, creating redundant or confusing announcements for assistive technology users. This change  aligns the component with WCAG best practices for decorative images.

V3 is already set without title