### PR TITLE
fix: remove ARIA menu roles from navigation megamenu

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Corretto il menu di navigazione principale per le tecnologie assistive. Le voci di menu e i sottomenu ora vengono annunciati correttamente.
+- Il nome annunciato dalle tecnologie assistive per i link del menu ora corrisponde sempre al testo visibile, anche per il link Vedi tutto e per le voci di menu con etichetta personalizzata.
 
 ## Versione 12.14.1 (22/07/2026)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,8 +53,8 @@
 
 ### Fix
 
-- Corretto il menu di navigazione principale per le tecnologie assistive. Le voci di menu e i sottomenu ora vengono annunciati correttamente.
-- Il nome annunciato dalle tecnologie assistive per i link del menu ora corrisponde sempre al testo visibile, anche per il link Vedi tutto e per le voci di menu con etichetta personalizzata.
+- Sistemata l'accessibilità del menu di navigazione principale del sito. Le voci di menu e i sottomenu ora vengono annunciati correttamente dalle tecnologie assistive.
+- Il nome annunciato dalle tecnologie assistive per i link del menu ora corrisponde sempre al testo visibile, anche per il link 'Vedi tutto'.
 
 ## Versione 12.14.1 (22/07/2026)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Corretto il menu di navigazione principale per le tecnologie assistive. Le voci di menu e i sottomenu ora vengono annunciati correttamente.
