### PR TITLE
fix: prevent event page crash when contact list is missing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Risolto un errore nella pagina degli eventi che in alcuni casi ne impediva la visualizzazione. L'errore si verificava quando la sezione Contatti dell'evento riportava informazioni sull'organizzatore o sui sostenitori ma non conteneva alcun contatto in elenco.
+
 ## Versione 12.13.0 (25/06/2026)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/View/EventoView/EventoContatti.jsx
+++ b/src/components/ItaliaTheme/View/EventoView/EventoContatti.jsx
@@ -21,14 +21,14 @@ const EventoContatti = ({ content }) => {
   const intl = useIntl();
 
   return richTextHasContent(content?.organizzato_da_esterno) ||
-    content?.organizzato_da_interno.length > 0 ||
+    content?.organizzato_da_interno?.length > 0 ||
     content?.supportato_da?.length > 0 ||
     content?.contact_info?.length > 0 ? (
     <RichTextSection
       tag_id="contatti"
       title={intl.formatMessage(messages.contatti)}
     >
-      {content.contact_info.map((contact) => (
+      {content.contact_info?.map((contact) => (
         <ContactsCard contact={contact} key={contact['@id']} />
       ))}
 


### PR DESCRIPTION
## Descrizione

Risolve un errore che in alcuni casi impediva la visualizzazione della pagina di un evento. L'errore si verificava quando la sezione Contatti dell'evento riportava informazioni sull'organizzatore o sui sostenitori ma non conteneva alcun contatto in elenco. In quel caso il rendering della lista dei contatti falliva e l'intera pagina non veniva mostrata.

## Modifiche

- Aggiunto l'optional chaining sulla lista dei contatti in EventoContatti.jsx, così la sezione viene mostrata correttamente anche senza contatti in elenco
- Corretto anche il controllo sulla lunghezza di organizzato_da_interno che poteva generare lo stesso tipo di errore