### PR TITLE
feat: link integrity in folder contents

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,7 +49,9 @@
 
 ### Novità
 
-- ...
+- Nella folder contents, ora viene mostrato un messaggio di avviso quando si sta cercando di spostare / cancellare / rinominare / cambiare lo stato di più di 300 elementi (o del numero configurabile a livello di applicazione dagli sviluppatori.) _(**Origine / contributo**: Regione Emilia-Romagna)_
+- Migliorata l'accessibilità della folder content. _(**Origine / contributo**: Regione Emilia-Romagna)_
+- Nella folder content, ora viene mostrato un messaggio di errore più coerente ed esplicativo quando si verifica un errore. _(**Origine / contributo**: Regione Emilia-Romagna)_
 
 ### Fix
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -117,6 +117,13 @@ msgstr ""
 msgid "Callout"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+#: components/manage/Contents/ContentsDeleteModal
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Cancel
+msgid "Cancel"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow
 # defaultMessage: Vedi
@@ -158,6 +165,16 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/EventSearch/DefaultFilters
 # defaultMessage: Cerca per parola chiave
 msgid "Cerca per parola chiave"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
+msgid "Change State"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
+msgid "Change workflow state recursively"
 msgstr ""
 
 #: overrideTranslations
@@ -207,6 +224,16 @@ msgstr ""
 msgid "Current filters applied"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut selected items?
+msgid "Cut selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut this item?
+msgid "Cut this item?"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/Dates
 # defaultMessage: Date aggiuntive
 msgid "Date aggiuntive"
@@ -225,6 +252,27 @@ msgstr ""
 #: helpers/Translations/searchBlockExtendedTranslations
 # defaultMessage: Dal {start} al {end}
 msgid "DateRangeFacetFilterListEntryDalAl"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Default
+msgid "Default"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete selected items?
+msgid "Delete selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete this item?
+msgid "Delete this item?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Deleting this item breaks {brokenReferences} {variation}.
+msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
@@ -475,6 +523,11 @@ msgstr ""
 msgid "Mostra tutti gli argomenti"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Navigate to this item
+msgid "Navigate to this item"
+msgstr ""
+
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
@@ -513,6 +566,21 @@ msgstr ""
 #: components/ItaliaTheme/Pagination/PaginationItem
 # defaultMessage: Pagina
 msgid "Page"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Paste
+msgid "Paste"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste the item here?
+msgid "Paste item here?"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste items here?
+msgid "Paste selected items?"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
@@ -565,6 +633,16 @@ msgstr ""
 #: overrideTranslations
 # defaultMessage: Published
 msgid "Published"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
+msgid "Rename Items Loading Message"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
+msgid "Rename items"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/FileWidget
@@ -623,6 +701,11 @@ msgstr ""
 msgid "Select all or none"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
+msgid "Select the transition to be used for modifying the items state."
+msgstr ""
+
 #: components/SelectInput/SelectInput
 # defaultMessage: Seleziona un'opzione
 msgid "SelectInput_default_label"
@@ -638,6 +721,11 @@ msgstr ""
 msgid "Seleziona un'icona"
 msgstr ""
 
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
+msgid "Short name"
+msgstr ""
+
 #: components/ItaliaTheme/Search/SearchCTs
 #: components/ItaliaTheme/Search/SearchTopics
 # defaultMessage: Mostra tutto
@@ -647,6 +735,16 @@ msgstr ""
 #: components/ItaliaTheme/Search/SearchCTs
 # defaultMessage: Mostra tutti i tipi di contenuto
 msgid "Show all content types"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders.
+msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken.
+msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
 #: components/ItaliaTheme/Search/Search
@@ -686,10 +784,26 @@ msgstr ""
 msgid "Thank you."
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: These items will have broken links
+msgid "These items will have broken links"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder.
+msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
+msgid "This name will be displayed in the URL."
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Edit
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/IconBlocks/Edit
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
+#: components/manage/Contents/ContentsRenameModal
 # defaultMessage: Titolo...
 msgid "Title"
 msgstr ""
@@ -822,14 +936,49 @@ msgstr ""
 msgid "VideoGalleryBlock"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: View links and references to this item
+msgid "View links and references to this item"
+msgstr ""
+
 #: overrideTranslations
 # defaultMessage: Visible only in view mode
 msgid "Visible only in view mode"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
+msgid "Workflow Change Loading Message"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Manda a capo il titolo con un trattino se è troppo lungo
 msgid "Wrap title"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: You are copying more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: You are cutting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: You are pasting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: You are renaming more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
@@ -2713,6 +2862,16 @@ msgstr ""
 msgid "insert_filter"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: item
+msgid "item"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: items
+msgid "items"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Iter del procedimento
@@ -2743,6 +2902,31 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
 # defaultMessage: Collegamento
 msgid "link"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut
+msgid "link-integrity: Cut"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete
+msgid "link-integrity: Delete"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete item and break links
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Checking...
+msgid "link-integrity: loading"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Checking references...
+msgid "link-integrity: loading references"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderCenter
@@ -3204,6 +3388,11 @@ msgstr ""
 msgid "parteciperanno"
 msgstr ""
 
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Checking...
+msgid "paste cheching: loading"
+msgstr ""
+
 #: components/ItaliaTheme/View/EventoView/EventoPatrocinatoDa
 # defaultMessage: Patrocinato da
 msgid "patrocinato_da"
@@ -3301,6 +3490,21 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeader
 # defaultMessage: Tempo di lettura
 msgid "reading_time"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: reference
+msgid "reference"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: references
+msgid "references"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: refers to
+msgid "refers to"
 msgstr ""
 
 #: components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -102,6 +102,13 @@ msgstr ""
 msgid "Callout"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+#: components/manage/Contents/ContentsDeleteModal
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Cancel
+msgid "Cancel"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow
 # defaultMessage: Vedi
@@ -144,6 +151,16 @@ msgstr "Search by topic"
 # defaultMessage: Cerca per parola chiave
 msgid "Cerca per parola chiave"
 msgstr "Search by keyword"
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
+msgid "Change State"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
+msgid "Change workflow state recursively"
+msgstr ""
 
 #: overrideTranslations
 # defaultMessage: Pulisci i campi
@@ -192,6 +209,16 @@ msgstr "Content"
 msgid "Current filters applied"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut selected items?
+msgid "Cut selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut this item?
+msgid "Cut this item?"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/Dates
 # defaultMessage: Date aggiuntive
 msgid "Date aggiuntive"
@@ -211,6 +238,27 @@ msgstr "Starting from {start}"
 # defaultMessage: Dal {start} al {end}
 msgid "DateRangeFacetFilterListEntryDalAl"
 msgstr "Between {start} and {end}"
+
+#: components/manage/Contents/ContentsRenameModal
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Default
+msgid "Default"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete selected items?
+msgid "Delete selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete this item?
+msgid "Delete this item?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Deleting this item breaks {brokenReferences} {variation}.
+msgid "Deleting this item breaks {brokenReferences} {variation}."
+msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
@@ -460,6 +508,11 @@ msgstr ""
 msgid "Mostra tutti gli argomenti"
 msgstr "Show all topics"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Navigate to this item
+msgid "Navigate to this item"
+msgstr ""
+
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
@@ -499,6 +552,21 @@ msgstr ""
 # defaultMessage: Pagina
 msgid "Page"
 msgstr "Page"
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Paste
+msgid "Paste"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste the item here?
+msgid "Paste item here?"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste items here?
+msgid "Paste selected items?"
+msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
@@ -550,6 +618,16 @@ msgstr ""
 #: overrideTranslations
 # defaultMessage: Published
 msgid "Published"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
+msgid "Rename Items Loading Message"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
+msgid "Rename items"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/FileWidget
@@ -608,6 +686,11 @@ msgstr "Select all content types or none"
 msgid "Select all or none"
 msgstr "Select all or none"
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
+msgid "Select the transition to be used for modifying the items state."
+msgstr ""
+
 #: components/SelectInput/SelectInput
 # defaultMessage: Seleziona un'opzione
 msgid "SelectInput_default_label"
@@ -623,6 +706,11 @@ msgstr ""
 msgid "Seleziona un'icona"
 msgstr ""
 
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
+msgid "Short name"
+msgstr ""
+
 #: components/ItaliaTheme/Search/SearchCTs
 #: components/ItaliaTheme/Search/SearchTopics
 # defaultMessage: Mostra tutto
@@ -633,6 +721,16 @@ msgstr "Show all"
 # defaultMessage: Mostra tutti i tipi di contenuto
 msgid "Show all content types"
 msgstr "Show all content types"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders.
+msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken.
+msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Sono occorsi degli errori
@@ -671,10 +769,26 @@ msgstr ""
 msgid "Thank you."
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: These items will have broken links
+msgid "These items will have broken links"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder.
+msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
+msgid "This name will be displayed in the URL."
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Edit
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/IconBlocks/Edit
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
+#: components/manage/Contents/ContentsRenameModal
 # defaultMessage: Titolo...
 msgid "Title"
 msgstr ""
@@ -807,14 +921,49 @@ msgstr "Video"
 msgid "VideoGalleryBlock"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: View links and references to this item
+msgid "View links and references to this item"
+msgstr ""
+
 #: overrideTranslations
 # defaultMessage: Visible only in view mode
 msgid "Visible only in view mode"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
+msgid "Workflow Change Loading Message"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Manda a capo il titolo con un trattino se è troppo lungo
 msgid "Wrap title"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: You are copying more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: You are cutting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: You are pasting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: You are renaming more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
@@ -2698,6 +2847,16 @@ msgstr "Page index"
 msgid "insert_filter"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: item
+msgid "item"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: items
+msgid "items"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Iter del procedimento
@@ -2729,6 +2888,31 @@ msgstr "Fields marked with (*) are required."
 # defaultMessage: Collegamento
 msgid "link"
 msgstr "Link"
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut
+msgid "link-integrity: Cut"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete
+msgid "link-integrity: Delete"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete item and break links
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Checking...
+msgid "link-integrity: loading"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Checking references...
+msgid "link-integrity: loading references"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderCenter
 # defaultMessage: homepage
@@ -3189,6 +3373,11 @@ msgstr ""
 msgid "parteciperanno"
 msgstr "Will participate"
 
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Checking...
+msgid "paste cheching: loading"
+msgstr ""
+
 #: components/ItaliaTheme/View/EventoView/EventoPatrocinatoDa
 # defaultMessage: Patrocinato da
 msgid "patrocinato_da"
@@ -3287,6 +3476,21 @@ msgstr "Event collection:"
 # defaultMessage: Tempo di lettura
 msgid "reading_time"
 msgstr "Reading time"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: reference
+msgid "reference"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: references
+msgid "references"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: refers to
+msgid "refers to"
+msgstr ""
 
 #: components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks
 # defaultMessage: Documenti

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -111,6 +111,13 @@ msgstr ""
 msgid "Callout"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+#: components/manage/Contents/ContentsDeleteModal
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Cancel
+msgid "Cancel"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow
 # defaultMessage: Vedi
@@ -153,6 +160,16 @@ msgstr "Buscar por tema"
 # defaultMessage: Cerca per parola chiave
 msgid "Cerca per parola chiave"
 msgstr "Buscar por palabra clave"
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
+msgid "Change State"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
+msgid "Change workflow state recursively"
+msgstr ""
 
 #: overrideTranslations
 # defaultMessage: Pulisci i campi
@@ -201,6 +218,16 @@ msgstr "Contenido"
 msgid "Current filters applied"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut selected items?
+msgid "Cut selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut this item?
+msgid "Cut this item?"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/Dates
 # defaultMessage: Date aggiuntive
 msgid "Date aggiuntive"
@@ -219,6 +246,27 @@ msgstr ""
 #: helpers/Translations/searchBlockExtendedTranslations
 # defaultMessage: Dal {start} al {end}
 msgid "DateRangeFacetFilterListEntryDalAl"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Default
+msgid "Default"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete selected items?
+msgid "Delete selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete this item?
+msgid "Delete this item?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Deleting this item breaks {brokenReferences} {variation}.
+msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
@@ -469,6 +517,11 @@ msgstr "Mostrar el fondo del bloque"
 msgid "Mostra tutti gli argomenti"
 msgstr "Mostrar todos los temas"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Navigate to this item
+msgid "Navigate to this item"
+msgstr ""
+
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
@@ -507,6 +560,21 @@ msgstr "Abrir en un nueva pestaña"
 #: components/ItaliaTheme/Pagination/PaginationItem
 # defaultMessage: Pagina
 msgid "Page"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Paste
+msgid "Paste"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste the item here?
+msgid "Paste item here?"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste items here?
+msgid "Paste selected items?"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
@@ -559,6 +627,16 @@ msgstr ""
 #: overrideTranslations
 # defaultMessage: Published
 msgid "Published"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
+msgid "Rename Items Loading Message"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
+msgid "Rename items"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/FileWidget
@@ -617,6 +695,11 @@ msgstr "Seleccione todos los tipos de contenido o ninguno"
 msgid "Select all or none"
 msgstr "Seleccionar todo o ninguno"
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
+msgid "Select the transition to be used for modifying the items state."
+msgstr ""
+
 #: components/SelectInput/SelectInput
 # defaultMessage: Seleziona un'opzione
 msgid "SelectInput_default_label"
@@ -632,6 +715,11 @@ msgstr "Seleccione un archivo"
 msgid "Seleziona un'icona"
 msgstr "Seleccione un icono en la barra lateral"
 
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
+msgid "Short name"
+msgstr ""
+
 #: components/ItaliaTheme/Search/SearchCTs
 #: components/ItaliaTheme/Search/SearchTopics
 # defaultMessage: Mostra tutto
@@ -642,6 +730,16 @@ msgstr "Mostrar todo"
 # defaultMessage: Mostra tutti i tipi di contenuto
 msgid "Show all content types"
 msgstr "Mostrar todos los tipos de contenido"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders.
+msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken.
+msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Sono occorsi degli errori
@@ -680,10 +778,26 @@ msgstr "Texto..."
 msgid "Thank you."
 msgstr "Gracias."
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: These items will have broken links
+msgid "These items will have broken links"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder.
+msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
+msgid "This name will be displayed in the URL."
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Edit
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/IconBlocks/Edit
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
+#: components/manage/Contents/ContentsRenameModal
 # defaultMessage: Titolo...
 msgid "Title"
 msgstr "Título..."
