### PR TITLE
Us#75601 prevent video when cookie not accepted

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,7 +48,7 @@
 ### Fix
 
 - Impedire all'input numerico nel blocco Form di inserire caratteri alfabetici
- 
+- Mostrare l'anteprima del blocco Video una volta accettati i cookie 
 
 ## Versione 12.12.0 (27/04/2026)
 

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -7,6 +7,7 @@
  * - added ConditionalEmbed
  * - changed icon for preview with FontAwesome icon
  * - overhauled url checking, it would break on correct links and allow incorrect ones
+ * - video passed to ConditionalEmbed only when cookie are accepted, preventing the fetch when not accepted
  */
 
 import React from 'react';
@@ -26,6 +27,18 @@ import config from '@plone/volto/registry';
  * @extends Component
  */
 const Body = ({ data, isEditMode }) => {
+
+  const gdprPreferences = useSelector(
+    (state) => {
+      return state.gdprPrivacyConsent ? state.gdprPrivacyConsent?.preferences : [];
+    },
+  );
+
+  const embedAllowed =
+    gdprPreferences !== undefined &&
+    (gdprPreferences?.prof_VIMEO === true ||
+      gdprPreferences?.prof_YOUTUBE === true);
+
   const allowsExternals =
     data.allowExternals !== undefined
       ? !!data.allowExternals
@@ -87,7 +100,7 @@ const Body = ({ data, isEditMode }) => {
           })}
         >
           <ConditionalEmbed url={data.url}>
-            {data.url.match('youtu') ? (
+            {embedAllowed && (data.url.match('youtu') ? (
               <>
                 {data.url.match('list') ? (
                   <Embed
@@ -111,11 +124,10 @@ const Body = ({ data, isEditMode }) => {
                           isInternalURL(
                             data.url.replace(getParentUrl(apiPath), ''),
                           )
-                            ? `${data.url}${
-                                data.url.indexOf('@@download/file') < 0
-                                  ? '/@@download/file'
-                                  : ''
-                              }`
+                            ? `${data.url}${data.url.indexOf('@@download/file') < 0
+                              ? '/@@download/file'
+                              : ''
+                            }`
                             : data.url
                         }
                         controls
@@ -147,7 +159,7 @@ const Body = ({ data, isEditMode }) => {
                   </>
                 )}
               </>
-            )}
+            ))}
           </ConditionalEmbed>
         </div>
       )}


### PR DESCRIPTION
[Us#75601](https://redturtle.tpondemand.com/RestUI/Board.aspx#page=bug/75601)

 Prevent to fetch video when cookie are not accepted, passed to ConditionalEmbed only when cookie are accepted.