### PR TITLE
feat: miglioramento accessibilità: aria-label descrittivi su link e bottoni read-more/link-read-more      

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -844,9 +844,11 @@ msgid "appStoreLink"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/ContactsBlock/View
 #: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
 #: components/ItaliaTheme/Blocks/HighlightedContent/Body
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/View
 #: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -674,6 +674,7 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -843,17 +844,7 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
-#: components/ItaliaTheme/Blocks/ContactsBlock/View
-#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
-#: components/ItaliaTheme/Blocks/HighlightedContent/Body
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/View
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
-#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+#: helpers/redraftHelper
 # defaultMessage: Approfondisci:
 msgid "approfondisci"
 msgstr ""

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -674,7 +674,6 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -842,6 +841,19 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 # defaultMessage: APPStore Link
 msgid "appStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
+#: components/ItaliaTheme/Blocks/HighlightedContent/Body
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
+#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+# defaultMessage: Approfondisci:
+msgid "approfondisci"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSlim/ArLogin
@@ -3852,6 +3864,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
 # defaultMessage: Vedi tutti
 msgid "view_all"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
+# defaultMessage: Vedi tutti gli argomenti
+msgid "view_all_argomenti"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/LocationsMap

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -659,6 +659,7 @@ msgstr "Go to page"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -828,17 +829,7 @@ msgstr "Opening date"
 msgid "appStoreLink"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
-#: components/ItaliaTheme/Blocks/ContactsBlock/View
-#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
-#: components/ItaliaTheme/Blocks/HighlightedContent/Body
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/View
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
-#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+#: helpers/redraftHelper
 # defaultMessage: Approfondisci:
 msgid "approfondisci"
 msgstr "Read more:"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -829,9 +829,11 @@ msgid "appStoreLink"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/ContactsBlock/View
 #: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
 #: components/ItaliaTheme/Blocks/HighlightedContent/Body
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/View
 #: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -659,7 +659,6 @@ msgstr "Go to page"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -828,6 +827,19 @@ msgstr "Opening date"
 # defaultMessage: APPStore Link
 msgid "appStoreLink"
 msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
+#: components/ItaliaTheme/Blocks/HighlightedContent/Body
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
+#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+# defaultMessage: Approfondisci:
+msgid "approfondisci"
+msgstr "Read more:"
 
 #: components/ItaliaTheme/Header/HeaderSlim/ArLogin
 # defaultMessage: Esci
@@ -3838,6 +3850,11 @@ msgstr "You are currently in a carousel, use left and right arrows to navigate"
 # defaultMessage: Vedi tutti
 msgid "view_all"
 msgstr "View all"
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
+# defaultMessage: Vedi tutti gli argomenti
+msgid "view_all_argomenti"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/LocationsMap
 # defaultMessage: Vedi su Apple Maps

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -838,9 +838,11 @@ msgid "appStoreLink"
 msgstr "Enlace de la tienda de aplicaciones"
 
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/ContactsBlock/View
 #: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
 #: components/ItaliaTheme/Blocks/HighlightedContent/Body
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/View
 #: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -668,6 +668,7 @@ msgstr "Ir a la página"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -837,17 +838,7 @@ msgstr "Fecha de apertura"
 msgid "appStoreLink"
 msgstr "Enlace de la tienda de aplicaciones"
 
-#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
-#: components/ItaliaTheme/Blocks/ContactsBlock/View
-#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
-#: components/ItaliaTheme/Blocks/HighlightedContent/Body
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/View
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
-#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+#: helpers/redraftHelper
 # defaultMessage: Approfondisci:
 msgid "approfondisci"
 msgstr ""

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -668,7 +668,6 @@ msgstr "Ir a la página"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -837,6 +836,19 @@ msgstr "Fecha de apertura"
 # defaultMessage: APPStore Link
 msgid "appStoreLink"
 msgstr "Enlace de la tienda de aplicaciones"
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
+#: components/ItaliaTheme/Blocks/HighlightedContent/Body
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
+#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+# defaultMessage: Approfondisci:
+msgid "approfondisci"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSlim/ArLogin
 # defaultMessage: Esci
@@ -3847,6 +3859,11 @@ msgstr "Tu estás actualmente en un carrusel, para navegar usa las flechas izqui
 # defaultMessage: Vedi tutti
 msgid "view_all"
 msgstr "Ver todo"
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
+# defaultMessage: Vedi tutti gli argomenti
+msgid "view_all_argomenti"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/LocationsMap
 # defaultMessage: Vedi su Apple Maps

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -676,6 +676,7 @@ msgstr "Aller à la page"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -845,17 +846,7 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
-#: components/ItaliaTheme/Blocks/ContactsBlock/View
-#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
-#: components/ItaliaTheme/Blocks/HighlightedContent/Body
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/View
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
-#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+#: helpers/redraftHelper
 # defaultMessage: Approfondisci:
 msgid "approfondisci"
 msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -846,9 +846,11 @@ msgid "appStoreLink"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/ContactsBlock/View
 #: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
 #: components/ItaliaTheme/Blocks/HighlightedContent/Body
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/View
 #: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -676,7 +676,6 @@ msgstr "Aller à la page"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -844,6 +843,19 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 # defaultMessage: APPStore Link
 msgid "appStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
+#: components/ItaliaTheme/Blocks/HighlightedContent/Body
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
+#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+# defaultMessage: Approfondisci:
+msgid "approfondisci"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSlim/ArLogin
@@ -3855,6 +3867,11 @@ msgstr ""
 # defaultMessage: Vedi tutti
 msgid "view_all"
 msgstr "Voir tous"
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
+# defaultMessage: Vedi tutti gli argomenti
+msgid "view_all_argomenti"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/LocationsMap
 # defaultMessage: Vedi su Apple Maps

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -659,6 +659,7 @@ msgstr "Vai alla pagina"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -828,17 +829,7 @@ msgstr "Apertura del bando"
 msgid "appStoreLink"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
-#: components/ItaliaTheme/Blocks/ContactsBlock/View
-#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
-#: components/ItaliaTheme/Blocks/HighlightedContent/Body
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/View
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
-#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+#: helpers/redraftHelper
 # defaultMessage: Approfondisci:
 msgid "approfondisci"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -829,9 +829,11 @@ msgid "appStoreLink"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/ContactsBlock/View
 #: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
 #: components/ItaliaTheme/Blocks/HighlightedContent/Body
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/View
 #: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -659,7 +659,6 @@ msgstr "Vai alla pagina"
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -827,6 +826,19 @@ msgstr "Apertura del bando"
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 # defaultMessage: APPStore Link
 msgid "appStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
+#: components/ItaliaTheme/Blocks/HighlightedContent/Body
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
+#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+# defaultMessage: Approfondisci:
+msgid "approfondisci"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSlim/ArLogin
@@ -3838,6 +3850,11 @@ msgstr ""
 # defaultMessage: Vedi tutti
 msgid "view_all"
 msgstr "Vedi tutti"
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
+# defaultMessage: Vedi tutti gli argomenti
+msgid "view_all_argomenti"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/LocationsMap
 # defaultMessage: Vedi su Apple Maps

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-04-22T07:47:42.451Z\n"
+"POT-Creation-Date: 2026-04-22T09:58:44.641Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -831,9 +831,11 @@ msgid "appStoreLink"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/ContactsBlock/View
 #: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
 #: components/ItaliaTheme/Blocks/HighlightedContent/Body
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/View
 #: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
 #: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-08-06T08:30:02.170Z\n"
