### PR TITLE
feat: save table listing column field schema

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
@@ -1,12 +1,12 @@
 /*
  * Template a tabella
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useIntl, defineMessages } from 'react-intl';
-// import { getCTSchema } from 'design-comuni-plone-theme/actions';
+import { getCTSchema } from 'design-comuni-plone-theme/actions';
 import { Table, Container } from 'design-react-kit';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 
@@ -32,10 +32,29 @@ const TableTemplate = (props) => {
   } = props;
 
   const intl = useIntl();
+  const dispatch = useDispatch();
   const { views } = config.widgets;
 
   // necessario per gli edditor nel momento in cui aggiungono nuove colonne
   const ct_schema = useSelector((state) => state.ct_schema?.subrequests);
+
+  // Load the CT schema for columns that don't already carry persisted
+  // field_properties, so date/datetime widgets can format their values in
+  // view mode (otherwise the raw ISO value would be rendered).
+  useEffect(() => {
+    const cts = [
+      ...new Set(
+        (columns ?? [])
+          .filter((c) => !c.field_properties && c.ct)
+          .map((c) => c.ct),
+      ),
+    ];
+    cts.forEach((ct) => {
+      if (!ct_schema?.[ct]) {
+        dispatch(getCTSchema(ct));
+      }
+    });
+  }, [columns, ct_schema, dispatch]);
 
   let render_columns =
     (columns ?? []).filter((c) => c.field === 'title').length > 0

--- a/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/TableTemplate.jsx
@@ -1,12 +1,12 @@
 /*
  * Template a tabella
  */
-import React, { useEffect } from 'react';
+import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useIntl, defineMessages } from 'react-intl';
-import { getCTSchema } from 'design-comuni-plone-theme/actions';
+// import { getCTSchema } from 'design-comuni-plone-theme/actions';
 import { Table, Container } from 'design-react-kit';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 
@@ -32,29 +32,10 @@ const TableTemplate = (props) => {
   } = props;
 
   const intl = useIntl();
-  const dispatch = useDispatch();
   const { views } = config.widgets;
 
   // necessario per gli edditor nel momento in cui aggiungono nuove colonne
   const ct_schema = useSelector((state) => state.ct_schema?.subrequests);
-
-  // Load the CT schema for columns that don't already carry persisted
-  // field_properties, so date/datetime widgets can format their values in
-  // view mode (otherwise the raw ISO value would be rendered).
-  useEffect(() => {
-    const cts = [
-      ...new Set(
-        (columns ?? [])
-          .filter((c) => !c.field_properties && c.ct)
-          .map((c) => c.ct),
-      ),
-    ];
-    cts.forEach((ct) => {
-      if (!ct_schema?.[ct]) {
-        dispatch(getCTSchema(ct));
-      }
-    });
-  }, [columns, ct_schema, dispatch]);
 
   let render_columns =
     (columns ?? []).filter((c) => c.field === 'title').length > 0

--- a/src/components/ItaliaTheme/index.js
+++ b/src/components/ItaliaTheme/index.js
@@ -19,6 +19,7 @@ export LocationFiltersWidget from 'design-comuni-plone-theme/components/ItaliaTh
 export CanaleDigitaleWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/CanaleDigitaleWidget';
 export CTFieldsWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/CTFieldsWidget';
 export CTTitleColumnWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/CTTitleColumnWidget';
+export CTFieldPropertiesWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/CTFieldPropertiesWidget';
 export BlocksViewWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/BlocksViewWidget';
 export PDCViewWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/PDCViewWidget';
 export DataGridWidget from 'design-comuni-plone-theme/components/ItaliaTheme/manage/Widgets/DataGridWidget';

--- a/src/components/ItaliaTheme/manage/Widgets/CTFieldPropertiesWidget.jsx
+++ b/src/components/ItaliaTheme/manage/Widgets/CTFieldPropertiesWidget.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import isEqual from 'lodash/isEqual';
+
+const CTFieldPropertiesWidget = (props) => {
+  const { onChange, id, value, objectvalue } = props;
+  const { ct, field } = objectvalue ?? {};
+  const ct_schema = useSelector(
+    (state) => state.ct_schema?.subrequests?.[ct]?.result,
+  );
+
+  useEffect(() => {
+    const field_properties = ct_schema?.properties?.[field];
+    if (field_properties && !isEqual(field_properties, value)) {
+      onChange(id, field_properties);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [objectvalue?.title, ct_schema]);
+
+  return null;
+};
+
+export default CTFieldPropertiesWidget;

--- a/src/config/Blocks/ListingOptions/tableTemplate.js
+++ b/src/config/Blocks/ListingOptions/tableTemplate.js
@@ -55,6 +55,10 @@ const ColumnSchema = ({ intl }) => ({
       description: intl.formatMessage(messages.title_description),
       widget: 'ct_title_column',
     },
+    field_properties: {
+      title: ' ',
+      widget: 'ct_field_properties',
+    },
     // sortable: {
     //   title: intl.formatMessage(messages.sortable),
     //   type: 'boolean',
@@ -91,7 +95,11 @@ export const addTableTemplateOptions = (
       schemaExtender: (schema, data, intl) => {
         const mutated = cloneDeep(schema);
         if (data.ct) {
-          mutated.fieldsets[0].fields.push('field', 'title' /*, 'sortable'*/);
+          mutated.fieldsets[0].fields.push(
+            'field',
+            'title',
+            'field_properties' /*, 'sortable'*/,
+          );
           mutated.properties.field.ct = data.ct;
         }
         return mutated;

--- a/src/config/Widgets/widgets.js
+++ b/src/config/Widgets/widgets.js
@@ -21,6 +21,7 @@ import {
   CanaleDigitaleWidget,
   CTFieldsWidget,
   CTTitleColumnWidget,
+  CTFieldPropertiesWidget,
   BlocksViewWidget,
   PDCViewWidget,
   DataGridWidget,
@@ -108,6 +109,7 @@ const getItaliaWidgets = (config) => {
       luoghi_correlati_evento: LuoghiCorrelatiEventoWidget,
       ct_fields: CTFieldsWidget,
       ct_title_column: CTTitleColumnWidget,
+      ct_field_properties: CTFieldPropertiesWidget,
     },
     views: {
       ...config.widgets.views,


### PR DESCRIPTION
In the table variation of the list block, columns were not rendering correctly in anonymous view: the https://github.com/types endpoint (used to determine the type/widget of each field) is only available in edit mode, while in anonymous context it returns Unauthorized. Without that information, the column has no way to know whether a field is date, datetime, etc.

As agreed in the discussion (cc @cekk), field schema information (type, widget, behavior, ...) is now saved inside each column at block save time. This way the view has everything it needs to render each column correctly, even in anonymous context, without additional backend calls.

Changes
New hidden widget CTFieldPropertiesWidget, in edit mode it reads the selected field's schema and persists it in the column as field_properties.
Widget registration (ct_field_properties).
Column schema, added the field_properties field.
TableTemplate, fixed datetime format (HH:MM → HH:mm: previously showed the month instead of minutes).

--> Same changes done in https://github.com/RedTurtle/io-sanita-theme/pull/161