+
 ## Versione 12.14.1 (22/07/2026)
 
 ### Migliorie

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -408,7 +408,7 @@ const MegaMenu = ({ item, pathname }) => {
                 <Row>
                   <Col lg={8} />
                   <Col lg={4}>
-                    <LinkList aria-label={showMoreLabel}>
+                    <LinkList>
                       <li className="it-more text-end">
                         <UniversalLink
                           className="list-item medium"

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -95,17 +95,13 @@ const MegaMenu = ({ item, pathname }) => {
     const handleEscape = (e) => {
       if (e.key === 'Escape') {
         setMenuStatus(false);
-        // No ref: DropdownToggle ignores innerRef when inNavbar is true.
-        document
-          .querySelector(`[data-element="${item.id_lighthouse}"]`)
-          ?.focus();
       }
     };
 
     document.addEventListener('keydown', handleEscape);
 
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [menuStatus, item.id_lighthouse]);
+  }, [menuStatus]);
 
   const getAnchorTarget = (nodeElement) => {
     if (nodeElement.nodeName === 'A') {
@@ -290,12 +286,7 @@ const MegaMenu = ({ item, pathname }) => {
           tag="div"
           toggle={() => setMenuStatus(!menuStatus)}
         >
-          <DropdownToggle
-            aria-haspopup
-            color="secondary"
-            nav
-            data-element={item.id_lighthouse}
-          >
+          <DropdownToggle aria-haspopup color="secondary" nav>
             <span dangerouslySetInnerHTML={{ __html: item.title }}></span>
             <Icon
               icon="it-expand"

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -149,6 +149,7 @@ const MegaMenu = ({ item, pathname }) => {
           tag={UniversalLink}
           data-element={item.id_lighthouse}
           active={isItemActive}
+          aria-label={item.title}
         >
           <span dangerouslySetInnerHTML={{ __html: item.title }}></span>
           {isItemActive && (
@@ -270,6 +271,11 @@ const MegaMenu = ({ item, pathname }) => {
         }
       }
     }
+
+    const showMoreLabel =
+      item.showMoreText?.length > 0
+        ? item.showMoreText
+        : intl.formatMessage(messages.view_all);
 
     return (
       <NavItem
@@ -417,12 +423,9 @@ const MegaMenu = ({ item, pathname }) => {
                           className="list-item medium"
                           item={item.showMoreLink[0]}
                           onClick={() => setMenuStatus(false)}
+                          aria-label={`${showMoreLabel} ${item.title}`}
                         >
-                          <span>
-                            {item.showMoreText?.length > 0
-                              ? item.showMoreText
-                              : intl.formatMessage(messages.view_all)}
-                          </span>
+                          <span>{showMoreLabel}</span>
                           <Icon icon="it-arrow-right" />
                         </UniversalLink>
                       </li>

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -93,8 +93,9 @@ const MegaMenu = ({ item, pathname }) => {
       return;
     }
     const handleEscape = (e) => {
-      if (e.key === 'Escape' || e.key === 'Esc') {
+      if (e.key === 'Escape') {
         setMenuStatus(false);
+        // No ref: DropdownToggle ignores innerRef when inNavbar is true.
         document
           .querySelector(`[data-element="${item.id_lighthouse}"]`)
           ?.focus();
@@ -295,6 +296,7 @@ const MegaMenu = ({ item, pathname }) => {
               className={cx('megamenu-toggle-icon', { open: menuStatus })}
             />
           </DropdownToggle>
+          {/* role={undefined} removes reactstrap's hardcoded role="menu" */}
           <DropdownMenu flip tag="div" role={undefined}>
             <div className="text-end megamenu-close-button">
               <Button
@@ -306,8 +308,7 @@ const MegaMenu = ({ item, pathname }) => {
                   }
                 }}
                 title={intl.formatMessage(messages.closeMenu)}
-                // APG spec: on Tab menu closes, so remove it from focusable elements
-                // https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/
+                // Out of Tab order: Escape/outside click already close the menu
                 tabIndex="-1"
               >
                 <Icon icon="it-close" />
@@ -318,12 +319,17 @@ const MegaMenu = ({ item, pathname }) => {
                 <Row>
                   {childrenGroups.map((group, index) => (
                     <Col lg={12 / max_cols} key={'group_' + index}>
-                      <LinkList className="bordered" aria-label={item.title ?? ''}>
+                      <LinkList
+                        className="bordered"
+                        aria-label={item.title ?? ''}
+                      >
                         {group.map((child, idx) => {
                           return (
                             <li
                               key={child['@id'] + idx}
-                              ref={index === 0 && idx === 0 ? firstItemRef : null}
+                              ref={
+                                index === 0 && idx === 0 ? firstItemRef : null
+                              }
                             >
                               {child.showAsHeader ? (
                                 <h3

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -417,7 +417,7 @@ const MegaMenu = ({ item, pathname }) => {
                 <Row>
                   <Col lg={8} />
                   <Col lg={4}>
-                    <LinkList aria-label={item.showMoreText ?? ''}>
+                    <LinkList aria-label={showMoreLabel}>
                       <li className="it-more text-end">
                         <UniversalLink
                           className="list-item medium"

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -3,7 +3,7 @@
  * @module components/theme/Navigation/Navigation
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { map } from 'lodash';
 import cx from 'classnames';
@@ -80,6 +80,31 @@ const MegaMenu = ({ item, pathname }) => {
   const isItemActive = isActive(item, pathname);
 
   const [menuStatus, setMenuStatus] = useState(false);
+  const firstItemRef = useRef(null);
+
+  useEffect(() => {
+    if (menuStatus) {
+      firstItemRef.current?.querySelector('a')?.focus();
+    }
+  }, [menuStatus]);
+
+  useEffect(() => {
+    if (!menuStatus) {
+      return;
+    }
+    const handleEscape = (e) => {
+      if (e.key === 'Escape' || e.key === 'Esc') {
+        setMenuStatus(false);
+        document
+          .querySelector(`[data-element="${item.id_lighthouse}"]`)
+          ?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [menuStatus, item.id_lighthouse]);
 
   const getAnchorTarget = (nodeElement) => {
     if (nodeElement.nodeName === 'A') {
@@ -115,7 +140,7 @@ const MegaMenu = ({ item, pathname }) => {
 
   if (item.mode === 'simpleLink') {
     return item.linkUrl?.length > 0 ? (
-      <NavItem tag="li" active={isItemActive} role="none">
+      <NavItem tag="li" active={isItemActive}>
         <NavLink
           className={isItemActive ? 'focus--mouse' : ''}
           href={item.linkUrl === '' ? '/' : null}
@@ -123,7 +148,6 @@ const MegaMenu = ({ item, pathname }) => {
           tag={UniversalLink}
           data-element={item.id_lighthouse}
           active={isItemActive}
-          role="menuitem"
         >
           <span dangerouslySetInnerHTML={{ __html: item.title }}></span>
           {isItemActive && (
@@ -251,7 +275,6 @@ const MegaMenu = ({ item, pathname }) => {
         tag="li"
         className={isItemActive ? 'focus--mouse megamenu' : 'megamenu'}
         active={isItemActive}
-        role="none"
       >
         <UncontrolledDropdown
           nav
@@ -261,7 +284,6 @@ const MegaMenu = ({ item, pathname }) => {
           toggle={() => setMenuStatus(!menuStatus)}
         >
           <DropdownToggle
-            role="menuitem"
             aria-haspopup
             color="secondary"
             nav
@@ -273,7 +295,7 @@ const MegaMenu = ({ item, pathname }) => {
               className={cx('megamenu-toggle-icon', { open: menuStatus })}
             />
           </DropdownToggle>
-          <DropdownMenu flip tag="div">
+          <DropdownMenu flip tag="div" role={undefined}>
             <div className="text-end megamenu-close-button">
               <Button
                 color="link"
@@ -296,14 +318,13 @@ const MegaMenu = ({ item, pathname }) => {
                 <Row>
                   {childrenGroups.map((group, index) => (
                     <Col lg={12 / max_cols} key={'group_' + index}>
-                      <LinkList
-                        className="bordered"
-                        role="menu"
-                        aria-label={item.title ?? ''}
-                      >
+                      <LinkList className="bordered" aria-label={item.title ?? ''}>
                         {group.map((child, idx) => {
                           return (
-                            <li key={child['@id'] + idx} role="none">
+                            <li
+                              key={child['@id'] + idx}
+                              ref={index === 0 && idx === 0 ? firstItemRef : null}
+                            >
                               {child.showAsHeader ? (
                                 <h3
                                   className={cx('list-item', {
@@ -319,7 +340,6 @@ const MegaMenu = ({ item, pathname }) => {
                                     condition={!!child['@id']}
                                     key={child['@id']}
                                     onClick={() => setMenuStatus(false)}
-                                    role="menuitem"
                                     aria-current="page"
                                   >
                                     <span>{child.title}</span>
@@ -339,7 +359,6 @@ const MegaMenu = ({ item, pathname }) => {
                                       true,
                                     ),
                                   })}
-                                  role="menuitem"
                                 >
                                   <span>{child.title}</span>
                                 </ConditionalLink>
@@ -386,13 +405,12 @@ const MegaMenu = ({ item, pathname }) => {
                 <Row>
                   <Col lg={8} />
                   <Col lg={4}>
-                    <LinkList role="menu" aria-label={item.showMoreText ?? ''}>
-                      <li className="it-more text-end" role="none">
+                    <LinkList aria-label={item.showMoreText ?? ''}>
+                      <li className="it-more text-end">
                         <UniversalLink
                           className="list-item medium"
                           item={item.showMoreLink[0]}
                           onClick={() => setMenuStatus(false)}
-                          role="menuitem"
                         >
                           <span>
                             {item.showMoreText?.length > 0

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -150,7 +150,6 @@ const Navigation = ({ pathname }) => {
                 <Nav
                   data-element="main-navigation"
                   navbar
-                  role="menubar"
                   aria-label={intl.formatMessage(messages.mainMenu)}
                 >
                   {menu


### PR DESCRIPTION
Rimossi gli attributi role="menubar", role="menuitem", role="menu" e role="none" dal menu di navigazione principale e dal megamenu.

Questi ruoli ARIA sono pensati per widget di tipo menu applicativo, che richiedono una gestione da tastiera specifica con le frecce. Il menu di navigazione del sito non implementa quel comportamento, quindi dichiarare quei ruoli comunicava alle tecnologie assistive una funzione che il menu non offriva realmente.

Le voci del menu e i link interni al megamenu ora usano la semantica nativa di ul/li/a.

Il pannello del megamenu (DropdownMenu di reactstrap) imposta comunque un role="menu" via prop di default. Per rimuoverlo del tutto è stato passato esplicitamente role={undefined}, che sovrascrive quello interno alla libreria.

Per mantenere l'accessibilità da tastiera dopo la rimozione dei ruoli sono state aggiunte due gestioni esplicite nel megamenu.

- Alla apertura del megamenu il focus si sposta sul primo link del pannello
- Il tasto Escape chiude il megamenu e riporta il focus sul pulsante che lo ha aperto
- Dall'ultimo elemento del pannello, in genere "Vedi tutto", un ulteriore Tab chiude il megamenu e sposta il focus sulla voce di menu successiva

Corretto inoltre il nome annunciato dalle tecnologie assistive per il link Vedi tutto e per le voci di menu con etichetta personalizzata, che in alcuni casi non corrispondeva al testo visibile del link.