### PR TITLE
fix: add aria-current to active slick dots

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- Migliorata l'accessibilità degli slider. Le tecnologie assistive ora segnalano quale slide è attualmente selezionata.
+
+### Novità
+
+- ...
+
+### Fix
+
+- ...
+
 ## Versione 12.14.0 (20/07/2026)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
@@ -19,6 +19,7 @@ import {
   setOriginalQuery,
 } from 'design-comuni-plone-theme/actions';
 import Item from 'design-comuni-plone-theme/components/ItaliaTheme/Blocks/Calendar/Item';
+import { decorateSliderDots } from 'design-comuni-plone-theme/components/ItaliaTheme/Slider/slider';
 import { viewDate } from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
@@ -176,6 +177,9 @@ const Body = ({ data, block, inEditMode, path, onChangeBlock, reactSlick }) => {
     infinite: false,
     initialSlide: 0,
     dotsClass: 'slick-dots dot',
+    appendDots: (dots) => (
+      <ul className="slick-dots dot">{decorateSliderDots(dots)}</ul>
+    ),
     lazyLoad: true,
     afterChange: (current, next) => setActivePage(current),
     responsive: [

--- a/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate.jsx
@@ -21,7 +21,10 @@ import {
   CarouselWrapper,
   ButtonPlayPause,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { useSlider } from 'design-comuni-plone-theme/components/ItaliaTheme/Slider/slider';
+import {
+  useSlider,
+  decorateSliderDots,
+} from 'design-comuni-plone-theme/components/ItaliaTheme/Slider/slider';
 import { GalleryPreview } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
 const messages = defineMessages({
@@ -128,7 +131,7 @@ const PhotogalleryTemplate = ({
         />
 
         <ul className="slick-dots" style={{ margin: '0px' }}>
-          {dots}
+          {decorateSliderDots(dots)}
         </ul>
       </div>
     ),

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -127,6 +127,10 @@ const SliderTemplate = ({
             function () {
               return null;
             };
+          // Inerte finché i dot restano aria-hidden, creato per coerenza.
+          const isActive = (item.props.className || '').includes(
+            'slick-active',
+          );
           return (
             <El
               key={index}
@@ -147,6 +151,7 @@ const SliderTemplate = ({
                 aria-label={intl.formatMessage(messages.slideDot, {
                   index: index + 1,
                 })}
+                {...(isActive ? { 'aria-current': 'true' } : {})}
               />
             </El>
           );

--- a/src/components/ItaliaTheme/Blocks/VideoGallery/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/VideoGallery/Body.jsx
@@ -14,6 +14,7 @@ import {
   NextArrow,
   PrevArrow,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { decorateSliderDots } from 'design-comuni-plone-theme/components/ItaliaTheme/Slider/slider';
 import { Container } from 'design-react-kit';
 import { UniversalLink } from '@plone/volto/components';
 
@@ -28,6 +29,9 @@ const Body = ({ data, children, nItems = 0, reactSlick }) => {
 
   const settings = {
     dots: true,
+    appendDots: (dots) => (
+      <ul className="slick-dots">{decorateSliderDots(dots)}</ul>
+    ),
     nextArrow: <NextArrow />,
     prevArrow: <PrevArrow />,
     infinite: true,

--- a/src/components/ItaliaTheme/Slider/slider.js
+++ b/src/components/ItaliaTheme/Slider/slider.js
@@ -1,8 +1,20 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, cloneElement } from 'react';
 import {
   NextArrow,
   PrevArrow,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
+
+// Aggiunge aria-current al dot attivo dello slider così gli screen reader lo annunciano.
+export const decorateSliderDots = (dots) =>
+  dots.map((dot) => {
+    const isActive = (dot.props.className || '').includes('slick-active');
+    if (!isActive) return dot;
+
+    const button = dot.props.children;
+    return cloneElement(dot, {
+      children: cloneElement(button, { 'aria-current': 'true' }),
+    });
+  });
 
 export const useSlider = (userAutoplay, setUserAutoplay, block_id) => {
   const slider = useRef(null);

--- a/src/components/ItaliaTheme/View/Commons/Gallery.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Gallery.jsx
@@ -13,7 +13,10 @@ import {
   SingleSlideWrapper,
   CarouselWrapper,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { useSlider } from 'design-comuni-plone-theme/components/ItaliaTheme/Slider/slider';
+import {
+  useSlider,
+  decorateSliderDots,
+} from 'design-comuni-plone-theme/components/ItaliaTheme/Slider/slider';
 
 import PropTypes from 'prop-types';
 import { contentFolderHasItems } from 'design-comuni-plone-theme/helpers';
@@ -64,6 +67,9 @@ const Gallery = ({
       slidesToScroll: slideToScroll ?? 3,
       nextArrow: <SliderNextArrow intl={intl} />,
       prevArrow: <SliderPrevArrow intl={intl} />,
+      appendDots: (dots) => (
+        <ul className="slick-dots">{decorateSliderDots(dots)}</ul>
+      ),
       responsive: [
         {
           breakpoint: 1024,


### PR DESCRIPTION
Aggiunto l'attributo aria-current al pallino attivo degli slider, così le tecnologie assistive comunicano quale slide è selezionata.

È stato creato un helper condiviso decorateSliderDots che centralizza la logica di marcatura del pallino attivo. In questo modo la creazione dei pallini resta uniforme tra i vari slider ed evita di ripetere la stessa logica in ogni componente. L'helper riceve i pallini generati, individua quello attivo e gli applica aria-current lasciando invariati gli altri.

- Applicato agli slider di Calendario, Video Gallery, Photogallery e Gallery delle viste
- Slider del blocco Elenco allineato per coerenza

**Importante**: È stato scelto aria-current al posto di aria-selected perché aria-selected è valido solo su elementi con ruoli specifici come option o tab e non su un semplice pulsante. Per indicare l'elemento corrente di un insieme lo standard prevede aria-current.
Riferimento https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current