@@ -816,14 +930,49 @@ msgstr "Vídeo"
 msgid "VideoGalleryBlock"
 msgstr "Galería de Vídeos"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: View links and references to this item
+msgid "View links and references to this item"
+msgstr ""
+
 #: overrideTranslations
 # defaultMessage: Visible only in view mode
 msgid "Visible only in view mode"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
+msgid "Workflow Change Loading Message"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Manda a capo il titolo con un trattino se è troppo lungo
 msgid "Wrap title"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: You are copying more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: You are cutting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: You are pasting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: You are renaming more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
@@ -2707,6 +2856,16 @@ msgstr "Índice de página"
 msgid "insert_filter"
 msgstr "Inserta un filtro del menú lateral para ver los resultados relacionados"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: item
+msgid "item"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: items
+msgid "items"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Iter del procedimento
@@ -2738,6 +2897,31 @@ msgstr ""
 # defaultMessage: Collegamento
 msgid "link"
 msgstr "Enlace"
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut
+msgid "link-integrity: Cut"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete
+msgid "link-integrity: Delete"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete item and break links
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Checking...
+msgid "link-integrity: loading"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Checking references...
+msgid "link-integrity: loading references"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderCenter
 # defaultMessage: homepage
@@ -3198,6 +3382,11 @@ msgstr ""
 msgid "parteciperanno"
 msgstr "Participara"
 
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Checking...
+msgid "paste cheching: loading"
+msgstr ""
+
 #: components/ItaliaTheme/View/EventoView/EventoPatrocinatoDa
 # defaultMessage: Patrocinato da
 msgid "patrocinato_da"
@@ -3296,6 +3485,21 @@ msgstr ""
 # defaultMessage: Tempo di lettura
 msgid "reading_time"
 msgstr "Tiempo de leer"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: reference
+msgid "reference"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: references
+msgid "references"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: refers to
+msgid "refers to"
+msgstr ""
 
 #: components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks
 # defaultMessage: Documenti

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -119,6 +119,13 @@ msgstr ""
 msgid "Callout"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+#: components/manage/Contents/ContentsDeleteModal
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Cancel
+msgid "Cancel"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow
 # defaultMessage: Vedi
@@ -161,6 +168,16 @@ msgstr "Recherche par sujet"
 # defaultMessage: Cerca per parola chiave
 msgid "Cerca per parola chiave"
 msgstr "Recherche par mots-clés"
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
+msgid "Change State"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
+msgid "Change workflow state recursively"
+msgstr ""
 
 #: overrideTranslations
 # defaultMessage: Pulisci i campi
@@ -209,6 +226,16 @@ msgstr "Contenu"
 msgid "Current filters applied"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut selected items?
+msgid "Cut selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut this item?
+msgid "Cut this item?"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/Dates
 # defaultMessage: Date aggiuntive
 msgid "Date aggiuntive"
@@ -227,6 +254,27 @@ msgstr ""
 #: helpers/Translations/searchBlockExtendedTranslations
 # defaultMessage: Dal {start} al {end}
 msgid "DateRangeFacetFilterListEntryDalAl"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Default
+msgid "Default"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete selected items?
+msgid "Delete selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete this item?
+msgid "Delete this item?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Deleting this item breaks {brokenReferences} {variation}.
+msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
@@ -477,6 +525,11 @@ msgstr ""
 msgid "Mostra tutti gli argomenti"
 msgstr "Afficher tous les sujets"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Navigate to this item
+msgid "Navigate to this item"
+msgstr ""
+
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
@@ -515,6 +568,21 @@ msgstr ""
 #: components/ItaliaTheme/Pagination/PaginationItem
 # defaultMessage: Pagina
 msgid "Page"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Paste
+msgid "Paste"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste the item here?
+msgid "Paste item here?"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste items here?
+msgid "Paste selected items?"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
@@ -567,6 +635,16 @@ msgstr ""
 #: overrideTranslations
 # defaultMessage: Published
 msgid "Published"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
+msgid "Rename Items Loading Message"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
+msgid "Rename items"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/FileWidget
@@ -625,6 +703,11 @@ msgstr "Sélectionner tous les types de contenu ou aucun"
 msgid "Select all or none"
 msgstr "Sélectionner tout ou aucun"
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
+msgid "Select the transition to be used for modifying the items state."
+msgstr ""
+
 #: components/SelectInput/SelectInput
 # defaultMessage: Seleziona un'opzione
 msgid "SelectInput_default_label"
@@ -640,6 +723,11 @@ msgstr "Sélectionner un fichier"
 msgid "Seleziona un'icona"
 msgstr ""
 
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
+msgid "Short name"
+msgstr ""
+
 #: components/ItaliaTheme/Search/SearchCTs
 #: components/ItaliaTheme/Search/SearchTopics
 # defaultMessage: Mostra tutto
@@ -650,6 +738,16 @@ msgstr "Afficher tout"
 # defaultMessage: Mostra tutti i tipi di contenuto
 msgid "Show all content types"
 msgstr "Afficher tous les types de contenu"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders.
+msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken.
+msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Sono occorsi degli errori
@@ -688,10 +786,26 @@ msgstr ""
 msgid "Thank you."
 msgstr "Merci."
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: These items will have broken links
+msgid "These items will have broken links"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder.
+msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
+msgid "This name will be displayed in the URL."
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Edit
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/IconBlocks/Edit
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
+#: components/manage/Contents/ContentsRenameModal
 # defaultMessage: Titolo...
 msgid "Title"
 msgstr ""
@@ -824,14 +938,49 @@ msgstr "Vidéo"
 msgid "VideoGalleryBlock"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: View links and references to this item
+msgid "View links and references to this item"
+msgstr ""
+
 #: overrideTranslations
 # defaultMessage: Visible only in view mode
 msgid "Visible only in view mode"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
+msgid "Workflow Change Loading Message"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Manda a capo il titolo con un trattino se è troppo lungo
 msgid "Wrap title"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: You are copying more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: You are cutting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: You are pasting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: You are renaming more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
@@ -2715,6 +2864,16 @@ msgstr "Index des pages"
 msgid "insert_filter"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: item
+msgid "item"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: items
+msgid "items"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Iter del procedimento
@@ -2745,6 +2904,31 @@ msgstr "Les champs marqués d'une (*) sont obligatoires."
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
 # defaultMessage: Collegamento
 msgid "link"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut
+msgid "link-integrity: Cut"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete
+msgid "link-integrity: Delete"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete item and break links
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Checking...
+msgid "link-integrity: loading"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Checking references...
+msgid "link-integrity: loading references"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderCenter
@@ -3206,6 +3390,11 @@ msgstr ""
 msgid "parteciperanno"
 msgstr "Participants"
 
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Checking...
+msgid "paste cheching: loading"
+msgstr ""
+
 #: components/ItaliaTheme/View/EventoView/EventoPatrocinatoDa
 # defaultMessage: Patrocinato da
 msgid "patrocinato_da"
@@ -3304,6 +3493,21 @@ msgstr ""
 # defaultMessage: Tempo di lettura
 msgid "reading_time"
 msgstr "Temps de lecture"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: reference
+msgid "reference"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: references
+msgid "references"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: refers to
+msgid "refers to"
+msgstr ""
 
 #: components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks
 # defaultMessage: Documenti

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -102,6 +102,13 @@ msgstr ""
 msgid "Callout"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+#: components/manage/Contents/ContentsDeleteModal
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Cancel
+msgid "Cancel"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow
 # defaultMessage: Vedi
@@ -144,6 +151,16 @@ msgstr "Cerca per argomento"
 # defaultMessage: Cerca per parola chiave
 msgid "Cerca per parola chiave"
 msgstr "Cerca per parola chiave"
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
+msgid "Change State"
+msgstr "Cambia stato"
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
+msgid "Change workflow state recursively"
+msgstr "Cambia stato ricorsivamente"
 
 #: overrideTranslations
 # defaultMessage: Pulisci i campi
@@ -192,6 +209,16 @@ msgstr "Contenuto"
 msgid "Current filters applied"
 msgstr "Filtri attualmente applicati"
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut selected items?
+msgid "Cut selected items?"
+msgstr "Vuoi tagliare gli elementi selezionati?"
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut this item?
+msgid "Cut this item?"
+msgstr "Vuoi tagliare questo elemento?"
+
 #: components/ItaliaTheme/View/Commons/Dates
 # defaultMessage: Date aggiuntive
 msgid "Date aggiuntive"
@@ -211,6 +238,27 @@ msgstr "Dal {start}"
 # defaultMessage: Dal {start} al {end}
 msgid "DateRangeFacetFilterListEntryDalAl"
 msgstr "Dal {start} al {end}"
+
+#: components/manage/Contents/ContentsRenameModal
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Default
+msgid "Default"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete selected items?
+msgid "Delete selected items?"
+msgstr "Vuoi eliminare gli elementi selezionati?"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete this item?
+msgid "Delete this item?"
+msgstr "Vuoi eliminare questo elemento?"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Deleting this item breaks {brokenReferences} {variation}.
+msgid "Deleting this item breaks {brokenReferences} {variation}."
+msgstr "Cancellando questo elemento si romperanno {brokenReferences} {variation}."
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
@@ -460,6 +508,11 @@ msgstr "Mostra lo sfondo del blocco"
 msgid "Mostra tutti gli argomenti"
 msgstr "Mostra tutti gli argomenti"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Navigate to this item
+msgid "Navigate to this item"
+msgstr ""
+
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
@@ -499,6 +552,21 @@ msgstr "Apri in un nuovo tab"
 # defaultMessage: Pagina
 msgid "Page"
 msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Paste
+msgid "Paste"
+msgstr "Incolla"
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste the item here?
+msgid "Paste item here?"
+msgstr "Vuoi incollare l'elemento qui?"
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste items here?
+msgid "Paste selected items?"
+msgstr "Vuoi incollare gli elementi qui?"
 
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
@@ -551,6 +619,16 @@ msgstr "Privato"
 # defaultMessage: Published
 msgid "Published"
 msgstr "Pubblicato"
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
+msgid "Rename Items Loading Message"
+msgstr "Sto rinominando gli elementi..."
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
+msgid "Rename items"
+msgstr "Rinomina"
 
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Rimuovi il file
@@ -608,6 +686,11 @@ msgstr "Seleziona tutti i tipi di contenuti o nessuno"
 msgid "Select all or none"
 msgstr "Seleziona tutti o nessuno"
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
+msgid "Select the transition to be used for modifying the items state."
+msgstr ""
+
 #: components/SelectInput/SelectInput
 # defaultMessage: Seleziona un'opzione
 msgid "SelectInput_default_label"
@@ -623,6 +706,11 @@ msgstr "Seleziona un file"
 msgid "Seleziona un'icona"
 msgstr "Seleziona un'icona nella barra a lato"
 
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
+msgid "Short name"
+msgstr "Nome breve"
+
 #: components/ItaliaTheme/Search/SearchCTs
 #: components/ItaliaTheme/Search/SearchTopics
 # defaultMessage: Mostra tutto
@@ -633,6 +721,16 @@ msgstr "Mostra tutto"
 # defaultMessage: Mostra tutti i tipi di contenuto
 msgid "Show all content types"
 msgstr "Mostra tutti i tipi di contenuto"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders.
+msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+msgstr "Alcuni elementi sono anche cartelle. Eliminandoli eliminerai anche {containedItemsToDelete} {variation} all'interno delle cartelle."
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken.
+msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+msgstr "Alcuni elementi sono referenziati da altri contenuti. Cancellandoli si romperanno {brokenReferences} {variation}."
 
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Sono occorsi degli errori
@@ -671,10 +769,26 @@ msgstr "Testo..."
 msgid "Thank you."
 msgstr "Grazie."
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: These items will have broken links
+msgid "These items will have broken links"
+msgstr "Questi elementi avranno dei collegamenti rotti"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder.
+msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+msgstr "Questo elemento è anche una cartella. Eliminandola eliminerai anche {containedItemsToDelete} {variation} in questa cartella."
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
+msgid "This name will be displayed in the URL."
+msgstr "Questo nome sarà visualizzato nell'URL."
+
 #: components/ItaliaTheme/Blocks/Accordion/Edit
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/IconBlocks/Edit
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
+#: components/manage/Contents/ContentsRenameModal
 # defaultMessage: Titolo...
 msgid "Title"
 msgstr "Titolo"
@@ -807,15 +921,50 @@ msgstr "Video"
 msgid "VideoGalleryBlock"
 msgstr "Video gallery"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: View links and references to this item
+msgid "View links and references to this item"
+msgstr "Visualizza collegamenti e riferimenti a questo elemento"
+
 #: overrideTranslations
 # defaultMessage: Visible only in view mode
 msgid "Visible only in view mode"
 msgstr "Visibile solamente in modalità visualizzazione"
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
+msgid "Workflow Change Loading Message"
+msgstr "Sto aggiornando gli stati..."
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Manda a capo il titolo con un trattino se è troppo lungo
 msgid "Wrap title"
 msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr "Per favore modifica lo stato di meno di {limit} elementi per volta. Altrimenti apri un ticket di assistenza tecnica."
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: You are copying more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr "Per favore copia meno di {limit} elementi per volta. Altrimenti apri un ticket di assistenza tecnica."
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: You are cutting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr "Per favore cancella meno di {limit} elementi per volta. Altrimenti apri un ticket di assistenza tecnica."
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: You are pasting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr "Per favore incolla meno di {limit} elementi per volta. Altrimenti apri un ticket di assistenza tecnica."
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: You are renaming more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr "Per favore rinomina meno di {limit} elementi per volta. Altrimenti apri un ticket di assistenza tecnica."
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
 # defaultMessage: You are trying to access a protected resource, please {login} first.