+"POT-Creation-Date: 2026-04-22T07:47:42.451Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -661,7 +661,6 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -829,6 +828,19 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 # defaultMessage: APPStore Link
 msgid "appStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
+#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
+#: components/ItaliaTheme/Blocks/HighlightedContent/Body
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
+#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
+#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
+#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
+#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+# defaultMessage: Approfondisci:
+msgid "approfondisci"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSlim/ArLogin
@@ -3839,6 +3851,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
 # defaultMessage: Vedi tutti
 msgid "view_all"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody
+# defaultMessage: Vedi tutti gli argomenti
+msgid "view_all_argomenti"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/LocationsMap

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-04-22T09:58:44.641Z\n"
+"POT-Creation-Date: 2026-04-27T12:55:23.714Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -661,6 +661,7 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
+#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
 #: components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate
 # defaultMessage: Vedi
@@ -830,17 +831,7 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
-#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
-#: components/ItaliaTheme/Blocks/ContactsBlock/View
-#: components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons
-#: components/ItaliaTheme/Blocks/HighlightedContent/Body
-#: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
-#: components/ItaliaTheme/Blocks/IconBlocks/View
-#: components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate
-#: components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
-#: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
-#: components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence
+#: helpers/redraftHelper
 # defaultMessage: Approfondisci:
 msgid "approfondisci"
 msgstr ""

