### PR TITLE
fix: aggiunto toast all'errore su upload massivo  di file

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -4807,6 +4807,11 @@ msgstr ""
 msgid "update_date"
 msgstr ""
 
+#: customizations/volto/components/manage/Contents/ContentsUploadModal
+# defaultMessage: An error has occurred while uploading files.
+msgid "upload_error"
+msgstr "Beim Hochladen der Dateien ist ein Fehler aufgetreten."
+
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: helpers/contentHelper
 # defaultMessage: Sito web

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -4792,6 +4792,11 @@ msgstr "Type"
 msgid "update_date"
 msgstr "Update date"
 
+#: customizations/volto/components/manage/Contents/ContentsUploadModal
+# defaultMessage: An error has occurred while uploading files.
+msgid "upload_error"
+msgstr "An error has occurred while uploading files."
+
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: helpers/contentHelper
 # defaultMessage: Sito web

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -4801,6 +4801,11 @@ msgstr "Tipo"
 msgid "update_date"
 msgstr ""
 
+#: customizations/volto/components/manage/Contents/ContentsUploadModal
+# defaultMessage: An error has occurred while uploading files.
+msgid "upload_error"
+msgstr "Se ha producido un error al subir los archivos."
+
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: helpers/contentHelper
 # defaultMessage: Sito web

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -4809,6 +4809,11 @@ msgstr "Typologie"
 msgid "update_date"
 msgstr ""
 
+#: customizations/volto/components/manage/Contents/ContentsUploadModal
+# defaultMessage: An error has occurred while uploading files.
+msgid "upload_error"
+msgstr "Une erreur s'est produite lors du téléversement des fichiers."
+
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: helpers/contentHelper
 # defaultMessage: Sito web

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -4792,6 +4792,11 @@ msgstr "Tipologia"
 msgid "update_date"
 msgstr "Data di aggiornamento"
 
+#: customizations/volto/components/manage/Contents/ContentsUploadModal
+# defaultMessage: An error has occurred while uploading files.
+msgid "upload_error"
+msgstr "Si è verificato un errore durante il caricamento dei file."
+
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: helpers/contentHelper
 # defaultMessage: Sito web

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -4794,6 +4794,11 @@ msgstr ""
 msgid "update_date"
 msgstr ""
 
+#: customizations/volto/components/manage/Contents/ContentsUploadModal
+# defaultMessage: An error has occurred while uploading files.
+msgid "upload_error"
+msgstr ""
+
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: helpers/contentHelper
 # defaultMessage: Sito web

--- a/src/customizations/volto/components/manage/Contents/ContentsUploadModal.jsx
+++ b/src/customizations/volto/components/manage/Contents/ContentsUploadModal.jsx
@@ -1,5 +1,8 @@
 // CUSTOMIZATION:
 // - 196-202 - 230-262: added file upload restraint message as per agid regulations
+// - added error toast when the upload request fails (e.g. an alias with the
+//   same id already exists in this location); the modal stays open so the
+//   user can remove or rename the conflicting file and retry
 
 /**
  * Contents upload modal.
@@ -27,9 +30,10 @@ import { concat, filter, map } from 'lodash';
 import filesize from 'filesize';
 import { readAsDataURL } from 'promise-file-reader';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { FormattedRelativeDate } from '@plone/volto/components';
+import { FormattedRelativeDate, Toast } from '@plone/volto/components';
 import { createContent, getTypes } from '@plone/volto/actions';
 import { validateFileUploadSize, getBaseUrl } from '@plone/volto/helpers';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 
 const Dropzone = loadable(() => import('react-dropzone'));
 
@@ -42,6 +46,14 @@ const messages = defineMessages({
     id: '{count, plural, one {Upload {count} file} other {Upload {count} files}}',
     defaultMessage:
       '{count, plural, one {Upload {count} file} other {Upload {count} files}}',
+  },
+  error: {
+    id: 'Error',
+    defaultMessage: 'Error',
+  },
+  uploadError: {
+    id: 'upload_error',
+    defaultMessage: 'An error has occurred while uploading files.',
   },
 });
 
@@ -100,6 +112,18 @@ class ContentsUploadModal extends Component {
       this.setState({
         files: [],
       });
+    }
+    if (this.props.request.loading && nextProps.request.error) {
+      const msgBody =
+        nextProps.request.error?.response?.body?.message ||
+        this.props.intl.formatMessage(messages.uploadError);
+      this.props.toastify.toast.error(
+        <Toast
+          error
+          title={this.props.intl.formatMessage(messages.error)}
+          content={msgBody}
+        />,
+      );
     }
   }
 
@@ -365,6 +389,7 @@ class ContentsUploadModal extends Component {
 
 export default compose(
   injectIntl,
+  injectLazyLibs(['toastify']),
   connect(
     (state) => ({
       request: state.content.subrequests?.[SUBREQUEST] || {},


### PR DESCRIPTION
aggiunto toast durante l'errore. prima non c'era nulla e l'utente non era avvisato che qualcosa si rompesse