@@ -2698,6 +2847,16 @@ msgstr "Indice della pagina"
 msgid "insert_filter"
 msgstr "Inserire un filtro dal menù laterale per visualizzare i relativi risultati"
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: item
+msgid "item"
+msgstr "elemento"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: items
+msgid "items"
+msgstr "elementi"
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Iter del procedimento
@@ -2729,6 +2888,31 @@ msgstr "I campi contrassegnati da (*) sono obbligatori."
 # defaultMessage: Collegamento
 msgid "link"
 msgstr "Collegamento"
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut
+msgid "link-integrity: Cut"
+msgstr "Taglia"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete
+msgid "link-integrity: Delete"
+msgstr "Elimina"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete item and break links
+msgid "link-integrity: Delete item and break links"
+msgstr "Elimina questo elemento e rompi i collegamenti"
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Checking...
+msgid "link-integrity: loading"
+msgstr "Sto verificando..."
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Checking references...
+msgid "link-integrity: loading references"
+msgstr "Sto caricando i riferimenti..."
 
 #: components/ItaliaTheme/Header/HeaderCenter
 # defaultMessage: homepage
@@ -3189,6 +3373,11 @@ msgstr "Menu principale del sito"
 msgid "parteciperanno"
 msgstr "Parteciperanno"
 
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Checking...
+msgid "paste cheching: loading"
+msgstr "Sto verificando..."
+
 #: components/ItaliaTheme/View/EventoView/EventoPatrocinatoDa
 # defaultMessage: Patrocinato da
 msgid "patrocinato_da"
@@ -3287,6 +3476,21 @@ msgstr ""
 # defaultMessage: Tempo di lettura
 msgid "reading_time"
 msgstr "Tempo di lettura"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: reference
+msgid "reference"
+msgstr "riferimento"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: references
+msgid "references"
+msgstr "riferimenti"
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: refers to
+msgid "refers to"
+msgstr "fa riferimento a"
 
 #: components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks
 # defaultMessage: Documenti

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-05-26T07:34:11.737Z\n"
+"POT-Creation-Date: 2026-06-25T09:35:45.600Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -104,6 +104,13 @@ msgstr ""
 msgid "Callout"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+#: components/manage/Contents/ContentsDeleteModal
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Cancel
+msgid "Cancel"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/Card/SimpleCardDefault
 #: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateOneForRow
 # defaultMessage: Vedi
@@ -145,6 +152,16 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/EventSearch/DefaultFilters
 # defaultMessage: Cerca per parola chiave
 msgid "Cerca per parola chiave"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
+msgid "Change State"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
+msgid "Change workflow state recursively"
 msgstr ""
 
 #: overrideTranslations
@@ -194,6 +211,16 @@ msgstr ""
 msgid "Current filters applied"
 msgstr ""
 
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut selected items?
+msgid "Cut selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut this item?
+msgid "Cut this item?"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/Dates
 # defaultMessage: Date aggiuntive
 msgid "Date aggiuntive"
@@ -212,6 +239,27 @@ msgstr ""
 #: helpers/Translations/searchBlockExtendedTranslations
 # defaultMessage: Dal {start} al {end}
 msgid "DateRangeFacetFilterListEntryDalAl"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Default
+msgid "Default"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete selected items?
+msgid "Delete selected items?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete this item?
+msgid "Delete this item?"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Deleting this item breaks {brokenReferences} {variation}.
+msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
@@ -462,6 +510,11 @@ msgstr ""
 msgid "Mostra tutti gli argomenti"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Navigate to this item
+msgid "Navigate to this item"
+msgstr ""
+
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
@@ -500,6 +553,21 @@ msgstr ""
 #: components/ItaliaTheme/Pagination/PaginationItem
 # defaultMessage: Pagina
 msgid "Page"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Paste
+msgid "Paste"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste the item here?
+msgid "Paste item here?"
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Do you want to paste items here?
+msgid "Paste selected items?"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
@@ -552,6 +620,16 @@ msgstr ""
 #: overrideTranslations
 # defaultMessage: Published
 msgid "Published"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
+msgid "Rename Items Loading Message"
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
+msgid "Rename items"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/FileWidget
@@ -610,6 +688,11 @@ msgstr ""
 msgid "Select all or none"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
+msgid "Select the transition to be used for modifying the items state."
+msgstr ""
+
 #: components/SelectInput/SelectInput
 # defaultMessage: Seleziona un'opzione
 msgid "SelectInput_default_label"
@@ -625,6 +708,11 @@ msgstr ""
 msgid "Seleziona un'icona"
 msgstr ""
 
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
+msgid "Short name"
+msgstr ""
+
 #: components/ItaliaTheme/Search/SearchCTs
 #: components/ItaliaTheme/Search/SearchTopics
 # defaultMessage: Mostra tutto
@@ -634,6 +722,16 @@ msgstr ""
 #: components/ItaliaTheme/Search/SearchCTs
 # defaultMessage: Mostra tutti i tipi di contenuto
 msgid "Show all content types"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders.
+msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken.
+msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
 #: components/ItaliaTheme/Search/Search
@@ -673,10 +771,26 @@ msgstr ""
 msgid "Thank you."
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: These items will have broken links
+msgid "These items will have broken links"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder.
+msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
+msgid "This name will be displayed in the URL."
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Accordion/Edit
 #: components/ItaliaTheme/Blocks/ContactsBlock/Edit
 #: components/ItaliaTheme/Blocks/IconBlocks/Edit
 #: components/ItaliaTheme/Blocks/VideoGallery/Edit
+#: components/manage/Contents/ContentsRenameModal
 # defaultMessage: Titolo...
 msgid "Title"
 msgstr ""
@@ -809,14 +923,49 @@ msgstr ""
 msgid "VideoGalleryBlock"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: View links and references to this item
+msgid "View links and references to this item"
+msgstr ""
+
 #: overrideTranslations
 # defaultMessage: Visible only in view mode
 msgid "Visible only in view mode"
 msgstr ""
 
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
+msgid "Workflow Change Loading Message"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Manda a capo il titolo con un trattino se è troppo lungo
 msgid "Wrap title"
+msgstr ""
+
+#: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: You are copying more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: You are cutting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: You are pasting more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+msgstr ""
+
+#: components/manage/Contents/ContentsRenameModal
+# defaultMessage: You are renaming more then {limit} items. It's recommended to contact administrators to do this operation.
+msgid "You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
 msgstr ""
 
 #: components/ItaliaTheme/Unauthorized/Unauthorized
@@ -2700,6 +2849,16 @@ msgstr ""
 msgid "insert_filter"
 msgstr ""
 
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: item
+msgid "item"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: items
+msgid "items"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Iter del procedimento
@@ -2730,6 +2889,31 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/SearchSections/SideBar
 # defaultMessage: Collegamento
 msgid "link"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Cut
+msgid "link-integrity: Cut"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete
+msgid "link-integrity: Delete"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Delete item and break links
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#: components/manage/Contents/ContentsAffectedItemsOnCopyModal
+# defaultMessage: Checking...
+msgid "link-integrity: loading"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: Checking references...
+msgid "link-integrity: loading references"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderCenter
@@ -3191,6 +3375,11 @@ msgstr ""
 msgid "parteciperanno"
 msgstr ""
 
+#: components/manage/Contents/ContentsPasteModal
+# defaultMessage: Checking...
+msgid "paste cheching: loading"
+msgstr ""
+
 #: components/ItaliaTheme/View/EventoView/EventoPatrocinatoDa
 # defaultMessage: Patrocinato da
 msgid "patrocinato_da"
@@ -3288,6 +3477,21 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeader
 # defaultMessage: Tempo di lettura
 msgid "reading_time"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: reference
+msgid "reference"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: references
+msgid "references"
+msgstr ""
+
+#: components/manage/Contents/ContentsDeleteModal
+# defaultMessage: refers to
+msgid "refers to"
 msgstr ""
 
 #: components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks

