### PR TITLE
fix: hide bc from lrf and hp

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Risolto un errore nella pagina degli eventi che in alcuni casi ne impediva la visualizzazione. L'errore si verificava quando la sezione Contatti dell'evento riportava informazioni sull'organizzatore o sui sostenitori ma non conteneva alcun contatto in elenco.
+- Rimossa la sezione delle breadcrumbs dalla pagina principale.
 
 ## Versione 12.13.0 (25/06/2026)
 

--- a/src/theme/ItaliaTheme/_home.scss
+++ b/src/theme/ItaliaTheme/_home.scss
@@ -4,6 +4,10 @@ body.public-ui.contenttype-lrf {
   .documentFirstHeading {
     @include visually-hidden;
   }
+
+  #briciole {
+    display: none;
+  }
 }
 
 body.subsite.subsite-root {


### PR DESCRIPTION
Nascosta la sezione breadcrumbs dalla hp e dalla language root folder. Anche se vuota, il margine impostato lasciava uno spazietto vuoto all'interno della pagina

<img width="2150" height="472" alt="image" src="https://github.com/user-attachments/assets/2a34ce98-8395-4da6-80e4-697fbb63d7f0" />
<img width="3092" height="462" alt="image" src="https://github.com/user-attachments/assets/33dae27b-5de9-4481-a94a-8580214c5186" />


N.B. Non ho messo @visually-hidden perchè tanto è vuota (siamo nella hp)




