### PR TITLE
Fix: Resolve [object Object] rendering in IconBlocks link text

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock.jsx
@@ -9,6 +9,7 @@ import redraft from 'redraft';
 import { useIntl, defineMessages } from 'react-intl';
 import cx from 'classnames';
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { getPlainText } from 'design-comuni-plone-theme/helpers';
 import { UniversalLink } from '@plone/volto/components';
 import config from '@plone/volto/registry';
 
@@ -68,7 +69,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
           {data.href && (
             <div className="link-more">
               <UniversalLink href={data.href}>
-                {data.linkMoreTitle || intl.formatMessage(messages.vedi)}
+                {getPlainText(data.linkMoreTitle) || intl.formatMessage(messages.vedi)}
                 <Icon icon="it-arrow-right" />
               </UniversalLink>
             </div>

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
@@ -6,13 +6,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
-import { convertFromRaw } from 'draft-js';
 import { useIntl, defineMessages } from 'react-intl';
 import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
-import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
+import {
+  getReadMoreAriaLabel,
+  getPlainText,
+} from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 
 /**
@@ -23,10 +25,7 @@ import config from '@plone/volto/registry';
 const AccordionView = ({ data, block }) => {
   const intl = useIntl();
   const id = new Date().getTime();
-  const blockPlainTitle = data.title
-    ? convertFromRaw(data.title).getPlainText()
-    : null;
-  const linkMoreAriaLabel = getReadMoreAriaLabel(intl, blockPlainTitle);
+  const linkMoreAriaLabel = getReadMoreAriaLabel(intl, getPlainText(data.title));
   return (
     <div className="block contacts">
       <div className="public-ui">
@@ -70,7 +69,7 @@ const AccordionView = ({ data, block }) => {
                   className="btn btn-tertiary"
                   aria-label={linkMoreAriaLabel}
                 >
-                  {data.linkMoreTitle}
+                  {getPlainText(data.linkMoreTitle)}
                 </UniversalLink>
               </div>
             )}

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock.jsx
@@ -6,12 +6,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
-import { convertFromRaw } from 'draft-js';
 import { useIntl, defineMessages } from 'react-intl';
 import { UniversalLink } from '@plone/volto/components';
 
 import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers';
+import {
+  getReadMoreAriaLabel,
+  getPlainText,
+} from 'design-comuni-plone-theme/helpers';
 import {
   Card,
   CardBody,
@@ -33,10 +35,11 @@ const messages = defineMessages({
  */
 const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
   const intl = useIntl();
-  const plainTitle = data.title
-    ? convertFromRaw(data.title).getPlainText()
-    : null;
-  const cardReadMoreAriaLabel = getReadMoreAriaLabel(intl, plainTitle);
+  const cardReadMoreAriaLabel = getReadMoreAriaLabel(
+    intl,
+    getPlainText(data.title),
+  );
+  const plainLinkMoreTitle = getPlainText(data.linkMoreTitle);
   return (
     <Card
       className="card-bg rounded subblock-view"
@@ -74,7 +77,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
             iconName="it-arrow-right"
             tag={UniversalLink}
             href={data.href ?? '#'}
-            text={data.linkMoreTitle || intl.formatMessage(messages.vedi)}
+            text={plainLinkMoreTitle || intl.formatMessage(messages.vedi)}
             aria-label={cardReadMoreAriaLabel}
           />
         )}

--- a/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/IconBlocks/View.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
-import { convertFromRaw } from 'draft-js';
 import { useIntl } from 'react-intl';
 import ViewBlock from './Block/ViewBlock';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
@@ -15,6 +14,7 @@ import { UniversalLink } from '@plone/volto/components';
 import {
   checkRedraftHasContent,
   getReadMoreAriaLabel,
+  getPlainText,
 } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 import cx from 'classnames';
@@ -27,10 +27,7 @@ import cx from 'classnames';
 const AccordionView = ({ data, block }) => {
   const intl = useIntl();
   const id = new Date().getTime();
-  const blockPlainTitle = data.title
-    ? convertFromRaw(data.title).getPlainText()
-    : null;
-  const linkMoreAriaLabel = getReadMoreAriaLabel(intl, blockPlainTitle);
+  const linkMoreAriaLabel = getReadMoreAriaLabel(intl, getPlainText(data.title));
 
   return (
     <div className="block iconBlocks">
@@ -96,7 +93,7 @@ const AccordionView = ({ data, block }) => {
                   className="btn btn-tertiary"
                   aria-label={linkMoreAriaLabel}
                 >
-                  {data.linkMoreTitle}
+                  {getPlainText(data.linkMoreTitle)}
                 </UniversalLink>
               </div>
             )}

--- a/src/helpers/getPlainText.js
+++ b/src/helpers/getPlainText.js
@@ -1,0 +1,9 @@
+import { convertFromRaw } from 'draft-js';
+
+export const getPlainText = (field) => {
+  if (!field) return null;
+  if (typeof field === 'object') {
+    return convertFromRaw(field).getPlainText() || null;
+  }
+  return field;
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -13,6 +13,7 @@ export {
 export { contentFolderHasItems } from 'design-comuni-plone-theme/helpers/contentHelper';
 export { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers/redraftHelper';
 export { getReadMoreAriaLabel } from 'design-comuni-plone-theme/helpers/getReadMoreAriaLabel';
+export { getPlainText } from 'design-comuni-plone-theme/helpers/getPlainText';
 export { getTableRowData } from 'design-comuni-plone-theme/helpers/amministrazioneTrasparenteHelper';
 export { getItemsByPath } from 'design-comuni-plone-theme/helpers/getItemsByPath';
 export {


### PR DESCRIPTION
Description:

In IconBlocks/Block/ViewBlock.jsx, the linkMoreTitle field was being passed directly to CardReadMore. When content was saved using the Draft.js rich-text widget, the value was stored as an object, causing [object Object] to be displayed in the UI instead of the intended text.

Key Changes:

- Centralized Logic: Added a getPlainText(field) helper utility to handle both Draft.js objects and plain strings transparently.
- Resilience: Applied the helper across multiple components to prevent similar issues and ensure compatibility with legacy content: