### PR TITLE
Blocco Listing - template a tabella - corretto errore di rendering per campi con valori multipli ("Destinatari")     

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Blocco Listing con template a tabella. Corretta la visualizzazione dei campi con valori multipli (es. "Destinatari") che causavano un errore di rendering. I valori vengono ora mostrati correttamente come etichette separate da virgola.
+
 ## Versione 12.12.4 (08/06/2026)
 
 ### Fix

--- a/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
@@ -1,12 +1,12 @@
 /*
  * Template a tabella
  */
-import React, { useEffect } from 'react';
+import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useIntl, defineMessages } from 'react-intl';
-import { getCTSchema } from 'design-comuni-plone-theme/actions';
+// import { getCTSchema } from 'design-comuni-plone-theme/actions';
 import { Table, Container } from 'design-react-kit';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 
@@ -79,8 +79,11 @@ const TableTemplate = (props) => {
                   const field_properties =
                     c.field_properties ??
                     ct_schema?.[c.ct]?.result?.properties?.[c.field] ??
-                    {};
-                  let render_value = JSON.stringify(item[c.field]);
+                    null;
+                  const raw = item[c.field];
+                  let render_value = Array.isArray(raw)
+                    ? raw.map((v) => v?.title ?? v).join(', ')
+                    : raw?.title ?? String(raw ?? '');
 
                   if (field_properties) {
                     const field = {

--- a/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
@@ -83,7 +83,7 @@ const TableTemplate = (props) => {
                   const raw = item[c.field];
                   let render_value = Array.isArray(raw)
                     ? raw.map((v) => v?.title ?? v).join(', ')
-                    : raw?.title ?? String(raw ?? '');
+                    : raw?.title ?? JSON.stringify(item[c.field]);
 
                   if (field_properties) {
                     const field = {


### PR DESCRIPTION
Il template a tabella del blocco Listing causava un errore di rendering in modalità visualizzazione (utenti anonimi e non in modifica) quando una colonna conteneva un campo con valori multipli (array di oggetti come il campo "Destinatari"). In assenza dello schema del tipo di contenuto, il valore veniva passato direttamente al widget di default causando un crash.

Fix: quando lo schema non è disponibile, i campi array vengono resi come lista di etichette separate da virgola. I campi oggetto con proprietà `title` vengono visualizzati correttamente.

<img width="3426" height="1802" alt="image" src="https://github.com/user-attachments/assets/45c4bb92-8630-4884-98a3-2f42fe314d98" />

@sabrina-bongiovanni @pnicolli Vi aggiungo perché questo file originariamente è vostro e non vorrei sovrascrivere qualcosa che non ho ancora visto