### PR TITLE
Configured sentry to ignore facebook in-app browser errors

### DIFF
--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -108,6 +108,7 @@ export default function applyConfig(voltoConfig) {
         'Loading CSS chunk',
         'Timeout (n)', //errori di recaptcha nella customer satisfaction
         'Uncaught (in promise) Timeout (n)', //errori di recaptcha nella customer satisfaction
+        'window.webkit.messageHandlers', //errore in-app browser Facebook/Instagram su iOS
       ],
       // https://docs.sentry.io/platforms/javascript/data-management/sensitive-data/
       // beforeSend(event) {


### PR DESCRIPTION
Sentry cattura spesso errori dovuti alla navigazione nel browser in-app di facebook su iOS, alcuni strumenti di analitica e/o js iniettati in pagina non gestiscono correttamente la presenza o meno di una feature di webkit per la comunicazione con il sistema operativo.