### PR TITLE
fix: info variable restored to boostrap color

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,6 +51,7 @@
 
 - Quando un blocco elenco viene affiancato a un blocco immagine allineato a sinistra, l'immagine e l'elenco puntato vengono visualizzati correttamente senza sovrapporsi.
 - Sistemato il colore del testo di un link con stile bottone all'interno di un Callout di colore blu, mostrando il link di colore bianco e non blu.
+- Ripristinato il colore standard di boostrap per la classe "info".
 
 ## Versione 12.11.4 (02/04/2026)
 

--- a/src/theme/bootstrap-override/bootstrap/_reboot.scss
+++ b/src/theme/bootstrap-override/bootstrap/_reboot.scss
@@ -6,6 +6,12 @@ body.public-ui {
   font-weight: $font-weight-base;
   line-height: $line-height-base;
   text-align: left; // 3
+  $info: #0dcaf0;
 
   @include font-size($font-size-base);
+}
+
+:root {
+  --bs-info: #0dcaf0;
+  --bs-info-rgb: rgb(13, 202, 240);
 }


### PR DESCRIPTION
We noticed that in io-cittadino the variable for "ongoing" record labels is "secondary" and the one for "completed" is "primary".

This is not very user-friendly when primary or secondary colors are colors like reds or oranges, as these colors in UX are associated with negative ideas or outcomes, while a record that is ongoing or completed is actually a positive one.

We tried to use BS variables like "success" (completed) and "info" (ongoing) but we noticed that  the "info" variable has been overwritten in a boostrap-italia commit three years ago with the secondary color, which makes no sense.


https://github.com/italia/bootstrap-italia/blob/v2.6.1/src/scss/utilities/colors_vars.scss#L106

Since we cannot patch boostrap-italia per se, we overrode the variable in the reboot file for boostrap-italia.

Already checked for potential breaking changes, but the only time "info" has been used in the entire repo is for cms-side color-list-widget button, which would be visible only if a component in a theme addon had used "info" as a variable.