--- a/src/components/manage/Contents/ContentsAffectedItemsOnCopyModal.jsx
+++ b/src/components/manage/Contents/ContentsAffectedItemsOnCopyModal.jsx
@@ -1,0 +1,75 @@
+/*Customizations: 
+- added message for MAX_AFFECTED_LIMIT (`limit` prop)
+- on Cut, check link integrity to request user confirm to move contents
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+
+import { Modal, Message } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  cutConfirmSingleItem: {
+    id: 'Cut this item?',
+    defaultMessage: 'Cut this item?',
+  },
+  cutConfirmMultipleItems: {
+    id: 'Cut selected items?',
+    defaultMessage: 'Cut selected items?',
+  },
+  loading: {
+    id: 'link-integrity: loading',
+    defaultMessage: 'Checking...',
+  },
+  cut: {
+    id: 'link-integrity: Cut',
+    defaultMessage: 'Cut',
+  },
+  cancel: {
+    id: 'Cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const ContentsAffectedItemsOnCopyModal = (props) => {
+  const { onOk, limit, open } = props;
+  const intl = useIntl();
+
+  const affectedItems = useSelector(
+    (state) => state.search?.subrequests?.affected_items_copy?.total ?? 0,
+  );
+
+  return (
+    open && (
+      <Modal
+        open={open}
+        confirmButton={intl.formatMessage(messages.cut)}
+        cancelButton={intl.formatMessage(messages.cancel)}
+        header="Copia"
+        content={
+          <div className="content">
+            {affectedItems > limit ? (
+              <Message warning>
+                <FormattedMessage
+                  id="You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+                  defaultMessage="You are copying more then {limit} items. It's recommended to contact administrators to do this operation."
+                  values={{ limit }}
+                />
+              </Message>
+            ) : null}
+          </div>
+        }
+        actions={['Ok']}
+        onActionClick={onOk}
+        size="medium"
+      />
+    )
+  );
+};
+
+ContentsAffectedItemsOnCopyModal.propTypes = {
+  onOk: PropTypes.func.isRequired,
+  limit: PropTypes.number,
+};
+export default ContentsAffectedItemsOnCopyModal;

--- a/src/components/manage/Contents/ContentsDeleteModal.jsx
+++ b/src/components/manage/Contents/ContentsDeleteModal.jsx
@@ -1,0 +1,401 @@
+/*
+CUSTOMIZATION:
+- added message for MAX_AFFECTED_LIMIT (`limit` prop)
+*/
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { map, find } from 'lodash';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+import { linkIntegrityCheck } from '@plone/volto/actions';
+import { flattenToAppURL } from '@plone/volto/helpers';
+
+import { Confirm, Dimmer, Loader, Table, Message } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  deleteConfirmSingleItem: {
+    id: 'Delete this item?',
+    defaultMessage: 'Delete this item?',
+  },
+  deleteConfirmMultipleItems: {
+    id: 'Delete selected items?',
+    defaultMessage: 'Delete selected items?',
+  },
+  navigate_to_this_item: {
+    id: 'Navigate to this item',
+    defaultMessage: 'Navigate to this item',
+  },
+  loading: {
+    id: 'link-integrity: loading references',
+    defaultMessage: 'Checking references...',
+  },
+  delete: {
+    id: 'link-integrity: Delete',
+    defaultMessage: 'Delete',
+  },
+  delete_and_broken_links: {
+    id: 'link-integrity: Delete item and break links',
+    defaultMessage: 'Delete item and break links',
+  },
+  cancel: {
+    id: 'Cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const ContentsDeleteModal = (props) => {
+  const { itemsToDelete = [], open, onCancel, onOk, items, limit } = props;
+  const intl = useIntl();
+  const dispatch = useDispatch();
+
+  const linkintegrityInfo = useSelector((state) => state.linkIntegrity?.result);
+  const loading = useSelector((state) => state.linkIntegrity?.loading);
+
+  const [brokenReferences, setBrokenReferences] = useState(0);
+  const [containedItemsToDelete, setContainedItemsToDelete] = useState([]);
+  const [breaches, setBreaches] = useState([]);
+
+  const [linksAndReferencesViewLink, setLinkAndReferencesViewLink] =
+    useState(null);
+
+  useEffect(() => {
+    const getFieldById = (id, field) => {
+      const item = find(items, { '@id': id });
+      return item ? item[field] : '';
+    };
+
+    if (itemsToDelete.length > 0 && open) {
+      dispatch(
+        linkIntegrityCheck(
+          map(itemsToDelete, (item) => getFieldById(item, 'UID')),
+        ),
+      );
+    }
+  }, [itemsToDelete, items, open, dispatch]);
+
+  useEffect(() => {
+    if (linkintegrityInfo) {
+      const containedItems = linkintegrityInfo
+        .map((result) => result.items_total ?? 0)
+        .reduce((acc, value) => acc + value, 0);
+      const breaches = linkintegrityInfo.flatMap((result) =>
+        result.breaches.map((source) => ({
+          source: source,
+          target: result,
+        })),
+      );
+      const source_by_uid = breaches.reduce(
+        (acc, value) => acc.set(value.source.uid, value.source),
+        new Map(),
+      );
+      const by_source = breaches.reduce((acc, value) => {
+        if (acc.get(value.source.uid) === undefined) {
+          acc.set(value.source.uid, new Set());
+        }
+        acc.get(value.source.uid).add(value.target);
+        return acc;
+      }, new Map());
+
+      setContainedItemsToDelete(containedItems);
+      setBrokenReferences(by_source.size);
+      setLinkAndReferencesViewLink(
+        linkintegrityInfo.length
+          ? linkintegrityInfo[0]['@id'] + '/links-to-item'
+          : null,
+      );
+      setBreaches(
+        Array.from(by_source, (entry) => ({
+          source: source_by_uid.get(entry[0]),
+          targets: Array.from(entry[1]),
+        })),
+      );
+    } else {
+      setContainedItemsToDelete([]);
+      setBrokenReferences(0);
+      setLinkAndReferencesViewLink(null);
+      setBreaches([]);
+    }
+  }, [linkintegrityInfo]);
+
+  const containedItemsLimitMessage =
+    containedItemsToDelete > limit ? (
+      <Message warning>
+        <FormattedMessage
+          id="You are deleting more then {limit} items. It's recommended to contact administrators to do this operation."
+          defaultMessage="You are cutting more then {limit} items. It's recommended to contact administrators to do this operation."
+          values={{ limit }}
+        />
+      </Message>
+    ) : (
+      <></>
+    );
+
+  return (
+    open && (
+      <Confirm
+        open={open}
+        confirmButton={
+          brokenReferences === 0
+            ? intl.formatMessage(messages.delete)
+            : intl.formatMessage(messages.delete_and_broken_links)
+        }
+        cancelButton={intl.formatMessage(messages.cancel)}
+        header={
+          itemsToDelete.length === 1
+            ? intl.formatMessage(messages.deleteConfirmSingleItem)
+            : intl.formatMessage(messages.deleteConfirmMultipleItems)
+        }
+        content={
+          <div className="content">
+            <Dimmer active={loading} inverted>
+              <Loader indeterminate size="massive">
+                {intl.formatMessage(messages.loading)}
+              </Loader>
+            </Dimmer>
+
+            {itemsToDelete.length > 1 ? (
+              containedItemsToDelete > 0 ? (
+                <>
+                  <FormattedMessage
+                    id="Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+                    defaultMessage="Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+                    values={{
+                      containedItemsToDelete: (
+                        <span>{containedItemsToDelete}</span>
+                      ),
+                      variation: (
+                        <span>
+                          {containedItemsToDelete === 1 ? (
+                            <FormattedMessage id="item" defaultMessage="item" />
+                          ) : (
+                            <FormattedMessage
+                              id="items"
+                              defaultMessage="items"
+                            />
+                          )}
+                        </span>
+                      ),
+                    }}
+                  />
+                  {containedItemsLimitMessage}
+
+                  {brokenReferences > 0 && (
+                    <>
+                      <br />
+                      <FormattedMessage
+                        id="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        defaultMessage="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        values={{
+                          brokenReferences: <span>{brokenReferences}</span>,
+                          variation: (
+                            <span>
+                              {brokenReferences === 1 ? (
+                                <FormattedMessage
+                                  id="reference"
+                                  defaultMessage="reference"
+                                />
+                              ) : (
+                                <FormattedMessage
+                                  id="references"
+                                  defaultMessage="references"
+                                />
+                              )}
+                            </span>
+                          ),
+                        }}
+                      />
+                    </>
+                  )}
+                </>
+              ) : (
+                <>
+                  {brokenReferences > 0 && (
+                    <>
+                      <FormattedMessage
+                        id="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        defaultMessage="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        values={{
+                          brokenReferences: <span>{brokenReferences}</span>,
+                          variation: (
+                            <span>
+                              {brokenReferences === 1 ? (
+                                <FormattedMessage
+                                  id="reference"
+                                  defaultMessage="reference"
+                                />
+                              ) : (
+                                <FormattedMessage
+                                  id="references"
+                                  defaultMessage="references"
+                                />
+                              )}
+                            </span>
+                          ),
+                        }}
+                      />
+                    </>
+                  )}
+                </>
+              )
+            ) : containedItemsToDelete > 0 ? (
+              <>
+                <FormattedMessage
+                  id="This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+                  defaultMessage="This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+                  values={{
+                    containedItemsToDelete: (
+                      <span>{containedItemsToDelete}</span>
+                    ),
+                    variation: (
+                      <span>
+                        {containedItemsToDelete === 1 ? (
+                          <FormattedMessage id="item" defaultMessage="item" />
+                        ) : (
+                          <FormattedMessage id="items" defaultMessage="items" />
+                        )}
+                      </span>
+                    ),
+                  }}
+                />
+                {containedItemsLimitMessage}
+
+                {brokenReferences > 0 && (
+                  <>
+                    <br />
+                    <FormattedMessage
+                      id="Deleting this item breaks {brokenReferences} {variation}."
+                      defaultMessage="Deleting this item breaks {brokenReferences} {variation}."
+                      values={{
+                        brokenReferences: <span>{brokenReferences}</span>,
+                        variation: (
+                          <span>
+                            {brokenReferences === 1 ? (
+                              <FormattedMessage
+                                id="reference"
+                                defaultMessage="reference"
+                              />
+                            ) : (
+                              <FormattedMessage
+                                id="references"
+                                defaultMessage="references"
+                              />
+                            )}
+                          </span>
+                        ),
+                      }}
+                    />
+                    <BrokenLinksList
+                      intl={intl}
+                      breaches={breaches}
+                      linksAndReferencesViewLink={linksAndReferencesViewLink}
+                    />
+                  </>
+                )}
+              </>
+            ) : brokenReferences > 0 ? (
+              <>
+                <FormattedMessage
+                  id="Deleting this item breaks {brokenReferences} {variation}."
+                  defaultMessage="Deleting this item breaks {brokenReferences} {variation}."
+                  values={{
+                    brokenReferences: <span>{brokenReferences}</span>,
+                    variation: (
+                      <span>
+                        {brokenReferences === 1 ? (
+                          <FormattedMessage
+                            id="reference"
+                            defaultMessage="reference"
+                          />
+                        ) : (
+                          <FormattedMessage
+                            id="references"
+                            defaultMessage="references"
+                          />
+                        )}
+                      </span>
+                    ),
+                  }}
+                />
+                <BrokenLinksList
+                  intl={intl}
+                  breaches={breaches}
+                  linksAndReferencesViewLink={linksAndReferencesViewLink}
+                />
+              </>
+            ) : null}
+          </div>
+        }
+        onCancel={onCancel}
+        onConfirm={onOk}
+        size="medium"
+      />
+    )
+  );
+};
+
+const BrokenLinksList = ({ intl, breaches, linksAndReferencesViewLink }) => {
+  return (
+    <div className="broken-links-list">
+      <FormattedMessage
+        id="These items will have broken links"
+        defaultMessage="These items will have broken links"
+      />
+      :
+      <Table compact>
+        <Table.Body>
+          {breaches.map((breach) => (
+            <Table.Row key={breach.source['@id']} verticalAlign="top">
+              <Table.Cell>
+                <Link
+                  to={flattenToAppURL(breach.source['@id'])}
+                  title={intl.formatMessage(messages.navigate_to_this_item)}
+                >
+                  {breach.source.title}
+                </Link>
+              </Table.Cell>
+              <Table.Cell style={{ minWidth: '140px' }}>
+                <FormattedMessage id="refers to" defaultMessage="refers to" />:
+              </Table.Cell>
+              <Table.Cell>
+                <ul style={{ margin: 0 }}>
+                  {breach.targets.map((target) => (
+                    <li key={target['@id']}>
+                      <Link
+                        to={flattenToAppURL(target['@id'])}
+                        title={intl.formatMessage(
+                          messages.navigate_to_this_item,
+                        )}
+                      >
+                        {target.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      {linksAndReferencesViewLink && (
+        <Link to={flattenToAppURL(linksAndReferencesViewLink)}>
+          <FormattedMessage
+            id="View links and references to this item"
+            defaultMessage="View links and references to this item"
+          />
+        </Link>
+      )}
+    </div>
+  );
+};
+ContentsDeleteModal.propTypes = {
+  itemsToDelete: PropTypes.arrayOf(
+    PropTypes.shape({
+      UID: PropTypes.string,
+    }),
+  ).isRequired,
+  open: PropTypes.bool.isRequired,
+  onOk: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+export default ContentsDeleteModal;

--- a/src/components/manage/Contents/ContentsPasteModal.jsx
+++ b/src/components/manage/Contents/ContentsPasteModal.jsx
@@ -1,0 +1,95 @@
+/*Customizations: 
+- added message for MAX_AFFECTED_LIMIT (`limit` prop)
+- on Paste, check link integrity to request user confirm to move contents
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+
+import { Confirm, Dimmer, Loader, Message } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  pasteConfirmSingleItem: {
+    id: 'Paste item here?',
+    defaultMessage: 'Do you want to paste the item here?',
+  },
+  pasteConfirmMultipleItems: {
+    id: 'Paste selected items?',
+    defaultMessage: 'Do you want to paste items here?',
+  },
+  loading: {
+    id: 'paste cheching: loading',
+    defaultMessage: 'Checking...',
+  },
+  paste: {
+    id: 'Paste',
+    defaultMessage: 'Paste',
+  },
+  cancel: {
+    id: 'Cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const ContentsPasteModal = (props) => {
+  const { itemsToPaste = [], open, onCancel, onOk, limit } = props;
+  const intl = useIntl();
+  const affectedItems = useSelector(
+    (state) => state.search?.subrequests?.affected_items_paste?.total ?? 0,
+  );
+  const loading = useSelector(
+    (state) =>
+      state.search?.subrequests?.affected_items_paste?.loading ?? false,
+  );
+
+  return (
+    open && (
+      <Confirm
+        open={open}
+        confirmButton={intl.formatMessage(messages.paste)}
+        cancelButton={intl.formatMessage(messages.cancel)}
+        header={
+          itemsToPaste.length === 1
+            ? intl.formatMessage(messages.pasteConfirmSingleItem)
+            : intl.formatMessage(messages.pasteConfirmMultipleItems)
+        }
+        content={
+          <div className="content">
+            <Dimmer active={loading} inverted>
+              <Loader indeterminate size="massive">
+                {intl.formatMessage(messages.loading)}
+              </Loader>
+            </Dimmer>
+
+            {affectedItems > limit ? (
+              <Message warning>
+                <FormattedMessage
+                  id="You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+                  defaultMessage="You are pasting more then {limit} items. It's recommended to contact administrators to do this operation."
+                  values={{ limit: limit }}
+                />
+              </Message>
+            ) : null}
+          </div>
+        }
+        onCancel={onCancel}
+        onConfirm={onOk}
+        size="medium"
+      />
+    )
+  );
+};
+
+ContentsPasteModal.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      UID: PropTypes.string,
+    }),
+  ).isRequired,
+  open: PropTypes.bool.isRequired,
+  onOk: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+export default ContentsPasteModal;

--- a/src/components/manage/Contents/ContentsRenameModal.jsx
+++ b/src/components/manage/Contents/ContentsRenameModal.jsx
@@ -1,0 +1,149 @@
+/*CUSTOMIZATION
+- added message for MAX_AFFECTED_LIMIT (`limit` prop)
+*/
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { concat, merge, map } from 'lodash';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+
+import { usePrevious } from '@plone/volto/helpers';
+import { updateContent } from '@plone/volto/actions';
+import { ModalForm } from '@plone/volto/components';
+import { Message } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  renameItems: {
+    id: 'Rename items',
+    defaultMessage: 'Rename items',
+  },
+  default: {
+    id: 'Default',
+    defaultMessage: 'Default',
+  },
+  title: {
+    id: 'Title',
+    defaultMessage: 'Title',
+  },
+  shortName: {
+    id: 'Short name',
+    defaultMessage: 'Short name',
+  },
+  shortNameDescription: {
+    id: 'This name will be displayed in the URL.',
+    defaultMessage: 'This name will be displayed in the URL.',
+  },
+  loadingMessage: {
+    id: 'Rename Items Loading Message',
+    defaultMessage: 'Renaming items...',
+  },
+});
+
+const ContentsRenameModal = (props) => {
+  const { onOk, open, items, onCancel, limit } = props;
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const request = useSelector((state) => state.content.update);
+  const prevrequestloading = usePrevious(request.loading);
+
+  const affectedItems = useSelector(
+    (state) => state.search?.subrequests?.affected_items?.total ?? 0,
+  );
+
+  useEffect(() => {
+    if (prevrequestloading && request.loaded) {
+      onOk();
+    }
+  }, [onOk, prevrequestloading, request.loaded]);
+
+  const onSubmit = useCallback(
+    (data) => {
+      dispatch(
+        updateContent(
+          map(items, (item) => item.url),
+          map(items, (item, index) => ({
+            id: data[`${index}_id`],
+            title: data[`${index}_title`],
+          })),
+        ),
+      );
+    },
+    [items, dispatch],
+  );
+
+  return (
+    open && (
+      <ModalForm
+        open={open}
+        loading={request.loading}
+        loadingMessage={intl.formatMessage(messages.loadingMessage)}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        formData={merge(
+          ...map(items, (item, index) => ({
+            [`${index}_title`]: item.title,
+            [`${index}_id`]: item.id,
+          })),
+        )}
+        title={
+          <>
+            {intl.formatMessage(messages.renameItems)}{' '}
+            {affectedItems > limit ? (
+              <Message warning style={{ fontSize: '1rem', marginTop: '1rem' }}>
+                <FormattedMessage
+                  id="You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
+                  defaultMessage="You are renaming more then {limit} items. It's recommended to contact administrators to do this operation."
+                  values={{ limit }}
+                />
+              </Message>
+            ) : null}
+          </>
+        }
+        schema={{
+          fieldsets: [
+            {
+              id: 'default',
+              title: intl.formatMessage(messages.default),
+              fields: concat(
+                ...map(items, (item, index) => [
+                  `${index}_title`,
+                  `${index}_id`,
+                ]),
+              ),
+            },
+          ],
+          properties: merge(
+            ...map(items, (item, index) => ({
+              [`${index}_title`]: {
+                title: intl.formatMessage(messages.title),
+                type: 'string',
+                description: '',
+              },
+              [`${index}_id`]: {
+                title: intl.formatMessage(messages.shortName),
+                type: 'id',
+                description: intl.formatMessage(messages.shortNameDescription),
+              },
+            })),
+          ),
+          required: [],
+        }}
+      />
+    )
+  );
+};
+
+ContentsRenameModal.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      title: PropTypes.string,
+      url: PropTypes.string,
+    }),
+  ).isRequired,
+  open: PropTypes.bool.isRequired,
+  onOk: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ContentsRenameModal;

--- a/src/components/manage/Contents/ContentsWorkflowModal.jsx
+++ b/src/components/manage/Contents/ContentsWorkflowModal.jsx
@@ -1,0 +1,150 @@
+/*CUSTOMIZATION
+- added message for MAX_AFFECTED_LIMIT (`limit` prop)
+*/
+
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { concat, filter, last, map, uniqBy } from 'lodash';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+
+import { usePrevious } from '@plone/volto/helpers';
+import { getWorkflow, transitionWorkflow } from '@plone/volto/actions';
+import { ModalForm } from '@plone/volto/components';
+import { Message } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  default: {
+    id: 'Default',
+    defaultMessage: 'Default',
+  },
+  stateTitle: {
+    id: 'Change State',
+    defaultMessage: 'Change State',
+  },
+  includeChildrenTitle: {
+    id: 'Change workflow state recursively',
+    defaultMessage: 'Change workflow state recursively',
+  },
+  stateDescription: {
+    id: 'Select the transition to be used for modifying the items state.',
+    defaultMessage:
+      'Select the transition to be used for modifying the items state.',
+  },
+  loadingMessage: {
+    id: 'Workflow Change Loading Message',
+    defaultMessage: 'Updating workflow states...',
+  },
+});
+
+const ContentsWorkflowModal = (props) => {
+  const { onOk, items, open, onCancel, limit } = props;
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const request = useSelector((state) => state.workflow.transition);
+
+  const workflows = useSelector(
+    (state) => state.workflow.multiple,
+    shallowEqual,
+  );
+  const prevrequestloading = usePrevious(request.loading);
+
+  const affectedItems = useSelector(
+    (state) => state.search?.subrequests?.affected_items?.total ?? 0,
+  );
+
+  useEffect(() => {
+    dispatch(getWorkflow(items));
+  }, [dispatch, items]);
+
+  useEffect(() => {
+    if (prevrequestloading && request.loaded) {
+      onOk();
+    }
+  }, [onOk, prevrequestloading, request.loaded]);
+
+  const onSubmit = useCallback(
+    ({ state, include_children }) => {
+      if (!state) {
+        return;
+      }
+      dispatch(
+        transitionWorkflow(
+          filter(
+            map(
+              concat(...map(workflows, (workflow) => workflow.transitions)),
+              (item) => item['@id'],
+            ),
+            (x) => last(x.split('/')) === state,
+          ),
+          include_children,
+        ),
+      );
+    },
+    [dispatch, workflows],
+  );
+
+  return (
+    open &&
+    workflows.length > 0 && (
+      <ModalForm
+        open={open}
+        loading={request.loading}
+        loadingMessage={intl.formatMessage(messages.loadingMessage)}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        title={
+          <>
+            {intl.formatMessage(messages.stateTitle)}
+            {affectedItems > limit ? (
+              <Message warning style={{ fontSize: '1rem', marginTop: '1rem' }}>
+                <FormattedMessage
+                  id="You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+                  defaultMessage="You are changing workflow of more then {limit} items. It's recommended to contact administrators to do this operation."
+                  values={{ limit }}
+                />
+              </Message>
+            ) : null}
+          </>
+        }
+        schema={{
+          fieldsets: [
+            {
+              id: 'default',
+              title: intl.formatMessage(messages.default),
+              fields: ['state', 'include_children'],
+            },
+          ],
+          properties: {
+            state: {
+              description: intl.formatMessage(messages.stateDescription),
+              title: intl.formatMessage(messages.stateTitle),
+              type: 'string',
+              choices: map(
+                uniqBy(
+                  concat(...map(workflows, (workflow) => workflow.transitions)),
+                  (x) => x.title,
+                ),
+                (y) => [last(y['@id'].split('/')), y.title],
+              ),
+            },
+            include_children: {
+              title: intl.formatMessage(messages.includeChildrenTitle),
+              type: 'boolean',
+            },
+          },
+          required: [],
+        }}
+      />
+    )
+  );
+};
+
+ContentsWorkflowModal.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.string).isRequired,
+  open: PropTypes.bool.isRequired,
+  onOk: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ContentsWorkflowModal;

