### PR TITLE
fix: hamburger menu button aria-label not being translated

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,5 +258,6 @@
   },
   "volta": {
     "node": "16.18.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -258,6 +258,5 @@
   },
   "volta": {
     "node": "16.18.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -33,6 +33,25 @@ import {
 
 import { getDropdownMenuNavitems, getItemsByPath } from 'volto-dropdownmenu';
 
+const messages = defineMessages({
+  CloseMenu: {
+    id: 'close-menu',
+    defaultMessage: 'Chiudi menu',
+  },
+  toggleMenu: {
+    id: 'toggle-menu',
+    defaultMessage: '{action} il menu',
+  },
+  toggleMenu_open: {
+    id: 'toggleMenu_open',
+    defaultMessage: 'Apri',
+  },
+  toggleMenu_close: {
+    id: 'toggleMenu_close',
+    defaultMessage: 'Chiudi',
+  },
+});
+
 const Navigation = ({ pathname }) => {
   const intl = useIntl();
   const [collapseOpen, setCollapseOpen] = useState(false);
@@ -176,25 +195,6 @@ const Navigation = ({ pathname }) => {
     </Header>
   );
 };
-
-const messages = defineMessages({
-  CloseMenu: {
-    id: 'close-menu',
-    defaultMessage: 'Chiudi menu',
-  },
-  toggleMenu: {
-    id: 'toggle-menu',
-    defaultMessage: '{action} il menu',
-  },
-  toggleMenu_open: {
-    id: 'toggleMenu_open',
-    defaultMessage: 'Apri',
-  },
-  toggleMenu_close: {
-    id: 'toggleMenu_close',
-    defaultMessage: 'Chiudi',
-  },
-});
 
 Navigation.propTypes = {
   pathname: PropTypes.string.isRequired,


### PR DESCRIPTION
The messages block was defined after the component. Since const isn't hoisted, the component tried to use the translations before they were initialized. This caused them to be undefined and show the default text.