### PR TITLE
fix: hide empty contacts section on Persona view

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Risolto un errore nella pagina delle persone che mostrava la sezione Contatti vuota. L'errore si verificava quando era presente un punto di contatto senza alcun valore compilato. <!--us-77265-->
+
 ## Versione 12.14.2 (30/07/2026)
 
 ### Fix

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,7 +53,7 @@
 
 ### Fix
 
-- Risolto un errore nella pagina delle persone che mostrava la sezione Contatti vuota. L'errore si verificava quando era presente un punto di contatto senza alcun valore compilato. <!--us-77265-->
+- Risolto un errore nella pagina delle persone che mostrava la sezione Contatti vuota. L'errore si verificava quando era presente un punto di contatto senza alcun valore compilato.
 
 ## Versione 12.14.2 (30/07/2026)
 

--- a/src/components/ItaliaTheme/View/PersonaView/PersonaContatti.jsx
+++ b/src/components/ItaliaTheme/View/PersonaView/PersonaContatti.jsx
@@ -15,12 +15,16 @@ const messages = defineMessages({
 const PersonaContatti = ({ content }) => {
   const intl = useIntl();
 
-  return content?.contact_info?.length > 0 ? (
+  const contacts = (content?.contact_info ?? []).filter(
+    (contact) => contact?.value_punto_contatto?.length > 0,
+  );
+
+  return contacts.length > 0 ? (
     <RichTextSection
       title={intl.formatMessage(messages.contacts)}
       tag_id="contacts"
     >
-      {content.contact_info.map((contact) => (
+      {contacts.map((contact) => (
         <ContactsCard contact={contact} key={contact['@id']} />
       ))}
     </RichTextSection>


### PR DESCRIPTION
La sezione Contatti nella pagina di una Persona veniva mostrata anche quando il contenuto non aveva alcun dato di contatto valido. Questo produceva un titolo Contatti seguito da un riquadro vuoto.

Il problema si verificava quando il campo contact_info conteneva un punto di contatto senza alcun valore compilato al suo interno.

Modifiche principali

Il componente PersonaContatti ora filtra i punti di contatto senza valori compilati prima di decidere se mostrare la sezione. Se non rimane nessun contatto valido la sezione non viene più renderizzata.