--- a/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import { TextEditorWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import {
   Card,
@@ -25,10 +26,6 @@ const messages = defineMessages({
   select_argument_sidebar: {
     id: 'select_argument_sidebar',
     defaultMessage: 'Seleziona un argomento nella barra a lato',
-  },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
   },
 });
 
@@ -75,14 +72,7 @@ const Block = ({
               tag="a"
               text={intl.formatMessage(messages.exploreArgument)}
               href={flattenToAppURL(argument['@id'])}
-              aria-label={
-                argument.title &&
-                intl.formatMessage(messages.approfondisci) +
-                  ' ' +
-                  (argument.title.length > 80
-                    ? argument.title.slice(0, 80) + '…'
-                    : argument.title)
-              }
+              aria-label={getCardAriaLabel(intl, argument.title)}
             />
           )}
         </CardBody>

--- a/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import { TextEditorWidget } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import {
   Card,
@@ -72,7 +72,7 @@ const Block = ({
               tag="a"
               text={intl.formatMessage(messages.exploreArgument)}
               href={flattenToAppURL(argument['@id'])}
-              aria-label={getCardAriaLabel(intl, argument.title)}
+              aria-label={getReadMoreAriaLabel(intl, argument.title)}
             />
           )}
         </CardBody>

--- a/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
@@ -79,7 +79,9 @@ const Block = ({
                 argument.title &&
                 intl.formatMessage(messages.approfondisci) +
                   ' ' +
-                  argument.title
+                  (argument.title.length > 80
+                    ? argument.title.slice(0, 80) + '…'
+                    : argument.title)
               }
             />
           )}

--- a/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block.jsx
@@ -26,6 +26,10 @@ const messages = defineMessages({
     id: 'select_argument_sidebar',
     defaultMessage: 'Seleziona un argomento nella barra a lato',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
 });
 
 const Block = ({
@@ -71,6 +75,12 @@ const Block = ({
               tag="a"
               text={intl.formatMessage(messages.exploreArgument)}
               href={flattenToAppURL(argument['@id'])}
+              aria-label={
+                argument.title &&
+                intl.formatMessage(messages.approfondisci) +
+                  ' ' +
+                  argument.title
+              }
             />
           )}
         </CardBody>

--- a/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody.jsx
+++ b/src/components/ItaliaTheme/Blocks/ArgumentsInEvidence/BottomBody.jsx
@@ -13,6 +13,10 @@ const messages = defineMessages({
     id: 'view_all',
     defaultMessage: 'Vedi tutti',
   },
+  view_all_argomenti: {
+    id: 'view_all_argomenti',
+    defaultMessage: 'Vedi tutti gli argomenti',
+  },
   otherArguments: {
     id: 'otherArguments',
     defaultMessage: 'ALTRI ARGOMENTI',
@@ -55,6 +59,7 @@ const BottomBody = ({ data, intl }) => {
           tag={UniversalLink}
           href="/argomenti"
           className="view-all text-decoration-none"
+          aria-label={intl?.formatMessage(messages.view_all_argomenti)}
         >
           {intl?.formatMessage(messages.view_all)}
         </Button>

--- a/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
@@ -352,6 +352,7 @@ const Body = ({ data, block, inEditMode, path, onChangeBlock, reactSlick }) => {
             href={data.linkHref}
             linkAlign={data.linkAlign}
             className="my-4"
+            blockTitle={data.title}
           />
         </div>
       </Container>

--- a/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
@@ -352,7 +352,7 @@ const Body = ({ data, block, inEditMode, path, onChangeBlock, reactSlick }) => {
             href={data.linkHref}
             linkAlign={data.linkAlign}
             className="my-4"
-            blockTitle={data.title}
+            ariaLabel={data.title}
           />
         </div>
       </Container>

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
@@ -12,7 +12,7 @@ import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 
 /**
@@ -26,7 +26,7 @@ const AccordionView = ({ data, block }) => {
   const blockPlainTitle = data.title
     ? convertFromRaw(data.title).getPlainText()
     : null;
-  const linkMoreAriaLabel = getCardAriaLabel(intl, blockPlainTitle);
+  const linkMoreAriaLabel = getReadMoreAriaLabel(intl, blockPlainTitle);
   return (
     <div className="block contacts">
       <div className="public-ui">

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
@@ -6,11 +6,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
+import { useIntl, defineMessages } from 'react-intl';
 import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
 import config from '@plone/volto/registry';
+
+const messages = defineMessages({
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
+});
 
 /**
  * View Accordion block class.
@@ -18,7 +26,12 @@ import config from '@plone/volto/registry';
  * @extends Component
  */
 const AccordionView = ({ data, block }) => {
+  const intl = useIntl();
   const id = new Date().getTime();
+  const blockPlainTitle = data.title?.blocks?.[0]?.text || null;
+  const linkMoreAriaLabel = blockPlainTitle
+    ? intl.formatMessage(messages.approfondisci) + ' ' + blockPlainTitle
+    : undefined;
   return (
     <div className="block contacts">
       <div className="public-ui">
@@ -60,6 +73,7 @@ const AccordionView = ({ data, block }) => {
                 <UniversalLink
                   href={flattenToAppURL(data.href)}
                   className="btn btn-tertiary"
+                  aria-label={linkMoreAriaLabel}
                 >
                   {data.linkMoreTitle}
                 </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
@@ -6,19 +6,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
+import { convertFromRaw } from 'draft-js';
 import { useIntl, defineMessages } from 'react-intl';
 import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
-
-const messages = defineMessages({
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
-  },
-});
 
 /**
  * View Accordion block class.
@@ -28,10 +23,10 @@ const messages = defineMessages({
 const AccordionView = ({ data, block }) => {
   const intl = useIntl();
   const id = new Date().getTime();
-  const blockPlainTitle = data.title?.blocks?.[0]?.text || null;
-  const linkMoreAriaLabel = blockPlainTitle
-    ? intl.formatMessage(messages.approfondisci) + ' ' + blockPlainTitle
-    : undefined;
+  const blockPlainTitle = data.title
+    ? convertFromRaw(data.title).getPlainText()
+    : null;
+  const linkMoreAriaLabel = getCardAriaLabel(intl, blockPlainTitle);
   return (
     <div className="block contacts">
       <div className="public-ui">

--- a/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
+++ b/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'design-react-kit/dist/design-react-kit';
 import { defineMessages, useIntl } from 'react-intl';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import { UniversalLink } from '@plone/volto/components';
 import { CardReadMore } from 'design-react-kit/dist/design-react-kit';
@@ -41,7 +41,7 @@ const StoresButtons = ({ data }) => {
           iconName="it-arrow-right"
           text={data.moreTitle || intl.formatMessage(messages.linkMore)}
           href={flattenToAppURL(data.moreHref)}
-          aria-label={getCardAriaLabel(intl, data.title)}
+          aria-label={getReadMoreAriaLabel(intl, data.title)}
         />
       )}
     </div>

--- a/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
+++ b/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
@@ -46,7 +46,11 @@ const StoresButtons = ({ data }) => {
           href={flattenToAppURL(data.moreHref)}
           aria-label={
             data.title &&
-            intl.formatMessage(messages.approfondisci) + ' ' + data.title
+            intl.formatMessage(messages.approfondisci) +
+              ' ' +
+              (data.title.length > 80
+                ? data.title.slice(0, 80) + '…'
+                : data.title)
           }
         />
       )}

--- a/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
+++ b/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
@@ -12,6 +12,10 @@ const messages = defineMessages({
     id: 'linkMore',
     defaultMessage: 'Link ad altro',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
 });
 
 const StoresButtons = ({ data }) => {
@@ -34,13 +38,16 @@ const StoresButtons = ({ data }) => {
           </Button>
         )}
       </div>
-
       {data.moreHref && (
         <CardReadMore
           tag={UniversalLink}
           iconName="it-arrow-right"
           text={data.moreTitle || intl.formatMessage(messages.linkMore)}
           href={flattenToAppURL(data.moreHref)}
+          aria-label={
+            data.title &&
+            intl.formatMessage(messages.approfondisci) + ' ' + data.title
+          }
         />
       )}
     </div>

--- a/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
+++ b/src/components/ItaliaTheme/Blocks/HeroImageLeft/StoresButtons.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'design-react-kit/dist/design-react-kit';
 import { defineMessages, useIntl } from 'react-intl';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import { UniversalLink } from '@plone/volto/components';
 import { CardReadMore } from 'design-react-kit/dist/design-react-kit';
@@ -11,10 +12,6 @@ const messages = defineMessages({
   linkMore: {
     id: 'linkMore',
     defaultMessage: 'Link ad altro',
-  },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
   },
 });
 
@@ -44,14 +41,7 @@ const StoresButtons = ({ data }) => {
           iconName="it-arrow-right"
           text={data.moreTitle || intl.formatMessage(messages.linkMore)}
           href={flattenToAppURL(data.moreHref)}
-          aria-label={
-            data.title &&
-            intl.formatMessage(messages.approfondisci) +
-              ' ' +
-              (data.title.length > 80
-                ? data.title.slice(0, 80) + '…'
-                : data.title)
-          }
+          aria-label={getCardAriaLabel(intl, data.title)}
         />
       )}
     </div>

--- a/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { ConditionalLink, UniversalLink } from '@plone/volto/components';
-import { defineMessages } from 'react-intl';
 import cx from 'classnames';
 import {
   Row,
@@ -24,14 +23,8 @@ import {
   CardCategory,
   getItemIcon,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { viewDate } from 'design-comuni-plone-theme/helpers';
+import { viewDate, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 
-const messages = defineMessages({
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
-  },
-});
 
 const Body = (props) => {
   const { content, block } = props;
@@ -104,14 +97,7 @@ const Body = (props) => {
                   iconName="it-arrow-right"
                   text={block.moreTitle || 'Vedi tutte le notizie'}
                   href={flattenToAppURL(block.moreHref)}
-                  aria-label={
-                    content.title &&
-                    intl.formatMessage(messages.approfondisci) +
-                      ' ' +
-                      (content.title.length > 80
-                        ? content.title.slice(0, 80) + '…'
-                        : content.title)
-                  }
+                  aria-label={getCardAriaLabel(intl, content.title)}
                 />
               )}
             </CardBody>

--- a/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { ConditionalLink, UniversalLink } from '@plone/volto/components';
+import { defineMessages } from 'react-intl';
 import cx from 'classnames';
 import {
   Row,
@@ -24,6 +25,13 @@ import {
   getItemIcon,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
 import { viewDate } from 'design-comuni-plone-theme/helpers';
+
+const messages = defineMessages({
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
+});
 
 const Body = (props) => {
   const { content, block } = props;
@@ -96,6 +104,12 @@ const Body = (props) => {
                   iconName="it-arrow-right"
                   text={block.moreTitle || 'Vedi tutte le notizie'}
                   href={flattenToAppURL(block.moreHref)}
+                  aria-label={
+                    content.title &&
+                    intl.formatMessage(messages.approfondisci) +
+                      ' ' +
+                      content.title
+                  }
                 />
               )}
             </CardBody>

--- a/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
@@ -108,7 +108,9 @@ const Body = (props) => {
                     content.title &&
                     intl.formatMessage(messages.approfondisci) +
                       ' ' +
-                      content.title
+                      (content.title.length > 80
+                        ? content.title.slice(0, 80) + '…'
+                        : content.title)
                   }
                 />
               )}

--- a/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/HighlightedContent/Body.jsx
@@ -23,8 +23,10 @@ import {
   CardCategory,
   getItemIcon,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { viewDate, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
-
+import {
+  viewDate,
+  getReadMoreAriaLabel,
+} from 'design-comuni-plone-theme/helpers';
 
 const Body = (props) => {
   const { content, block } = props;
@@ -97,7 +99,7 @@ const Body = (props) => {
                   iconName="it-arrow-right"
                   text={block.moreTitle || 'Vedi tutte le notizie'}
                   href={flattenToAppURL(block.moreHref)}
-                  aria-label={getCardAriaLabel(intl, content.title)}
+                  aria-label={getReadMoreAriaLabel(intl, content.title)}
                 />
               )}
             </CardBody>

--- a/src/components/ItaliaTheme/Blocks/HighlightedContent/Skeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/HighlightedContent/Skeleton.jsx
@@ -40,7 +40,6 @@ const Skeleton = ({ content, pathname, block }) => {
                   iconName="it-arrow-right"
                   text=" "
                   to="#"
-                  aria-label={''}
                 />
               )}
             </CardBody>

--- a/src/components/ItaliaTheme/Blocks/HighlightedContent/Skeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/HighlightedContent/Skeleton.jsx
@@ -40,6 +40,7 @@ const Skeleton = ({ content, pathname, block }) => {
                   iconName="it-arrow-right"
                   text=" "
                   to="#"
+                  aria-label={''}
                 />
               )}
             </CardBody>

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -11,7 +11,7 @@ import { useIntl, defineMessages } from 'react-intl';
 import { UniversalLink } from '@plone/volto/components';
 
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import {
   Card,
   CardBody,
@@ -33,8 +33,10 @@ const messages = defineMessages({
  */
 const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
   const intl = useIntl();
-  const plainTitle = data.title ? convertFromRaw(data.title).getPlainText() : null;
-  const cardReadMoreAriaLabel = getCardAriaLabel(intl, plainTitle);
+  const plainTitle = data.title
+    ? convertFromRaw(data.title).getPlainText()
+    : null;
+  const cardReadMoreAriaLabel = getReadMoreAriaLabel(intl, plainTitle);
   return (
     <Card
       className="card-bg rounded subblock-view"

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -6,10 +6,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
+import { convertFromRaw } from 'draft-js';
 import { useIntl, defineMessages } from 'react-intl';
 import { UniversalLink } from '@plone/volto/components';
 
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import {
   Card,
   CardBody,
@@ -18,9 +20,9 @@ import {
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
+  vedi: {
+    id: 'Vedi',
+    defaultMessage: 'Vedi',
   },
 });
 
@@ -31,12 +33,8 @@ const messages = defineMessages({
  */
 const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
   const intl = useIntl();
-  const plainTitle = data.title?.blocks?.[0]?.text || null;
-  const cardReadMoreAriaLabel = plainTitle
-    ? intl.formatMessage(messages.approfondisci) +
-      ' ' +
-      (plainTitle.length > 80 ? plainTitle.slice(0, 80) + '…' : plainTitle)
-    : undefined;
+  const plainTitle = data.title ? convertFromRaw(data.title).getPlainText() : null;
+  const cardReadMoreAriaLabel = getCardAriaLabel(intl, plainTitle);
   return (
     <Card
       className="card-bg rounded subblock-view"

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -31,6 +31,12 @@ const messages = defineMessages({
  */
 const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
   const intl = useIntl();
+  const plainTitle = data.title?.blocks?.[0]?.text || null;
+  const cardReadMoreAriaLabel = plainTitle
+    ? intl.formatMessage(messages.approfondisci) +
+      ' ' +
+      (plainTitle.length > 80 ? plainTitle.slice(0, 80) + '…' : plainTitle)
+    : undefined;
   return (
     <Card
       className="card-bg rounded subblock-view"
@@ -69,14 +75,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
             tag={UniversalLink}
             href={data.href ?? '#'}
             text={data.linkMoreTitle || intl.formatMessage(messages.vedi)}
-            aria-label={
-              data.title &&
-              intl.formatMessage(messages.approfondisci) +
-                ' ' +
-                (data.title.length > 80
-                  ? data.title.slice(0, 80) + '…'
-                  : data.title)
-            }
+            aria-label={cardReadMoreAriaLabel}
           />
         )}
       </CardBody>

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -71,7 +71,11 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
             text={data.linkMoreTitle || intl.formatMessage(messages.vedi)}
             aria-label={
               data.title &&
-              intl.formatMessage(messages.approfondisci) + ' ' + data.title
+              intl.formatMessage(messages.approfondisci) +
+                ' ' +
+                (data.title.length > 80
+                  ? data.title.slice(0, 80) + '…'
+                  : data.title)
             }
           />
         )}

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -18,9 +18,9 @@ import {
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
-  vedi: {
-    id: 'Vedi',
-    defaultMessage: 'Vedi',
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
   },
 });
 
@@ -70,9 +70,8 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
             href={data.href ?? '#'}
             text={data.linkMoreTitle || intl.formatMessage(messages.vedi)}
             aria-label={
-              data.linkMoreTitle
-                ? data.linkMoreTitle
-                : intl.formatMessage(messages.vedi) + ' ' + data.title
+              data.title &&
+              intl.formatMessage(messages.approfondisci) + ' ' + data.title
             }
           />
         )}

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -12,10 +12,12 @@ import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL, addAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
-import { checkRedraftHasContent, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import {
+  checkRedraftHasContent,
+  getReadMoreAriaLabel,
+} from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
-
 
 /**
  * View Accordion block class.
@@ -28,7 +30,7 @@ const AccordionView = ({ data, block }) => {
   const blockPlainTitle = data.title
     ? convertFromRaw(data.title).getPlainText()
     : null;
-  const linkMoreAriaLabel = getCardAriaLabel(intl, blockPlainTitle);
+  const linkMoreAriaLabel = getReadMoreAriaLabel(intl, blockPlainTitle);
 
   return (
     <div className="block iconBlocks">

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -6,21 +6,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
-import { useIntl, defineMessages } from 'react-intl';
+import { convertFromRaw } from 'draft-js';
+import { useIntl } from 'react-intl';
 import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL, addAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
-import { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers';
+import { checkRedraftHasContent, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
 
-const messages = defineMessages({
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
-  },
-});
 
 /**
  * View Accordion block class.
@@ -30,10 +25,10 @@ const messages = defineMessages({
 const AccordionView = ({ data, block }) => {
   const intl = useIntl();
   const id = new Date().getTime();
-  const blockPlainTitle = data.title?.blocks?.[0]?.text || null;
-  const linkMoreAriaLabel = blockPlainTitle
-    ? intl.formatMessage(messages.approfondisci) + ' ' + blockPlainTitle
-    : undefined;
+  const blockPlainTitle = data.title
+    ? convertFromRaw(data.title).getPlainText()
+    : null;
+  const linkMoreAriaLabel = getCardAriaLabel(intl, blockPlainTitle);
 
   return (
     <div className="block iconBlocks">

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
+import { useIntl, defineMessages } from 'react-intl';
 import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL, addAppURL } from '@plone/volto/helpers';
@@ -14,13 +15,25 @@ import { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
 
+const messages = defineMessages({
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
+});
+
 /**
  * View Accordion block class.
  * @class View
  * @extends Component
  */
 const AccordionView = ({ data, block }) => {
+  const intl = useIntl();
   const id = new Date().getTime();
+  const blockPlainTitle = data.title?.blocks?.[0]?.text || null;
+  const linkMoreAriaLabel = blockPlainTitle
+    ? intl.formatMessage(messages.approfondisci) + ' ' + blockPlainTitle
+    : undefined;
 
   return (
     <div className="block iconBlocks">
@@ -84,6 +97,7 @@ const AccordionView = ({ data, block }) => {
                 <UniversalLink
                   href={flattenToAppURL(data.href)}
                   className="btn btn-tertiary"
+                  aria-label={linkMoreAriaLabel}
                 >
                   {data.linkMoreTitle}
                 </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate.jsx
@@ -94,7 +94,7 @@ const AmministrazioneTrasparenteTablesTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate.jsx
@@ -90,7 +90,12 @@ const AmministrazioneTrasparenteTablesTemplate = ({
           </tbody>
         </table>
 
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -256,10 +256,12 @@ const BandiInEvidenceTemplate = ({
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
                       aria-label={
-                        (item.title || item.id) &&
+                        item.title &&
                         intl.formatMessage(messages.approfondisci) +
                           ' ' +
-                          (item.title || item.id)
+                          (item.title.length > 80
+                            ? item.title.slice(0, 80) + '…'
+                            : item.title)
                       }
                     />
                   </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -271,7 +271,12 @@ const BandiInEvidenceTemplate = ({
           })}
         </div>
 
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -17,16 +17,12 @@ import {
   ListingText,
   ListingLinkMore,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { viewDate } from 'design-comuni-plone-theme/helpers';
+import { viewDate, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
   vedi: {
     id: 'bando_vedi',
     defaultMessage: 'Vedi',
-  },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
   },
   pubblicazione: {
     id: 'bando_data_pubblicazione',
@@ -255,14 +251,7 @@ const BandiInEvidenceTemplate = ({
                       item={!isEditMode ? item : null}
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
-                      aria-label={
-                        item.title &&
-                        intl.formatMessage(messages.approfondisci) +
-                          ' ' +
-                          (item.title.length > 80
-                            ? item.title.slice(0, 80) + '…'
-                            : item.title)
-                      }
+                      aria-label={getCardAriaLabel(intl, item.title)}
                     />
                   </div>
                 </CardBody>
@@ -275,7 +264,7 @@ const BandiInEvidenceTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -17,7 +17,10 @@ import {
   ListingText,
   ListingLinkMore,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { viewDate, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import {
+  viewDate,
+  getReadMoreAriaLabel,
+} from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
   vedi: {
@@ -251,7 +254,7 @@ const BandiInEvidenceTemplate = ({
                       item={!isEditMode ? item : null}
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
-                      aria-label={getCardAriaLabel(intl, item.title)}
+                      aria-label={getReadMoreAriaLabel(intl, item.title)}
                     />
                   </div>
                 </CardBody>

--- a/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/BandiInEvidenceTemplate.jsx
@@ -24,6 +24,10 @@ const messages = defineMessages({
     id: 'bando_vedi',
     defaultMessage: 'Vedi',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
   pubblicazione: {
     id: 'bando_data_pubblicazione',
     defaultMessage: 'Pubblicato il',
@@ -251,6 +255,12 @@ const BandiInEvidenceTemplate = ({
                       item={!isEditMode ? item : null}
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
+                      aria-label={
+                        (item.title || item.id) &&
+                        intl.formatMessage(messages.approfondisci) +
+                          ' ' +
+                          (item.title || item.id)
+                      }
                     />
                   </div>
                 </CardBody>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -198,7 +198,7 @@ const CardWithImageTemplate = (props) => {
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -194,7 +194,12 @@ const CardWithImageTemplate = (props) => {
             );
           })}
         </Row>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -7,7 +7,10 @@ import {
 
 import { UniversalLink } from '@plone/volto/components';
 
-import { getCalendarDate, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import {
+  getCalendarDate,
+  getReadMoreAriaLabel,
+} from 'design-comuni-plone-theme/helpers';
 import {
   ListingLinkMore,
   ListingCategory,
@@ -83,7 +86,7 @@ const CardWithSlideUpTextTemplate = (props) => {
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
                       className="justify-content-end"
-                      aria-label={getCardAriaLabel(intl, item?.title)}
+                      aria-label={getReadMoreAriaLabel(intl, item?.title)}
                     />
                   </div>
                 </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -7,7 +7,7 @@ import {
 
 import { UniversalLink } from '@plone/volto/components';
 
-import { getCalendarDate } from 'design-comuni-plone-theme/helpers';
+import { getCalendarDate, getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import {
   ListingLinkMore,
   ListingCategory,
@@ -20,10 +20,6 @@ const messages = defineMessages({
   vedi: {
     id: 'card_vedi',
     defaultMessage: 'Vedi',
-  },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
   },
 });
 
@@ -87,14 +83,7 @@ const CardWithSlideUpTextTemplate = (props) => {
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
                       className="justify-content-end"
-                      aria-label={
-                        item?.title &&
-                        intl.formatMessage(messages.approfondisci) +
-                          ' ' +
-                          (item.title.length > 80
-                            ? item.title.slice(0, 80) + '…'
-                            : item.title)
-                      }
+                      aria-label={getCardAriaLabel(intl, item?.title)}
                     />
                   </div>
                 </div>
@@ -107,7 +96,7 @@ const CardWithSlideUpTextTemplate = (props) => {
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -21,6 +21,10 @@ const messages = defineMessages({
     id: 'card_vedi',
     defaultMessage: 'Vedi',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
 });
 
 const CardWithSlideUpTextTemplate = (props) => {
@@ -83,6 +87,12 @@ const CardWithSlideUpTextTemplate = (props) => {
                       href={isEditMode ? '#' : null}
                       text={intl.formatMessage(messages.vedi)}
                       className="justify-content-end"
+                      aria-label={
+                        item?.title &&
+                        intl.formatMessage(messages.approfondisci) +
+                          ' ' +
+                          item.title
+                      }
                     />
                   </div>
                 </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -91,7 +91,9 @@ const CardWithSlideUpTextTemplate = (props) => {
                         item?.title &&
                         intl.formatMessage(messages.approfondisci) +
                           ' ' +
-                          item.title
+                          (item.title.length > 80
+                            ? item.title.slice(0, 80) + '…'
+                            : item.title)
                       }
                     />
                   </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -103,7 +103,12 @@ const CardWithSlideUpTextTemplate = (props) => {
           })}
         </div>
 
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore.jsx
@@ -11,24 +11,21 @@ const messages = defineMessages({
   },
 });
 
-export const ListingLinkMore = ({
-  title,
-  href,
-  className = '',
-  blockTitle,
-}) => {
+export const ListingLinkMore = ({ title, href, className = '', ariaLabel }) => {
   const intl = useIntl();
   const url = href?.[0]?.['@id'];
   const linkText = title || intl.formatMessage(messages.view_all);
-  const ariaLabel =
-    !title && blockTitle ? `${linkText} ${blockTitle}` : undefined;
+  // No custom button text: add aria-label with section title for context (es. "Vedi tutto Notizie").
+  // Custom button text: skip aria-label, editor is responsible for a descriptive text.
+  const ariaLabelTitle =
+    !title && ariaLabel ? `${linkText} ${ariaLabel}` : undefined;
 
   return url ? (
     <div className={`link-button text-center ${className}`}>
       <UniversalLink
         href={flattenToAppURL(url)}
         className="btn btn-tertiary"
-        aria-label={ariaLabel}
+        aria-label={ariaLabelTitle}
       >
         {linkText}
       </UniversalLink>
@@ -38,7 +35,7 @@ export const ListingLinkMore = ({
 
 ListingLinkMore.propTypes = {
   linkMore: PropTypes.object,
-  blockTitle: PropTypes.string,
+  ariaLabel: PropTypes.string,
 };
 
 export default ListingLinkMore;

--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore.jsx
@@ -11,14 +11,26 @@ const messages = defineMessages({
   },
 });
 
-export const ListingLinkMore = ({ title, href, className = '' }) => {
+export const ListingLinkMore = ({
+  title,
+  href,
+  className = '',
+  blockTitle,
+}) => {
   const intl = useIntl();
   const url = href?.[0]?.['@id'];
+  const linkText = title || intl.formatMessage(messages.view_all);
+  const ariaLabel =
+    !title && blockTitle ? `${linkText} ${blockTitle}` : undefined;
 
   return url ? (
     <div className={`link-button text-center ${className}`}>
-      <UniversalLink href={flattenToAppURL(url)} className="btn btn-tertiary">
-        {title || intl.formatMessage(messages.view_all)}
+      <UniversalLink
+        href={flattenToAppURL(url)}
+        className="btn btn-tertiary"
+        aria-label={ariaLabel}
+      >
+        {linkText}
       </UniversalLink>
     </div>
   ) : null;
@@ -26,6 +38,7 @@ export const ListingLinkMore = ({ title, href, className = '' }) => {
 
 ListingLinkMore.propTypes = {
   linkMore: PropTypes.object,
+  blockTitle: PropTypes.string,
 };
 
 export default ListingLinkMore;

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -94,7 +94,12 @@ const CompleteBlockLinksTemplate = ({
             );
           })}
         </Row>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -98,7 +98,7 @@ const CompleteBlockLinksTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
@@ -112,7 +112,12 @@ const ContentInEvidenceTemplate = ({
           );
         })}
 
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
@@ -116,7 +116,7 @@ const ContentInEvidenceTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
@@ -103,7 +103,12 @@ const GridGalleryTemplate = ({
             );
           })}
         </div>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-5" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-5"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
@@ -107,7 +107,7 @@ const GridGalleryTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-5"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -168,7 +168,12 @@ const InEvidenceTemplate = (props) => {
             );
           })}
         </div>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -172,7 +172,7 @@ const InEvidenceTemplate = (props) => {
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/MapTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/MapTemplate.jsx
@@ -97,7 +97,12 @@ const MapTemplate = ({
           intl.formatMessage(messages.no_markers)
         )}
 
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-5" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-5"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/MapTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/MapTemplate.jsx
@@ -101,7 +101,7 @@ const MapTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-5"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -218,7 +218,7 @@ const PhotogalleryTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -214,7 +214,12 @@ const PhotogalleryTemplate = ({
             ) : null}
           </div>
         </div>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -146,7 +146,7 @@ const RibbonCardTemplate = (props) => {
           title={linkTitle}
           href={linkHref}
           className="my-5"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -142,7 +142,12 @@ const RibbonCardTemplate = (props) => {
             );
           })}
         </Row>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-5" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-5"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -73,7 +73,7 @@ const SimpleCardTemplateCompact = ({
         title={linkTitle}
         href={linkHref}
         className="my-4"
-        blockTitle={title}
+        ariaLabel={title}
       />
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -69,7 +69,12 @@ const SimpleCardTemplateCompact = ({
         ))}
       </div>
 
-      <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+      <ListingLinkMore
+        title={linkTitle}
+        href={linkHref}
+        className="my-4"
+        blockTitle={title}
+      />
     </div>
   );
 };

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -234,7 +234,7 @@ const SimpleCardTemplateDefault = (props) => {
         title={linkTitle}
         href={linkHref}
         className="my-4"
-        blockTitle={title}
+        ariaLabel={title}
       />
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -230,7 +230,12 @@ const SimpleCardTemplateDefault = (props) => {
         })}
       </div>
 
-      <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+      <ListingLinkMore
+        title={linkTitle}
+        href={linkHref}
+        className="my-4"
+        blockTitle={title}
+      />
     </div>
   );
 };

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleListTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleListTemplate.jsx
@@ -41,7 +41,12 @@ const SimpleListTemplate = ({
             </Col>
           </Row>
         )}
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleListTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleListTemplate.jsx
@@ -45,7 +45,7 @@ const SimpleListTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -374,7 +374,7 @@ const SliderTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -370,7 +370,12 @@ const SliderTemplate = ({
             </Slider>
           </div>
         </div>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
@@ -61,7 +61,7 @@ const SmallBlockLinksTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
@@ -57,7 +57,12 @@ const SmallBlockLinksTemplate = ({
             );
           })}
         </Row>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
@@ -42,7 +42,12 @@ const SquaresImageTemplate = ({
           })}
         </div>
 
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
@@ -46,7 +46,7 @@ const SquaresImageTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/Listing/serviziAmministrazioneTrasparenteTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/serviziAmministrazioneTrasparenteTemplate.jsx
@@ -91,7 +91,12 @@ const GridGalleryTemplate = ({
             ))}
           </tbody>
         </table>
-        <ListingLinkMore title={linkTitle} href={linkHref} className="my-4" />
+        <ListingLinkMore
+          title={linkTitle}
+          href={linkHref}
+          className="my-4"
+          blockTitle={title}
+        />
       </Container>
     </div>
   );

--- a/src/components/ItaliaTheme/Blocks/Listing/serviziAmministrazioneTrasparenteTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/serviziAmministrazioneTrasparenteTemplate.jsx
@@ -95,7 +95,7 @@ const GridGalleryTemplate = ({
           title={linkTitle}
           href={linkHref}
           className="my-4"
-          blockTitle={title}
+          ariaLabel={title}
         />
       </Container>
     </div>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -27,6 +27,10 @@ const messages = defineMessages({
     id: 'Vedi tutto',
     defaultMessage: 'Vedi tutto',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
 });
 
 const CardWithImageRssTemplate = ({
@@ -97,6 +101,12 @@ const CardWithImageRssTemplate = ({
                     rel="noopener noreferrer"
                     href={item?.url}
                     text={intl.formatMessage(messages.readMore)}
+                    aria-label={
+                      item.title &&
+                      intl.formatMessage(messages.approfondisci) +
+                        ' ' +
+                        item.title
+                    }
                   />
                 </Card>
               </Col>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -105,7 +105,9 @@ const CardWithImageRssTemplate = ({
                       item.title &&
                       intl.formatMessage(messages.approfondisci) +
                         ' ' +
-                        item.title
+                        (item.title.length > 80
+                          ? item.title.slice(0, 80) + '…'
+                          : item.title)
                     }
                   />
                 </Card>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import cx from 'classnames';
 
 import {
@@ -28,7 +28,6 @@ const messages = defineMessages({
     id: 'Vedi tutto',
     defaultMessage: 'Vedi tutto',
   },
-
 });
 
 const CardWithImageRssTemplate = ({
@@ -99,7 +98,7 @@ const CardWithImageRssTemplate = ({
                     rel="noopener noreferrer"
                     href={item?.url}
                     text={intl.formatMessage(messages.readMore)}
-                    aria-label={getCardAriaLabel(intl, item.title)}
+                    aria-label={getReadMoreAriaLabel(intl, item.title)}
                   />
                 </Card>
               </Col>
@@ -110,7 +109,7 @@ const CardWithImageRssTemplate = ({
               <UniversalLink
                 href={flattenToAppURL(data.linkMore)}
                 className="btn btn-tertiary"
-                aria-label={getCardAriaLabel(intl, data.title)}
+                aria-label={getReadMoreAriaLabel(intl, data.title)}
               >
                 {data.linkMoreTitle || intl.formatMessage(messages.view_all)}
               </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import cx from 'classnames';
 
 import {
@@ -27,10 +28,7 @@ const messages = defineMessages({
     id: 'Vedi tutto',
     defaultMessage: 'Vedi tutto',
   },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
-  },
+
 });
 
 const CardWithImageRssTemplate = ({
@@ -101,14 +99,7 @@ const CardWithImageRssTemplate = ({
                     rel="noopener noreferrer"
                     href={item?.url}
                     text={intl.formatMessage(messages.readMore)}
-                    aria-label={
-                      item.title &&
-                      intl.formatMessage(messages.approfondisci) +
-                        ' ' +
-                        (item.title.length > 80
-                          ? item.title.slice(0, 80) + '…'
-                          : item.title)
-                    }
+                    aria-label={getCardAriaLabel(intl, item.title)}
                   />
                 </Card>
               </Col>
@@ -119,13 +110,7 @@ const CardWithImageRssTemplate = ({
               <UniversalLink
                 href={flattenToAppURL(data.linkMore)}
                 className="btn btn-tertiary"
-                aria-label={
-                  data.title
-                    ? intl.formatMessage(messages.approfondisci) +
-                      ' ' +
-                      data.title
-                    : undefined
-                }
+                aria-label={getCardAriaLabel(intl, data.title)}
               >
                 {data.linkMoreTitle || intl.formatMessage(messages.view_all)}
               </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -119,6 +119,13 @@ const CardWithImageRssTemplate = ({
               <UniversalLink
                 href={flattenToAppURL(data.linkMore)}
                 className="btn btn-tertiary"
+                aria-label={
+                  data.title
+                    ? intl.formatMessage(messages.approfondisci) +
+                      ' ' +
+                      data.title
+                    : undefined
+                }
               >
                 {data.linkMoreTitle || intl.formatMessage(messages.view_all)}
               </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import cx from 'classnames';
 
 import {
@@ -26,10 +27,7 @@ const messages = defineMessages({
     id: 'Vedi tutto',
     defaultMessage: 'Vedi tutto',
   },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
-  },
+
 });
 
 const CardWithoutImageRssTemplate = ({
@@ -91,14 +89,7 @@ const CardWithoutImageRssTemplate = ({
                     rel="noopener noreferrer"
                     href={item?.url}
                     text={intl.formatMessage(messages.readMore)}
-                    aria-label={
-                      item.title &&
-                      intl.formatMessage(messages.approfondisci) +
-                        ' ' +
-                        (item.title.length > 80
-                          ? item.title.slice(0, 80) + '…'
-                          : item.title)
-                    }
+                    aria-label={getCardAriaLabel(intl, item.title)}
                   />
                 </Card>
               </Col>
@@ -109,13 +100,7 @@ const CardWithoutImageRssTemplate = ({
               <UniversalLink
                 href={flattenToAppURL(data.linkMore)}
                 className="btn btn-tertiary"
-                aria-label={
-                  data.title
-                    ? intl.formatMessage(messages.approfondisci) +
-                      ' ' +
-                      data.title
-                    : undefined
-                }
+                aria-label={getCardAriaLabel(intl, data.title)}
               >
                 {data.linkMoreTitle || intl.formatMessage(messages.view_all)}
               </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -26,6 +26,10 @@ const messages = defineMessages({
     id: 'Vedi tutto',
     defaultMessage: 'Vedi tutto',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
 });
 
 const CardWithoutImageRssTemplate = ({
@@ -87,6 +91,12 @@ const CardWithoutImageRssTemplate = ({
                     rel="noopener noreferrer"
                     href={item?.url}
                     text={intl.formatMessage(messages.readMore)}
+                    aria-label={
+                      item.title &&
+                      intl.formatMessage(messages.approfondisci) +
+                        ' ' +
+                        item.title
+                    }
                   />
                 </Card>
               </Col>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -95,7 +95,9 @@ const CardWithoutImageRssTemplate = ({
                       item.title &&
                       intl.formatMessage(messages.approfondisci) +
                         ' ' +
-                        item.title
+                        (item.title.length > 80
+                          ? item.title.slice(0, 80) + '…'
+                          : item.title)
                     }
                   />
                 </Card>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -109,6 +109,13 @@ const CardWithoutImageRssTemplate = ({
               <UniversalLink
                 href={flattenToAppURL(data.linkMore)}
                 className="btn btn-tertiary"
+                aria-label={
+                  data.title
+                    ? intl.formatMessage(messages.approfondisci) +
+                      ' ' +
+                      data.title
+                    : undefined
+                }
               >
                 {data.linkMoreTitle || intl.formatMessage(messages.view_all)}
               </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import cx from 'classnames';
 
 import {
@@ -27,7 +27,6 @@ const messages = defineMessages({
     id: 'Vedi tutto',
     defaultMessage: 'Vedi tutto',
   },
-
 });
 
 const CardWithoutImageRssTemplate = ({
@@ -89,7 +88,7 @@ const CardWithoutImageRssTemplate = ({
                     rel="noopener noreferrer"
                     href={item?.url}
                     text={intl.formatMessage(messages.readMore)}
-                    aria-label={getCardAriaLabel(intl, item.title)}
+                    aria-label={getReadMoreAriaLabel(intl, item.title)}
                   />
                 </Card>
               </Col>
@@ -100,7 +99,7 @@ const CardWithoutImageRssTemplate = ({
               <UniversalLink
                 href={flattenToAppURL(data.linkMore)}
                 className="btn btn-tertiary"
-                aria-label={getCardAriaLabel(intl, data.title)}
+                aria-label={getReadMoreAriaLabel(intl, data.title)}
               >
                 {data.linkMoreTitle || intl.formatMessage(messages.view_all)}
               </UniversalLink>

--- a/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
@@ -16,6 +16,10 @@ const messages = defineMessages({
     id: 'explore',
     defaultMessage: 'Esplora',
   },
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
 });
 
 /**
@@ -39,6 +43,12 @@ const ItemInEvidence = ({ content }) => {
             tag="a"
             text={intl.formatMessage(messages.explore)}
             href={flattenToAppURL(correlato_in_evidenza['@id'])}
+            aria-label={
+              correlato_in_evidenza.title &&
+              intl.formatMessage(messages.approfondisci) +
+                ' ' +
+                correlato_in_evidenza.title
+            }
           />
         </CardBody>
       </Card>

--- a/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
+import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
 import {
   Card,
   CardBody,
@@ -15,10 +16,6 @@ const messages = defineMessages({
   explore: {
     id: 'explore',
     defaultMessage: 'Esplora',
-  },
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
   },
 });
 
@@ -43,14 +40,7 @@ const ItemInEvidence = ({ content }) => {
             tag="a"
             text={intl.formatMessage(messages.explore)}
             href={flattenToAppURL(correlato_in_evidenza['@id'])}
-            aria-label={
-              correlato_in_evidenza.title &&
-              intl.formatMessage(messages.approfondisci) +
-                ' ' +
-                (correlato_in_evidenza.title.length > 80
-                  ? correlato_in_evidenza.title.slice(0, 80) + '…'
-                  : correlato_in_evidenza.title)
-            }
+            aria-label={getCardAriaLabel(intl, correlato_in_evidenza.title)}
           />
         </CardBody>
       </Card>

--- a/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
@@ -47,7 +47,9 @@ const ItemInEvidence = ({ content }) => {
               correlato_in_evidenza.title &&
               intl.formatMessage(messages.approfondisci) +
                 ' ' +
-                correlato_in_evidenza.title
+                (correlato_in_evidenza.title.length > 80
+                  ? correlato_in_evidenza.title.slice(0, 80) + '…'
+                  : correlato_in_evidenza.title)
             }
           />
         </CardBody>

--- a/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItemInEvidence/ItemInEvidence.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
-import { getCardAriaLabel } from 'design-comuni-plone-theme/helpers';
+import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
 import {
   Card,
   CardBody,
@@ -40,7 +40,7 @@ const ItemInEvidence = ({ content }) => {
             tag="a"
             text={intl.formatMessage(messages.explore)}
             href={flattenToAppURL(correlato_in_evidenza['@id'])}
-            aria-label={getCardAriaLabel(intl, correlato_in_evidenza.title)}
+            aria-label={getReadMoreAriaLabel(intl, correlato_in_evidenza.title)}
           />
         </CardBody>
       </Card>

--- a/src/helpers/getReadMoreAriaLabel.js
+++ b/src/helpers/getReadMoreAriaLabel.js
@@ -1,0 +1,19 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
+});
+
+const ARIA_LABEL_MAX_LENGTH = 80;
+
+export const getReadMoreAriaLabel = (intl, title) => {
+  if (!title) return undefined;
+  const truncated =
+    title.length > ARIA_LABEL_MAX_LENGTH
+      ? title.slice(0, ARIA_LABEL_MAX_LENGTH) + '…'
+      : title;
+  return intl.formatMessage(messages.approfondisci) + ' ' + truncated;
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -11,10 +11,8 @@ export {
   getEventRecurrenceMore,
 } from 'design-comuni-plone-theme/helpers/ListingHelper';
 export { contentFolderHasItems } from 'design-comuni-plone-theme/helpers/contentHelper';
-export {
-  checkRedraftHasContent,
-  getCardAriaLabel,
-} from 'design-comuni-plone-theme/helpers/redraftHelper';
+export { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers/redraftHelper';
+export { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers/getReadMoreAriaLabel';
 export { getTableRowData } from 'design-comuni-plone-theme/helpers/amministrazioneTrasparenteHelper';
 export { getItemsByPath } from 'design-comuni-plone-theme/helpers/getItemsByPath';
 export {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -11,7 +11,10 @@ export {
   getEventRecurrenceMore,
 } from 'design-comuni-plone-theme/helpers/ListingHelper';
 export { contentFolderHasItems } from 'design-comuni-plone-theme/helpers/contentHelper';
-export { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers/redraftHelper';
+export {
+  checkRedraftHasContent,
+  getCardAriaLabel,
+} from 'design-comuni-plone-theme/helpers/redraftHelper';
 export { getTableRowData } from 'design-comuni-plone-theme/helpers/amministrazioneTrasparenteHelper';
 export { getItemsByPath } from 'design-comuni-plone-theme/helpers/getItemsByPath';
 export {

--- a/src/helpers/redraftHelper.js
+++ b/src/helpers/redraftHelper.js
@@ -7,23 +7,3 @@ export const checkRedraftHasContent = (text) => {
     return blocks.length > 0 ? true : false;
   }
 };
-
-import { defineMessages } from 'react-intl';
-
-const messages = defineMessages({
-  approfondisci: {
-    id: 'approfondisci',
-    defaultMessage: 'Approfondisci:',
-  },
-});
-
-const ARIA_LABEL_MAX_LENGTH = 80;
-
-export const getCardAriaLabel = (intl, title) => {
-  if (!title) return undefined;
-  const truncated =
-    title.length > ARIA_LABEL_MAX_LENGTH
-      ? title.slice(0, ARIA_LABEL_MAX_LENGTH) + '…'
-      : title;
-  return intl.formatMessage(messages.approfondisci) + ' ' + truncated;
-};

--- a/src/helpers/redraftHelper.js
+++ b/src/helpers/redraftHelper.js
@@ -7,3 +7,23 @@ export const checkRedraftHasContent = (text) => {
     return blocks.length > 0 ? true : false;
   }
 };
+
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  approfondisci: {
+    id: 'approfondisci',
+    defaultMessage: 'Approfondisci:',
+  },
+});
+
+const ARIA_LABEL_MAX_LENGTH = 80;
+
+export const getCardAriaLabel = (intl, title) => {
+  if (!title) return undefined;
+  const truncated =
+    title.length > ARIA_LABEL_MAX_LENGTH
+      ? title.slice(0, ARIA_LABEL_MAX_LENGTH) + '…'
+      : title;
+  return intl.formatMessage(messages.approfondisci) + ' ' + truncated;
+};


### PR DESCRIPTION
I link e i bottoni con testo generico come "Vedi tutto", "Vedi tutti" o "Approfondisci" non soddisfano il criterio WCAG 2.1 SC 2.4.4 (Link Purpose), che richiede che lo scopo di un link sia comprensibile dal solo testo del link, senza dipendere dal contesto visivo circostante.

Gli utenti che navigano con screen reader spesso accedono all'elenco di tutti i link della pagina fuori contesto. In quel caso, sentire ripetuto "Vedi tutto" più volte senza sapere cosa si vedrà è un'esperienza inaccessibile.

**Soluzione adottata**
- **CardReadMore — pattern aria-label="Approfondisci: {titolo}"**
Tutti i componenti che usano CardReadMore ora ricevono un aria-label nel formato "Approfondisci: {titolo dell'elemento}", con troncamento a 80 caratteri per evitare label eccessivamente verbosi con gli screen reader. Il testo è internazionalizzato tramite defineMessages in ogni file

- **ListingLinkMore — blockTitle come contesto di fallback**
Il componente ListingLinkMore è usato in circa 20 template del blocco Listing. Quando l'editor non configura un testo personalizzato per il bottone, questo ricade sul generico "Vedi tutto".
La soluzione adottata centralizza la logica nel componente stesso. È stato aggiunto un prop opzionale blockTitle che, solo quando non è presente un titolo personalizzato, viene usato per costruire un aria-label nel formato "Vedi tutto {titolo del blocco}"

- **Perché centralizzare in ListingLinkMore**
Aggiungere aria-label direttamente nei template avrebbe richiesto di importare useIntl in tutti quelli che oggi non lo usano, aumentando il coupling e duplicando la logica di internazionalizzazione.

- **BottomBody (ArgumentsInEvidence) — aria-label fisso**
Il bottone "Vedi tutti" che punta a /argomenti è semanticamente fisso: porta sempre alla pagina degli argomenti. Riceve quindi un aria-label="Vedi tutti gli argomenti" internazionalizzato tramite defineMessages.     