--- a/src/customizations/volto/components/manage/Contents/Contents.jsx
+++ b/src/customizations/volto/components/manage/Contents/Contents.jsx
@@ -1,0 +1,2097 @@
+/**
+ * CUSTOMIZATIONS:
+ * - Print error from request when clipboardRequest has error.
+ * - on copy, delete, paste, rename, workflow operation, check affectedItems to display a message if number is grather than config.settings?.content_op_max_affected_items (default=300).
+ * - added aria-live to Contents component with polite value.
+ * - added aria-controls and aria-label to the search input
+ * - wrapped the search results in a new <div> with id="contents-table-wrapper"
+ */
+/**
+ * Contents component.
+ * @module components/manage/Contents/Contents
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { Portal } from 'react-portal';
+import { Link } from 'react-router-dom';
+import {
+  Button,
+  Container as SemanticContainer,
+  Divider,
+  Dropdown,
+  Menu,
+  Input,
+  Segment,
+  Table,
+  Loader,
+  Dimmer,
+} from 'semantic-ui-react';
+import {
+  concat,
+  filter,
+  find,
+  indexOf,
+  keys,
+  map,
+  mapValues,
+  pull,
+} from 'lodash';
+import move from 'lodash-move';
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+import { asyncConnect } from '@plone/volto/helpers';
+
+import {
+  searchContent,
+  resetSearchContent,
+  cut,
+  copy,
+  copyContent,
+  deleteContent,
+  listActions,
+  moveContent,
+  orderContent,
+  sortContent,
+  updateColumnsContent,
+  getContent,
+} from '@plone/volto/actions';
+import Indexes, { defaultIndexes } from '@plone/volto/constants/Indexes';
+import {
+  ContentsBreadcrumbs,
+  ContentsIndexHeader,
+  ContentsItem,
+  // ContentsRenameModal,
+  ContentsUploadModal,
+  // ContentsWorkflowModal,
+  ContentsTagsModal,
+  ContentsPropertiesModal,
+  Pagination,
+  Popup,
+  Toolbar,
+  Toast,
+  Icon,
+  Unauthorized,
+} from '@plone/volto/components';
+//import ContentsDeleteModal from '@plone/volto/components/manage/Contents/ContentsDeleteModal';
+//this is custom
+import ContentsDeleteModal from 'design-comuni-plone-theme/components/manage/Contents/ContentsDeleteModal';
+//this is custom
+import ContentsPasteModal from 'design-comuni-plone-theme/components/manage/Contents/ContentsPasteModal';
+//this is custom
+import ContentsRenameModal from 'design-comuni-plone-theme/components/manage/Contents/ContentsRenameModal';
+//this is custom
+import ContentsWorkflowModal from 'design-comuni-plone-theme/components/manage/Contents/ContentsWorkflowModal';
+//this is custom
+import ContentsAffectedItemsOnCopyModal from 'design-comuni-plone-theme/components/manage/Contents/ContentsAffectedItemsOnCopyModal';
+
+import { Helmet, getBaseUrl } from '@plone/volto/helpers';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import config from '@plone/volto/registry';
+
+import backSVG from '@plone/volto/icons/back.svg';
+import cutSVG from '@plone/volto/icons/cut.svg';
+import deleteSVG from '@plone/volto/icons/delete.svg';
+import copySVG from '@plone/volto/icons/copy.svg';
+import tagSVG from '@plone/volto/icons/tag.svg';
+import renameSVG from '@plone/volto/icons/rename.svg';
+import semaphoreSVG from '@plone/volto/icons/semaphore.svg';
+import uploadSVG from '@plone/volto/icons/upload.svg';
+import propertiesSVG from '@plone/volto/icons/properties.svg';
+import pasteSVG from '@plone/volto/icons/paste.svg';
+import zoomSVG from '@plone/volto/icons/zoom.svg';
+import checkboxUncheckedSVG from '@plone/volto/icons/checkbox-unchecked.svg';
+import checkboxCheckedSVG from '@plone/volto/icons/checkbox-checked.svg';
+import checkboxIndeterminateSVG from '@plone/volto/icons/checkbox-indeterminate.svg';
+import configurationSVG from '@plone/volto/icons/configuration-app.svg';
+import sortDownSVG from '@plone/volto/icons/sort-down.svg';
+import sortUpSVG from '@plone/volto/icons/sort-up.svg';
+import downKeySVG from '@plone/volto/icons/down-key.svg';
+import moreSVG from '@plone/volto/icons/more.svg';
+import clearSVG from '@plone/volto/icons/clear.svg';
+
+const MAX_AFFECTED_ITEMS = 300;
+
+const messages = defineMessages({
+  back: {
+    id: 'Back',
+    defaultMessage: 'Back',
+  },
+  contents: {
+    id: 'Contents',
+    defaultMessage: 'Contents',
+  },
+  copy: {
+    id: 'Copy',
+    defaultMessage: 'Copy',
+  },
+  cut: {
+    id: 'Cut',
+    defaultMessage: 'Cut',
+  },
+  error: {
+    id: "You can't paste this content here",
+    defaultMessage: "You can't paste this content here",
+  },
+  delete: {
+    id: 'Delete',
+    defaultMessage: 'Delete',
+  },
+  deleteError: {
+    id: 'The item could not be deleted.',
+    defaultMessage: 'The item could not be deleted.',
+  },
+  loading: {
+    id: 'loading',
+    defaultMessage: 'Loading',
+  },
+  home: {
+    id: 'Home',
+    defaultMessage: 'Home',
+  },
+  filter: {
+    id: 'Filter…',
+    defaultMessage: 'Filter…',
+  },
+  messageCopied: {
+    id: 'Item(s) copied.',
+    defaultMessage: 'Item(s) copied.',
+  },
+  messageCut: {
+    id: 'Item(s) cut.',
+    defaultMessage: 'Item(s) cut.',
+  },
+  messageUpdate: {
+    id: 'Item(s) has been updated.',
+    defaultMessage: 'Item(s) has been updated.',
+  },
+  messageReorder: {
+    id: 'Item succesfully moved.',
+    defaultMessage: 'Item successfully moved.',
+  },
+  messagePasted: {
+    id: 'Item(s) pasted.',
+    defaultMessage: 'Item(s) pasted.',
+  },
+  messageWorkflowUpdate: {
+    id: 'Item(s) state has been updated.',
+    defaultMessage: 'Item(s) state has been updated.',
+  },
+  paste: {
+    id: 'Paste',
+    defaultMessage: 'Paste',
+  },
+  properties: {
+    id: 'Properties',
+    defaultMessage: 'Properties',
+  },
+  rearrangeBy: {
+    id: 'Rearrange items by…',
+    defaultMessage: 'Rearrange items by…',
+  },
+  rename: {
+    id: 'Rename',
+    defaultMessage: 'Rename',
+  },
+  select: {
+    id: 'Select…',
+    defaultMessage: 'Select…',
+  },
+  selected: {
+    id: '{count} selected',
+    defaultMessage: '{count} selected',
+  },
+  selectColumns: {
+    id: 'Select columns to show',
+    defaultMessage: 'Select columns to show',
+  },
+  sort: {
+    id: 'sort',
+    defaultMessage: 'sort',
+  },
+  state: {
+    id: 'State',
+    defaultMessage: 'State',
+  },
+  tags: {
+    id: 'Tags',
+    defaultMessage: 'Tags',
+  },
+  upload: {
+    id: 'Upload',
+    defaultMessage: 'Upload',
+  },
+  success: {
+    id: 'Success',
+    defaultMessage: 'Success',
+  },
+  publicationDate: {
+    id: 'Publication date',
+    defaultMessage: 'Publication date',
+  },
+  createdOn: {
+    id: 'Created on',
+    defaultMessage: 'Created on',
+  },
+  expirationDate: {
+    id: 'Expiration date',
+    defaultMessage: 'Expiration date',
+  },
+  id: {
+    id: 'ID',
+    defaultMessage: 'ID',
+  },
+  uid: {
+    id: 'UID',
+    defaultMessage: 'UID',
+  },
+  reviewState: {
+    id: 'Review state',
+    defaultMessage: 'Review state',
+  },
+  folder: {
+    id: 'Folder',
+    defaultMessage: 'Folder',
+  },
+  excludedFromNavigation: {
+    id: 'Excluded from navigation',
+    defaultMessage: 'Excluded from navigation',
+  },
+  objectSize: {
+    id: 'Object Size',
+    defaultMessage: 'Object Size',
+  },
+  lastCommentedDate: {
+    id: 'Last comment date',
+    defaultMessage: 'Last comment date',
+  },
+  totalComments: {
+    id: 'Total comments',
+    defaultMessage: 'Total comments',
+  },
+  creator: {
+    id: 'Creator',
+    defaultMessage: 'Creator',
+  },
+  endDate: {
+    id: 'End Date',
+    defaultMessage: 'End Date',
+  },
+  startDate: {
+    id: 'Start Date',
+    defaultMessage: 'Start Date',
+  },
+  all: {
+    id: 'All',
+    defaultMessage: 'All',
+  },
+  numberOfResults: {
+    id: 'Number of results',
+    defaultMessage: 'Number of results',
+  },
+});
+
+/**
+ * Contents class.
+ * @class Contents
+ * @extends Component
+ */
+class Contents extends Component {
+  /**
+   * Property types.
+   * @property {Object} propTypes Property types.
+   * @static
+   */
+  static propTypes = {
+    action: PropTypes.string,
+    source: PropTypes.arrayOf(PropTypes.string),
+    searchContent: PropTypes.func.isRequired,
+    resetSearchContent: PropTypes.func,
+    cut: PropTypes.func.isRequired,
+    copy: PropTypes.func.isRequired,
+    copyContent: PropTypes.func.isRequired,
+    deleteContent: PropTypes.func.isRequired,
+    moveContent: PropTypes.func.isRequired,
+    orderContent: PropTypes.func.isRequired,
+    sortContent: PropTypes.func.isRequired,
+    updateColumnsContent: PropTypes.func.isRequired,
+    clipboardRequest: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
+    deleteRequest: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
+    updateRequest: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
+    searchRequest: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        '@id': PropTypes.string,
+        '@type': PropTypes.string,
+        title: PropTypes.string,
+        description: PropTypes.string,
+      }),
+    ),
+    breadcrumbs: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ).isRequired,
+    total: PropTypes.number.isRequired,
+    pathname: PropTypes.string.isRequired,
+  };
+
+  /**
+   * Default properties.
+   * @property {Object} defaultProps Default properties.
+   * @static
+   */
+  static defaultProps = {
+    items: [],
+    action: null,
+    source: null,
+    index: {
+      order: keys(Indexes),
+      values: mapValues(Indexes, (value, key) => ({
+        ...value,
+        selected: indexOf(defaultIndexes, key) !== -1,
+      })),
+      selectedCount: defaultIndexes.length + 1,
+    },
+  };
+
+  /**
+   * Constructor
+   * @method constructor
+   * @param {Object} props Component properties
+   * @constructs ContentsComponent
+   */
+  constructor(props) {
+    super(props);
+    this.onDeselect = this.onDeselect.bind(this);
+    this.onSelect = this.onSelect.bind(this);
+    this.onSelectAll = this.onSelectAll.bind(this);
+    this.onSelectIndex = this.onSelectIndex.bind(this);
+    this.onSelectNone = this.onSelectNone.bind(this);
+    this.onDeleteOk = this.onDeleteOk.bind(this);
+    this.onDeleteCancel = this.onDeleteCancel.bind(this);
+    this.onUploadOk = this.onUploadOk.bind(this);
+    this.onUploadCancel = this.onUploadCancel.bind(this);
+    this.onRenameOk = this.onRenameOk.bind(this);
+    this.onRenameCancel = this.onRenameCancel.bind(this);
+    this.onTagsOk = this.onTagsOk.bind(this);
+    this.onTagsCancel = this.onTagsCancel.bind(this);
+    this.onPropertiesOk = this.onPropertiesOk.bind(this);
+    this.onPropertiesCancel = this.onPropertiesCancel.bind(this);
+    this.onWorkflowOk = this.onWorkflowOk.bind(this);
+    this.onWorkflowCancel = this.onWorkflowCancel.bind(this);
+    this.onChangeFilter = this.onChangeFilter.bind(this);
+    this.onChangePage = this.onChangePage.bind(this);
+    this.onChangePageSize = this.onChangePageSize.bind(this);
+    this.onOrderIndex = this.onOrderIndex.bind(this);
+    this.onOrderItem = this.onOrderItem.bind(this);
+    this.onSortItems = this.onSortItems.bind(this);
+    this.onMoveToTop = this.onMoveToTop.bind(this);
+    this.onChangeSelected = this.onChangeSelected.bind(this);
+    this.onMoveToBottom = this.onMoveToBottom.bind(this);
+    this.onPasteOk = this.onPasteOk.bind(this);
+    this.onPasteCancel = this.onPasteCancel.bind(this);
+    this.cut = this.cut.bind(this);
+    this.copy = this.copy.bind(this);
+    this.delete = this.delete.bind(this);
+    this.upload = this.upload.bind(this);
+    this.rename = this.rename.bind(this);
+    this.tags = this.tags.bind(this);
+    this.properties = this.properties.bind(this);
+    this.workflow = this.workflow.bind(this);
+    this.paste = this.paste.bind(this);
+    this.fetchContents = this.fetchContents.bind(this);
+    this.orderTimeout = null;
+    this.max_affected_items =
+      config.settings?.content_op_max_affected_items ?? MAX_AFFECTED_ITEMS;
+
+    this.state = {
+      selected: [],
+      showDelete: false,
+      showUpload: false,
+      showRename: false,
+      showPaste: false,
+      showTags: false,
+      showProperties: false,
+      showWorkflow: false,
+      itemsToDelete: [],
+      itemsToPast: [],
+      items: this.props.items,
+      filter: '',
+      currentPage: 0,
+      pageSize: 50,
+      index: this.props.index || {
+        order: keys(Indexes),
+        values: mapValues(Indexes, (value, key) => ({
+          ...value,
+          selected: indexOf(defaultIndexes, key) !== -1,
+        })),
+        selectedCount: defaultIndexes.length + 1,
+      },
+      sort_on: this.props.sort?.on || 'getObjPositionInParent',
+      sort_order: this.props.sort?.order || 'ascending',
+      isClient: false,
+      showModalAffectedItems: false,
+    };
+    this.filterTimeout = null;
+  }
+
+  /**
+   * Component did mount
+   * @method componentDidMount
+   * @returns {undefined}
+   */
+  componentDidMount() {
+    this.fetchContents();
+    this.setState({ isClient: true });
+  }
+
+  /**
+   * Component will receive props
+   * @method componentWillReceiveProps
+   * @param {Object} nextProps Next properties
+   * @returns {undefined}
+   */
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      (this.props.clipboardRequest.loading &&
+        nextProps.clipboardRequest.loaded) ||
+      (this.props.deleteRequest.loading && nextProps.deleteRequest.loaded) ||
+      (this.props.updateRequest.loading && nextProps.updateRequest.loaded)
+    ) {
+      this.fetchContents(nextProps.pathname);
+    }
+    if (this.props.updateRequest.loading && nextProps.updateRequest.loaded) {
+      this.props.toastify.toast.success(
+        <Toast
+          success
+          title={this.props.intl.formatMessage(messages.success)}
+          content={this.props.intl.formatMessage(messages.messageUpdate)}
+        />,
+      );
+    }
+    if (this.props.pathname !== nextProps.pathname) {
+      // Refetching content to sync the current object in the toolbar
+      this.props.getContent(getBaseUrl(nextProps.pathname));
+      this.setState(
+        {
+          currentPage: 0,
+        },
+        () =>
+          this.setState({ filter: '' }, () =>
+            this.fetchContents(nextProps.pathname),
+          ),
+      );
+    }
+    if (this.props.searchRequest.loading && nextProps.searchRequest.loaded) {
+      this.setState({
+        items: nextProps.items,
+      });
+    }
+    if (
+      this.props.clipboardRequest.loading &&
+      nextProps.clipboardRequest.error
+    ) {
+      //customization: print error message in toast
+      const msgBody =
+        nextProps.clipboardRequest.error?.response?.body?.message ||
+        this.props.intl.formatMessage(messages.error);
+      this.props.toastify.toast.error(
+        <Toast
+          error
+          title={this.props.intl.formatMessage(messages.error)}
+          content={msgBody}
+        />,
+      );
+    }
+
+    if (
+      this.props.clipboardRequest.loading &&
+      nextProps.clipboardRequest.loaded
+    ) {
+      this.props.toastify.toast.success(
+        <Toast
+          success
+          title={this.props.intl.formatMessage(messages.success)}
+          content={this.props.intl.formatMessage(messages.messagePasted)}
+        />,
+      );
+    }
+
+    if (this.props.deleteRequest.loading && nextProps.deleteRequest.error) {
+      this.props.toastify.toast.error(
+        <Toast
+          error
+          title={this.props.intl.formatMessage(messages.deleteError)}
+          content={this.props.intl.formatMessage(messages.deleteError)}
+        />,
+      );
+    }
+
+    if (this.props.orderRequest.loading && nextProps.orderRequest.loaded) {
+      this.props.toastify.toast.success(
+        <Toast
+          success
+          title={this.props.intl.formatMessage(messages.success)}
+          content={this.props.intl.formatMessage(messages.messageReorder)}
+        />,
+      );
+    }
+
+    if (
+      nextProps.affected_items_copy?.total > this.max_affected_items &&
+      !nextProps.affected_items_copy?.loading
+    ) {
+      this.setState({ showModalAffectedItems: true });
+    }
+  }
+
+  getCountAffectedItems = (subrequest = 'affected_items', items) => {
+    const _items = items ?? this.state.selected;
+    this.props.searchContent(
+      getBaseUrl(this.props.pathname),
+      {
+        b_size: 1,
+        'path.query': _items,
+      },
+      subrequest,
+    );
+  };
+
+  clearAffectedItems = () => {
+    this.props.resetSearchContent('affected_items');
+    this.props.resetSearchContent('affected_items_copy');
+  };
+  /**
+   * On deselect handler
+   * @method onDeselect
+   * @param {object} event Event object
+   * @param {string} value Value
+   * @returns {undefined}
+   */
+  onDeselect(event, { value }) {
+    this.setState({
+      selected: pull(this.state.selected, value),
+    });
+  }
+
+  /**
+   * On select handler
+   * @method onSelect
+   * @param {object} event Event object
+   * @returns {undefined}
+   */
+  onSelect(event, id) {
+    if (indexOf(this.state.selected, id) === -1) {
+      this.setState({
+        selected: concat(this.state.selected, id),
+      });
+    } else {
+      this.setState({
+        selected: pull(this.state.selected, id),
+      });
+    }
+  }
+
+  /**
+   * On select all handler
+   * @method onSelectAll
+   * @returns {undefined}
+   */
+  onSelectAll() {
+    this.setState({
+      selected: map(this.state.items, (item) => item['@id']),
+    });
+  }
+
+  /**
+   * On select none handler
+   * @method onSelectNone
+   * @returns {undefined}
+   */
+  onSelectNone() {
+    this.setState({
+      selected: [],
+    });
+  }
+
+  /**
+   * On select index
+   * @method onSelectIndex
+   * @param {object} event Event object.
+   * @param {string} value Index value.
+   * @returns {undefined}
+   */
+  onSelectIndex(event, { value }) {
+    let newIndex = {
+      ...this.state.index,
+      selectedCount:
+        this.state.index.selectedCount +
+        (this.state.index.values[value].selected ? -1 : 1),
+      values: mapValues(this.state.index.values, (indexValue, indexKey) => ({
+        ...indexValue,
+        selected:
+          indexKey === value ? !indexValue.selected : indexValue.selected,
+      })),
+    };
+    this.setState({
+      index: newIndex,
+    });
+    this.props.updateColumnsContent(getBaseUrl(this.props.pathname), newIndex);
+  }
+
+  /**
+   * On change filter
+   * @method onChangeFilter
+   * @param {object} event Event object.
+   * @param {string} value Filter value.
+   * @returns {undefined}
+   */
+  onChangeFilter(event, { value }) {
+    const self = this;
+    clearTimeout(self.filterTimeout);
+    this.setState(
+      {
+        filter: value,
+      },
+      () => {
+        self.filterTimeout = setTimeout(() => {
+          self.fetchContents();
+        }, 200);
+      },
+    );
+  }
+
+  /**
+   * On change selected values (Filter)
+   * @method onChangeSelected
+   * @param {object} event Event object.
+   * @param {string} value Filter value.
+   * @returns {undefined}
+   */
+  onChangeSelected(event, { value }) {
+    event.stopPropagation();
+    const { items, selected } = this.state;
+
+    const filteredItems = filter(selected, (selectedItem) =>
+      find(items, (item) => item['@id'] === selectedItem)
+        .title.toLowerCase()
+        .includes(value.toLowerCase()),
+    );
+
+    this.setState({
+      filteredItems,
+      selectedMenuFilter: value,
+    });
+  }
+
+  /**
+   * On change page
+   * @method onChangePage
+   * @param {object} event Event object.
+   * @param {string} value Page value.
+   * @returns {undefined}
+   */
+  onChangePage(event, { value }) {
+    this.setState(
+      {
+        currentPage: value,
+      },
+      () => this.fetchContents(),
+    );
+  }
+
+  /**
+   * On change page size
+   * @method onChangePageSize
+   * @param {object} event Event object.
+   * @param {string} value Page size value.
+   * @returns {undefined}
+   */
+  onChangePageSize(event, { value }) {
+    this.setState(
+      {
+        pageSize: value,
+        currentPage: 0,
+      },
+      () => this.fetchContents(),
+    );
+  }
+
+  /**
+   * On order index
+   * @method onOrderIndex
+   * @param {number} index Index
+   * @param {number} delta Delta
+   * @returns {undefined}
+   */
+  onOrderIndex(index, delta) {
+    this.setState({
+      index: {
+        ...this.state.index,
+        order: move(this.state.index.order, index, index + delta),
+      },
+    });
+    this.props.updateColumnsContent(
+      getBaseUrl(this.props.pathname),
+      this.state.index,
+    );
+  }
+
+  /**
+   * On order item
+   * @method onOrderItem
+   * @param {string} id Item id
+   * @param {number} itemIndex Item index
+   * @param {number} delta Delta
+   * @returns {undefined}
+   */
+  onOrderItem(id, itemIndex, delta, backend) {
+    if (backend) {
+      this.props.orderContent(
+        getBaseUrl(this.props.pathname),
+        id.replace(/^.*\//, ''),
+        delta,
+      );
+    } else {
+      this.setState({
+        items: move(this.state.items, itemIndex, itemIndex + delta),
+      });
+    }
+  }
+
+  /**
+   * On sort items
+   * @method onSortItems
+   * @param {object} event Event object
+   * @param {string} value Item index
+   * @returns {undefined}
+   */
+  onSortItems(event, { value }) {
+    const values = value.split('|');
+    this.setState({
+      sort_on: values[0],
+      sort_order: values[1],
+    });
+    this.props.sortContent(
+      getBaseUrl(this.props.pathname),
+      values[0],
+      values[1],
+    );
+  }
+
+  /**
+   * On move to top
+   * @method onMoveToTop
+   * @param {object} event Event object
+   * @param {string} value Item index
+   * @returns {undefined}
+   */
+  onMoveToTop(event, { value }) {
+    const id = this.state.items[value]['@id'];
+    this.props
+      .orderContent(
+        getBaseUrl(this.props.pathname),
+        id.replace(/^.*\//, ''),
+        'top',
+      )
+      .then(() => {
+        this.setState(
+          {
+            currentPage: 0,
+          },
+          () => this.fetchContents(),
+        );
+      });
+  }
+
+  /**
+   * On move to bottom
+   * @method onMoveToBottom
+   * @param {object} event Event object
+   * @param {string} value Item index
+   * @returns {undefined}
+   */
+  onMoveToBottom(event, { value }) {
+    const id = this.state.items[value]['@id'];
+    this.props
+      .orderContent(
+        getBaseUrl(this.props.pathname),
+        id.replace(/^.*\//, ''),
+        'bottom',
+      )
+      .then(() => {
+        this.setState(
+          {
+            currentPage: 0,
+          },
+          () => this.fetchContents(),
+        );
+      });
+  }
+
+  /**
+   * On delete ok
+   * @method onDeleteOk
+   * @returns {undefined}
+   */
+  onDeleteOk() {
+    this.props.deleteContent(this.state.itemsToDelete);
+    this.setState({
+      showDelete: false,
+      itemsToDelete: [],
+      selected: [],
+    });
+  }
+
+  /**
+   * On delete cancel
+   * @method onDeleteCancel
+   * @returns {undefined}
+   */
+  onDeleteCancel() {
+    this.setState({
+      showDelete: false,
+      itemsToDelete: [],
+    });
+  }
+
+  /**
+   * On upload ok
+   * @method onUploadOk
+   * @returns {undefined}
+   */
+  onUploadOk() {
+    this.fetchContents();
+    this.setState({
+      showUpload: false,
+    });
+  }
+
+  /**
+   * On upload cancel
+   * @method onUploadCancel
+   * @returns {undefined}
+   */
+  onUploadCancel() {
+    this.setState({
+      showUpload: false,
+    });
+  }
+
+  /**
+   * On rename ok
+   * @method onRenameOk
+   * @returns {undefined}
+   */
+  onRenameOk() {
+    this.setState({
+      showRename: false,
+      selected: [],
+    });
+    this.clearAffectedItems();
+  }
+
+  /**
+   * On rename cancel
+   * @method onRenameCancel
+   * @returns {undefined}
+   */
+  onRenameCancel() {
+    this.setState({
+      showRename: false,
+    });
+    this.clearAffectedItems();
+  }
+
+  /**
+   * On tags ok
+   * @method onTagsOk
+   * @returns {undefined}
+   */
+  onTagsOk() {
+    this.setState({
+      showTags: false,
+      selected: [],
+    });
+  }
+
+  /**
+   * On tags cancel
+   * @method onTagsCancel
+   * @returns {undefined}
+   */
+  onTagsCancel() {
+    this.setState({
+      showTags: false,
+    });
+  }
+
+  /**
+   * On properties ok
+   * @method onPropertiesOk
+   * @returns {undefined}
+   */
+  onPropertiesOk() {
+    this.setState({
+      showProperties: false,
+      selected: [],
+    });
+  }
+
+  /**
+   * On properties cancel
+   * @method onPropertiesCancel
+   * @returns {undefined}
+   */
+  onPropertiesCancel() {
+    this.setState({
+      showProperties: false,
+    });
+  }
+
+  /**
+   * On workflow ok
+   * @method onWorkflowOk
+   * @returns {undefined}
+   */
+  onWorkflowOk() {
+    this.fetchContents();
+    this.setState({
+      showWorkflow: false,
+      selected: [],
+    });
+    this.clearAffectedItems();
+    this.props.toastify.toast.success(
+      <Toast
+        success
+        title={this.props.intl.formatMessage(messages.success)}
+        content={this.props.intl.formatMessage(messages.messageWorkflowUpdate)}
+      />,
+    );
+  }
+
+  /**
+   * On workflow cancel
+   * @method onWorkflowCancel
+   * @returns {undefined}
+   */
+  onWorkflowCancel() {
+    this.setState({
+      showWorkflow: false,
+    });
+    this.clearAffectedItems();
+  }
+
+  /**
+   * Get field by id
+   * @method getFieldById
+   * @param {string} id Id of object
+   * @param {string} field Field of object
+   * @returns {string} Field of object
+   */
+  getFieldById(id, field) {
+    const item = find(this.state.items, { '@id': id });
+    return item ? item[field] : '';
+  }
+
+  /**
+   * Fetch contents handler
+   * @method fetchContents
+   * @param {string} pathname Pathname to fetch contents.
+   * @returns {undefined}
+   */
+  fetchContents(pathname) {
+    if (this.state.pageSize === this.props.intl.formatMessage(messages.all)) {
+      //'All'
+      this.props.searchContent(getBaseUrl(pathname || this.props.pathname), {
+        'path.depth': 1,
+        sort_on: this.state.sort_on,
+        sort_order: this.state.sort_order,
+        metadata_fields: '_all',
+        b_size: 100000000,
+        show_inactive: true,
+        ...(this.state.filter && { SearchableText: `${this.state.filter}*` }),
+      });
+    } else {
+      this.props.searchContent(getBaseUrl(pathname || this.props.pathname), {
+        'path.depth': 1,
+        sort_on: this.state.sort_on,
+        sort_order: this.state.sort_order,
+        metadata_fields: '_all',
+        ...(this.state.filter && { SearchableText: `${this.state.filter}*` }),
+        b_size: this.state.pageSize,
+        b_start: this.state.currentPage * this.state.pageSize,
+        show_inactive: true,
+      });
+    }
+  }
+
+  /**
+   * Cut handler
+   * @method cut
+   * @param {Object} event Event object.
+   * @param {string} value Value of the event.
+   * @returns {undefined}
+   */
+  //Questo è l'originale di volto:
+  cut(event, { value }) {
+    this.props.cut(value ? [value] : this.state.selected);
+    this.onSelectNone();
+    this.props.toastify.toast.success(
+      <Toast
+        success
+        title={this.props.intl.formatMessage(messages.success)}
+        content={this.props.intl.formatMessage(messages.messageCut)}
+      />,
+    );
+  }
+
+  /**
+   * Copy handler
+   * @method copy
+   * @param {Object} event Event object.
+   * @param {string} value Value of the event.
+   * @returns {undefined}
+   */
+  copy(event, { value }) {
+    this.props.copy(value ? [value] : this.state.selected);
+    this.onSelectNone();
+    this.props.toastify.toast.success(
+      <Toast
+        success
+        title={this.props.intl.formatMessage(messages.success)}
+        content={this.props.intl.formatMessage(messages.messageCopied)}
+      />,
+    );
+  }
+
+  /**
+   * Delete handler
+   * @method delete
+   * @param {Object} event Event object.
+   * @param {string} value Value of the event.
+   * @returns {undefined}
+   */
+  delete(event, { value }) {
+    this.setState({
+      showDelete: true,
+      itemsToDelete: value ? [value] : this.state.selected,
+    });
+  }
+
+  /**
+   * Upload handler
+   * @method upload
+   * @returns {undefined}
+   */
+  upload() {
+    this.setState({
+      showUpload: true,
+    });
+  }
+
+  /**
+   * Rename handler
+   * @method rename
+   * @returns {undefined}
+   */
+  rename() {
+    this.setState({
+      showRename: true,
+    });
+    this.getCountAffectedItems();
+  }
+
+  /**
+   * Tags handler
+   * @method tags
+   * @returns {undefined}
+   */
+  tags() {
+    this.setState({
+      showTags: true,
+    });
+  }
+
+  /**
+   * Properties handler
+   * @method properties
+   * @returns {undefined}
+   */
+  properties() {
+    this.setState({
+      showProperties: true,
+    });
+  }
+
+  /**
+   * Workflow handler
+   * @method workflow
+   * @returns {undefined}
+   */
+  workflow() {
+    this.setState({
+      showWorkflow: true,
+    });
+    this.getCountAffectedItems();
+  }
+
+  /**
+   * Paste handler
+   * @method paste
+   * @returns {undefined}
+   */
+  paste() {
+    this.getCountAffectedItems('affected_items_paste', this.props.source);
+    this.setState({
+      showPaste: true,
+    });
+    // spostato nella onPasteOk
+    // if (this.props.action === 'copy') {
+    //   this.props.copyContent(
+    //     this.props.source,
+    //     getBaseUrl(this.props.pathname),
+    //   );
+    // }
+    // if (this.props.action === 'cut') {
+    //   this.props.moveContent(
+    //     this.props.source,
+    //     getBaseUrl(this.props.pathname),
+    //   );
+    // }
+  }
+
+  onPasteOk() {
+    if (this.props.action === 'copy') {
+      this.props.copyContent(
+        this.props.source,
+        getBaseUrl(this.props.pathname),
+      );
+    }
+    if (this.props.action === 'cut') {
+      this.props.moveContent(
+        this.props.source,
+        getBaseUrl(this.props.pathname),
+      );
+    }
+    this.onSelectNone();
+    this.setState({
+      showPaste: false,
+    });
+  }
+
+  onPasteCancel() {
+    this.setState({
+      showPaste: false,
+    });
+    this.clearAffectedItems();
+  }
+
+  /**
+   * Render method.
+   * @method render
+   * @returns {string} Markup for the component.
+   */
+  render() {
+    const selected = this.state.selected.length > 0;
+    const filteredItems = this.state.filteredItems || this.state.selected;
+    const path = getBaseUrl(this.props.pathname);
+    const folderContentsAction = find(this.props.objectActions, {
+      id: 'folderContents',
+    });
+    const loading =
+      (this.props.clipboardRequest?.loading &&
+        !this.props.clipboardRequest?.error) ||
+      (this.props.deleteRequest?.loading && !this.props.deleteRequest?.error) ||
+      (this.props.updateRequest?.loading && !this.props.updateRequest?.error) ||
+      (this.props.orderRequest?.loading && !this.props.orderRequest?.error) ||
+      (this.props.searchRequest?.loading && !this.props.searchRequest?.error);
+
+    const Container =
+      config.getComponent({ name: 'Container' }).component || SemanticContainer;
+
+    return this.props.token && this.props.objectActions?.length > 0 ? (
+      <>
+        {folderContentsAction ? (
+          <Container
+            id="page-contents"
+            className="folder-contents"
+            aria-live="polite"
+          >
+            <Dimmer.Dimmable as="div" blurring dimmed={loading}>
+              <Dimmer active={loading} inverted>
+                <Loader indeterminate size="massive">
+                  {this.props.intl.formatMessage(messages.loading)}
+                </Loader>
+              </Dimmer>
+
+              <Helmet
+                title={this.props.intl.formatMessage(messages.contents)}
+              />
+              <div className="container">
+                <article id="content">
+                  <ContentsDeleteModal
+                    open={this.state.showDelete}
+                    onCancel={this.onDeleteCancel}
+                    onOk={this.onDeleteOk}
+                    items={this.state.items}
+                    itemsToDelete={this.state.itemsToDelete}
+                    limit={this.max_affected_items}
+                  />
+                  <ContentsPasteModal
+                    open={this.state.showPaste}
+                    onCancel={this.onPasteCancel}
+                    onOk={this.onPasteOk}
+                    items={this.props.source}
+                    limit={this.max_affected_items}
+                  />
+                  <ContentsUploadModal
+                    open={this.state.showUpload}
+                    onCancel={this.onUploadCancel}
+                    onOk={this.onUploadOk}
+                    pathname={getBaseUrl(this.props.pathname)}
+                  />
+                  <ContentsRenameModal
+                    open={this.state.showRename}
+                    onCancel={this.onRenameCancel}
+                    onOk={this.onRenameOk}
+                    items={map(this.state.selected, (item) => ({
+                      url: item,
+                      title: this.getFieldById(item, 'title'),
+                      id: this.getFieldById(item, 'id'),
+                    }))}
+                    limit={this.max_affected_items}
+                  />
+                  <ContentsTagsModal
+                    open={this.state.showTags}
+                    onCancel={this.onTagsCancel}
+                    onOk={this.onTagsOk}
+                    items={map(this.state.selected, (item) => ({
+                      url: item,
+                      subjects: this.getFieldById(item, 'Subject'),
+                    }))}
+                  />
+                  <ContentsPropertiesModal
+                    open={this.state.showProperties}
+                    onCancel={this.onPropertiesCancel}
+                    onOk={this.onPropertiesOk}
+                    items={this.state.selected}
+                    values={map(this.state.selected, (id) =>
+                      find(this.state.items, { '@id': id }),
+                    ).filter((item) => item)}
+                  />
+                  {this.state.showWorkflow && (
+                    <ContentsWorkflowModal
+                      open={this.state.showWorkflow}
+                      onCancel={this.onWorkflowCancel}
+                      onOk={this.onWorkflowOk}
+                      items={this.state.selected}
+                      limit={this.max_affected_items}
+                    />
+                  )}
+                  <ContentsAffectedItemsOnCopyModal
+                    open={this.state.showModalAffectedItems}
+                    onOk={() => {
+                      this.setState({ showModalAffectedItems: false });
+                      this.clearAffectedItems();
+                    }}
+                    limit={this.max_affected_items}
+                  />
+                  <section id="content-core">
+                    <Segment.Group raised>
+                      <Menu secondary attached className="top-menu">
+                        <Menu.Menu className="top-menu-menu">
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.upload}
+                                className="upload"
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.upload,
+                                )}
+                              >
+                                <Icon
+                                  name={uploadSVG}
+                                  color="#007eb1"
+                                  size="24px"
+                                  className="upload"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.upload,
+                            )}
+                            size="mini"
+                          />
+                        </Menu.Menu>
+                        <Menu.Menu className="top-menu-menu">
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.rename}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.rename,
+                                )}
+                              >
+                                <Icon
+                                  name={renameSVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="rename"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.rename,
+                            )}
+                            size="mini"
+                          />
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.workflow}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.state,
+                                )}
+                              >
+                                <Icon
+                                  name={semaphoreSVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="semaphore"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.state,
+                            )}
+                            size="mini"
+                          />
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.tags}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.tags,
+                                )}
+                              >
+                                <Icon
+                                  name={tagSVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="tag"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.tags,
+                            )}
+                            size="mini"
+                          />
+
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.properties}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.properties,
+                                )}
+                              >
+                                <Icon
+                                  name={propertiesSVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="properties"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.properties,
+                            )}
+                            size="mini"
+                          />
+                        </Menu.Menu>
+                        <Menu.Menu className="top-menu-menu">
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.cut}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.cut,
+                                )}
+                              >
+                                <Icon
+                                  name={cutSVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="cut"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.cut,
+                            )}
+                            size="mini"
+                          />
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.copy}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.copy,
+                                )}
+                              >
+                                <Icon
+                                  name={copySVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="copy"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.copy,
+                            )}
+                            size="mini"
+                          />
+
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.paste}
+                                disabled={!this.props.action}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.paste,
+                                )}
+                              >
+                                <Icon
+                                  name={pasteSVG}
+                                  color={selected ? '#826a6a' : 'grey'}
+                                  size="24px"
+                                  className="paste"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.paste,
+                            )}
+                            size="mini"
+                          />
+
+                          <Popup
+                            trigger={
+                              <Menu.Item
+                                icon
+                                as={Button}
+                                onClick={this.delete}
+                                disabled={!selected}
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.delete,
+                                )}
+                              >
+                                <Icon
+                                  name={deleteSVG}
+                                  color={selected ? '#e40166' : 'grey'}
+                                  size="24px"
+                                  className="delete"
+                                />
+                              </Menu.Item>
+                            }
+                            position="top center"
+                            content={this.props.intl.formatMessage(
+                              messages.delete,
+                            )}
+                            size="mini"
+                          />
+                        </Menu.Menu>
+                        <Menu.Menu
+                          position="right"
+                          className="top-menu-searchbox"
+                        >
+                          <div className="ui right aligned category search item">
+                            <Input
+                              type="text"
+                              transparent
+                              placeholder={this.props.intl.formatMessage(
+                                messages.filter,
+                              )}
+                              size="small"
+                              value={this.state.filter}
+                              onChange={this.onChangeFilter}
+                              aria-controls="contents-table-wrapper"
+                              aria-label={this.props.intl.formatMessage(
+                                messages.filter,
+                              )}
+                            />
+                            {this.state.filter && (
+                              <Button
+                                className="icon icon-container"
+                                onClick={() => {
+                                  this.onChangeFilter('', { value: '' });
+                                }}
+                              >
+                                <Icon
+                                  name={clearSVG}
+                                  size="30px"
+                                  color="#e40166"
+                                />
+                              </Button>
+                            )}
+                            <Icon
+                              name={zoomSVG}
+                              size="30px"
+                              color="#007eb1"
+                              className="zoom"
+                              style={{ flexShrink: '0' }}
+                            />
+                            <div className="results" />
+                          </div>
+                        </Menu.Menu>
+                      </Menu>
+                      <Segment
+                        secondary
+                        attached
+                        className="contents-breadcrumbs"
+                      >
+                        <ContentsBreadcrumbs items={this.props.breadcrumbs} />
+                        <Dropdown
+                          item
+                          upward={false}
+                          icon={
+                            <Icon name={moreSVG} size="24px" color="#826a6a" />
+                          }
+                          className="right floating selectIndex"
+                        >
+                          <Dropdown.Menu className="left">
+                            <Dropdown.Header
+                              content={this.props.intl.formatMessage(
+                                messages.selectColumns,
+                              )}
+                            />
+                            <Dropdown.Menu scrolling>
+                              {map(
+                                filter(
+                                  this.state.index.order,
+                                  (index) => index !== 'sortable_title',
+                                ),
+                                (index) => (
+                                  <Dropdown.Item
+                                    key={index}
+                                    value={index}
+                                    onClick={this.onSelectIndex}
+                                    className="iconAlign"
+                                  >
+                                    {this.state.index.values[index].selected ? (
+                                      <Icon
+                                        name={checkboxCheckedSVG}
+                                        size="24px"
+                                        color="#007eb1"
+                                        className={
+                                          this.state.index.values[index].label
+                                        }
+                                      />
+                                    ) : (
+                                      <Icon
+                                        name={checkboxUncheckedSVG}
+                                        className={
+                                          this.state.index.values[index].label
+                                        }
+                                        size="24px"
+                                      />
+                                    )}
+                                    <span>
+                                      {' '}
+                                      {this.props.intl.formatMessage({
+                                        id: this.state.index.values[index]
+                                          .label,
+                                        defaultMessage:
+                                          this.state.index.values[index].label,
+                                      })}
+                                    </span>
+                                  </Dropdown.Item>
+                                ),
+                              )}
+                            </Dropdown.Menu>
+                          </Dropdown.Menu>
+                        </Dropdown>
+                      </Segment>
+                      <div
+                        id="contents-table-wrapper"
+                        className="contents-table-wrapper"
+                        role="region"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="search-feedback visually-hidden"
+                          role="status"
+                        >
+                          {`${this.props.intl.formatMessage(
+                            messages.numberOfResults,
+                          )}: ${this.props.total || 0}`}
+                        </span>
+                        <Table selectable compact singleLine attached>
+                          <Table.Header>
+                            <Table.Row>
+                              <Table.HeaderCell>
+                                <Popup
+                                  menu={true}
+                                  position="bottom left"
+                                  flowing={true}
+                                  basic={true}
+                                  on="click"
+                                  popper={{
+                                    className: 'dropdown-popup',
+                                  }}
+                                  trigger={
+                                    <Icon
+                                      name={configurationSVG}
+                                      size="24px"
+                                      color="#826a6a"
+                                      className="dropdown-popup-trigger configuration-svg"
+                                    />
+                                  }
+                                >
+                                  <Menu vertical borderless fluid>
+                                    <Menu.Header
+                                      content={this.props.intl.formatMessage(
+                                        messages.rearrangeBy,
+                                      )}
+                                    />
+                                    {map(
+                                      [
+                                        'id',
+                                        'sortable_title',
+                                        'EffectiveDate',
+                                        'CreationDate',
+                                        'ModificationDate',
+                                        'portal_type',
+                                      ],
+                                      (index) => (
+                                        <Dropdown
+                                          key={index}
+                                          item
+                                          simple
+                                          className={`sort_${index} icon-align`}
+                                          icon={
+                                            <Icon
+                                              name={downKeySVG}
+                                              size="24px"
+                                              className="left"
+                                            />
+                                          }
+                                          text={this.props.intl.formatMessage({
+                                            id: Indexes[index].label,
+                                          })}
+                                        >
+                                          <Dropdown.Menu>
+                                            <Dropdown.Item
+                                              onClick={this.onSortItems}
+                                              value={`${Indexes[index].sort_on}|ascending`}
+                                              className={`sort_${Indexes[index].sort_on}_ascending icon-align`}
+                                            >
+                                              <Icon
+                                                name={sortDownSVG}
+                                                size="24px"
+                                              />{' '}
+                                              <FormattedMessage
+                                                id="Ascending"
+                                                defaultMessage="Ascending"
+                                              />
+                                            </Dropdown.Item>
+                                            <Dropdown.Item
+                                              onClick={this.onSortItems}
+                                              value={`${Indexes[index].sort_on}|descending`}
+                                              className={`sort_${Indexes[index].sort_on}_descending icon-align`}
+                                            >
+                                              <Icon
+                                                name={sortUpSVG}
+                                                size="24px"
+                                              />{' '}
+                                              <FormattedMessage
+                                                id="Descending"
+                                                defaultMessage="Descending"
+                                              />
+                                            </Dropdown.Item>
+                                          </Dropdown.Menu>
+                                        </Dropdown>
+                                      ),
+                                    )}
+                                  </Menu>
+                                </Popup>
+                              </Table.HeaderCell>
+                              <Table.HeaderCell>
+                                <Popup
+                                  menu={true}
+                                  position="bottom left"
+                                  flowing={true}
+                                  basic={true}
+                                  on="click"
+                                  popper={{
+                                    className: 'dropdown-popup',
+                                  }}
+                                  trigger={
+                                    <Icon
+                                      name={
+                                        this.state.selected.length === 0
+                                          ? checkboxUncheckedSVG
+                                          : this.state.selected.length ===
+                                              this.state.items.length
+                                            ? checkboxCheckedSVG
+                                            : checkboxIndeterminateSVG
+                                      }
+                                      color={
+                                        this.state.selected.length > 0
+                                          ? '#007eb1'
+                                          : '#826a6a'
+                                      }
+                                      className="dropdown-popup-trigger"
+                                      size="24px"
+                                    />
+                                  }
+                                >
+                                  <Menu vertical borderless fluid>
+                                    <Menu.Header
+                                      content={this.props.intl.formatMessage(
+                                        messages.select,
+                                      )}
+                                    />
+                                    <Menu.Item onClick={this.onSelectAll}>
+                                      <Icon
+                                        name={checkboxCheckedSVG}
+                                        color="#007eb1"
+                                        size="24px"
+                                      />{' '}
+                                      <FormattedMessage
+                                        id="All"
+                                        defaultMessage="All"
+                                      />
+                                    </Menu.Item>
+                                    <Menu.Item onClick={this.onSelectNone}>
+                                      <Icon
+                                        name={checkboxUncheckedSVG}
+                                        size="24px"
+                                      />{' '}
+                                      <FormattedMessage
+                                        id="None"
+                                        defaultMessage="None"
+                                      />
+                                    </Menu.Item>
+                                    <Divider />
+                                    <Menu.Header
+                                      content={this.props.intl.formatMessage(
+                                        messages.selected,
+                                        {
+                                          count: this.state.selected.length,
+                                        },
+                                      )}
+                                    />
+                                    <Input
+                                      icon={<Icon name={zoomSVG} size="24px" />}
+                                      iconPosition="left"
+                                      className="item search"
+                                      placeholder={this.props.intl.formatMessage(
+                                        messages.filter,
+                                      )}
+                                      value={
+                                        this.state.selectedMenuFilter || ''
+                                      }
+                                      onChange={this.onChangeSelected}
+                                      onClick={(e) => {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                      }}
+                                    />
+                                    <Menu.Menu scrolling>
+                                      {map(filteredItems, (item) => (
+                                        <Menu.Item
+                                          key={item}
+                                          value={item}
+                                          onClick={this.onDeselect}
+                                        >
+                                          <Icon
+                                            name={deleteSVG}
+                                            color="#e40166"
+                                            size="24px"
+                                          />{' '}
+                                          {this.getFieldById(item, 'title')}
+                                        </Menu.Item>
+                                      ))}
+                                    </Menu.Menu>
+                                  </Menu>
+                                </Popup>
+                              </Table.HeaderCell>
+                              <Table.HeaderCell
+                                width={Math.ceil(
+                                  16 / this.state.index.selectedCount,
+                                )}
+                              >
+                                <FormattedMessage
+                                  id="Title"
+                                  defaultMessage="Title"
+                                />
+                              </Table.HeaderCell>
+                              {map(
+                                this.state.index.order,
+                                (index, order) =>
+                                  this.state.index.values[index].selected && (
+                                    <ContentsIndexHeader
+                                      key={index}
+                                      width={Math.ceil(
+                                        16 / this.state.index.selectedCount,
+                                      )}
+                                      label={
+                                        this.state.index.values[index].label
+                                      }
+                                      order={order}
+                                      onOrderIndex={this.onOrderIndex}
+                                    />
+                                  ),
+                              )}
+                              <Table.HeaderCell textAlign="right">
+                                <FormattedMessage
+                                  id="Actions"
+                                  defaultMessage="Actions"
+                                />
+                              </Table.HeaderCell>
+                            </Table.Row>
+                          </Table.Header>
+                          <Table.Body>
+                            {this.state.items.map((item, order) => (
+                              <ContentsItem
+                                key={item['@id']}
+                                item={item}
+                                order={order}
+                                selected={
+                                  indexOf(this.state.selected, item['@id']) !==
+                                  -1
+                                }
+                                onClick={this.onSelect}
+                                indexes={filter(
+                                  map(this.state.index.order, (index) => ({
+                                    id: index,
+                                    type: this.state.index.values[index].type,
+                                  })),
+                                  (index) =>
+                                    this.state.index.values[index.id].selected,
+                                )}
+                                onCut={this.cut}
+                                onCopy={this.copy}
+                                onDelete={this.delete}
+                                onOrderItem={this.onOrderItem}
+                                onMoveToTop={this.onMoveToTop}
+                                onMoveToBottom={this.onMoveToBottom}
+                              />
+                            ))}
+                          </Table.Body>
+                        </Table>
+                      </div>
+
+                      <div className="contents-pagination">
+                        <Pagination
+                          current={this.state.currentPage}
+                          total={Math.ceil(
+                            this.props.total / this.state.pageSize,
+                          )}
+                          pageSize={this.state.pageSize}
+                          pageSizes={[
+                            50,
+                            this.props.intl.formatMessage(messages.all),
+                          ]}
+                          onChangePage={this.onChangePage}
+                          onChangePageSize={this.onChangePageSize}
+                        />
+                      </div>
+                    </Segment.Group>
+                  </section>
+                </article>
+              </div>
+              {this.state.isClient && (
+                <Portal node={document.getElementById('toolbar')}>
+                  <Toolbar
+                    pathname={this.props.pathname}
+                    inner={
+                      <Link
+                        to={`${path}`}
+                        aria-label={this.props.intl.formatMessage(
+                          messages.back,
+                        )}
+                      >
+                        <Icon
+                          name={backSVG}
+                          className="contents circled"
+                          size="30px"
+                          title={this.props.intl.formatMessage(messages.back)}
+                        />
+                      </Link>
+                    }
+                  />
+                </Portal>
+              )}
+            </Dimmer.Dimmable>
+          </Container>
+        ) : (
+          <Unauthorized staticContext={this.props.staticContext} />
+        )}
+      </>
+    ) : (
+      <Unauthorized staticContext={this.props.staticContext} />
+    );
+  }
+}
+
+let dndContext;
+
+const DragDropConnector = (props) => {
+  const { DragDropContext } = props.reactDnd;
+  const HTML5Backend = props.reactDndHtml5Backend.default;
+
+  const DndConnectedContents = React.useMemo(() => {
+    if (!dndContext) {
+      dndContext = DragDropContext(HTML5Backend);
+    }
+    return dndContext(Contents);
+  }, [DragDropContext, HTML5Backend]);
+
+  return <DndConnectedContents {...props} />;
+};
+
+export const __test__ = compose(
+  injectIntl,
+  injectLazyLibs(['toastify', 'reactDnd']),
+  connect(
+    (store, props) => {
+      return {
+        token: store.userSession.token,
+        items: store.search.items,
+        sort: store.content.update.sort,
+        index: store.content.updatecolumns.idx,
+        breadcrumbs: store.breadcrumbs.items,
+        total: store.search.total,
+        searchRequest: {
+          loading: store.search.loading,
+          loaded: store.search.loaded,
+        },
+        pathname: props.location.pathname,
+        action: store.clipboard.action,
+        source: store.clipboard.source,
+        clipboardRequest: store.clipboard.request,
+        deleteRequest: store.content.delete,
+        updateRequest: store.content.update,
+        objectActions: store.actions.actions.object,
+        orderRequest: store.content.order,
+      };
+    },
+    {
+      searchContent,
+      cut,
+      copy,
+      copyContent,
+      deleteContent,
+      listActions,
+      moveContent,
+      orderContent,
+      sortContent,
+      updateColumnsContent,
+      getContent,
+    },
+  ),
+)(Contents);
+
+export default compose(
+  injectIntl,
+  connect(
+    (store, props) => {
+      return {
+        token: store.userSession.token,
+        items: store.search.items,
+        sort: store.content.update.sort,
+        index: store.content.updatecolumns.idx,
+        breadcrumbs: store.breadcrumbs.items,
+        total: store.search.total,
+        searchRequest: {
+          loading: store.search.loading,
+          loaded: store.search.loaded,
+        },
+        pathname: props.location.pathname,
+        action: store.clipboard.action,
+        source: store.clipboard.source,
+        clipboardRequest: store.clipboard.request,
+        deleteRequest: store.content.delete,
+        updateRequest: store.content.update,
+        objectActions: store.actions.actions.object,
+        orderRequest: store.content.order,
+        affected_items: store.search.subrequests.affected_items,
+        affected_items_copy: store.search.subrequests.affected_items_copy,
+      };
+    },
+    {
+      searchContent,
+      resetSearchContent,
+      cut,
+      copy,
+      copyContent,
+      deleteContent,
+      listActions,
+      moveContent,
+      orderContent,
+      sortContent,
+      updateColumnsContent,
+      getContent,
+    },
+  ),
+  asyncConnect([
+    {
+      key: 'actions',
+      // Dispatch async/await to make the operation synchronous, otherwise it returns
+      // before the promise is resolved
+      promise: async ({ location, store: { dispatch } }) =>
+        await dispatch(listActions(getBaseUrl(location.pathname))),
+    },
+  ]),
+  injectLazyLibs(['toastify', 'reactDnd', 'reactDndHtml5Backend']),
+)(DragDropConnector);


### PR DESCRIPTION
viene mostrato un messaggio quando si sta cercando di spostare / cancellare / rinominare / cambiare lo stato di più di 300 elementi. 

Il numero massimo è configurabile nel config del sito nella variabile `config.settings.content_op_max_affected_items`, il suo valore di default è `300`.

Migliorata l'accessibilità della folder content. 

Mostrato un messaggio di errore più coerente ed esplicativo quando si verifica un errore nella folder content. a