### PR TITLE
fix: fallback when size does not exist

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- I link ai file che non hanno informazioni sulla dimensione vengono ora visualizzati correttamente, senza mostrare spazi vuoti o causare errori.
+
 ## Versione 12.12.3 (28/05/2026)
 
 ### Fix

--- a/src/helpers/EnhanceLink.js
+++ b/src/helpers/EnhanceLink.js
@@ -16,7 +16,7 @@ const EnhanceLink = ({
 
   let size =
     enhanced_link_infos.getObjSize?.replaceAll('.', ',') ??
-    (enhanced_link_infos.size && enhanced_link_infos
+    (enhanced_link_infos?.size
       ? prettybytes(enhanced_link_infos.size, {
           locale: intl.locale,
         })?.toUpperCase()

--- a/src/helpers/EnhanceLink.js
+++ b/src/helpers/EnhanceLink.js
@@ -16,9 +16,11 @@ const EnhanceLink = ({
 
   let size =
     enhanced_link_infos.getObjSize?.replaceAll('.', ',') ??
-    prettybytes(enhanced_link_infos.size, {
-      locale: intl.locale,
-    })?.toUpperCase();
+    (enhanced_link_infos.size && enhanced_link_infos
+      ? prettybytes(enhanced_link_infos.size, {
+          locale: intl.locale,
+        })?.toUpperCase()
+      : undefined);
 
   if (enhanced_link_infos) {
     const viewFormat = getFileViewFormat(enhanced_link_infos);
@@ -30,7 +32,7 @@ const EnhanceLink = ({
             <span className="file-format">{viewFormat.label}</span> -{' '}
           </>
         )}
-        <span className="file-size">{size}</span>
+        {size && <span className="file-size">{size}</span>}
         {')'}
       </span>
     );


### PR DESCRIPTION
Ci è capitato recentemente con un cliente (S. Lazzaro) che per qualche motivo, sospettiamo durante una migrazione, un CT file non avesse un file associato.

Al di là del fatto che non dovrebbe essere possibile, succedeva che quando si arrivava sulla vista del CT da un link da un altro punto del sito, la vista si rompeva.

Il problema era che il plugin per calcolare e mostrare la dimensione del file prettybytes si rompeva non avendo i dati in entrata.

Aggiunto fallback nel caso in cui le informazioni non siano presenti in modo da non entrare nella funzione del plugin nel caso in cui non ci siano info sulla dimensione.