### PR TITLE
chore: bump volto-data-grid-widget to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "typeface-roboto-mono": "0.0.75",
     "typeface-titillium-web": "0.0.72",
     "volto-blocks-widget": "3.4.8",
-    "volto-data-grid-widget": "2.4.0",
+    "volto-data-grid-widget": "2.4.1",
     "volto-dropdownmenu": "4.1.6",
     "volto-editablefooter": "5.1.12",
     "volto-feedback": "0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8341,7 +8341,7 @@ __metadata:
     typeface-roboto-mono: 0.0.75
     typeface-titillium-web: 0.0.72
     volto-blocks-widget: 3.4.8
-    volto-data-grid-widget: 2.4.0
+    volto-data-grid-widget: 2.4.1
     volto-dropdownmenu: 4.1.6
     volto-editablefooter: 5.1.12
     volto-feedback: 0.7.2
@@ -16547,12 +16547,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-data-grid-widget@npm:2.4.0":
-  version: 2.4.0
-  resolution: "volto-data-grid-widget@npm:2.4.0"
+"volto-data-grid-widget@npm:2.4.1":
+  version: 2.4.1
+  resolution: "volto-data-grid-widget@npm:2.4.1"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: ebb47d78eec2cd718004b213bfa0e22f2978b09758731e60ab473bc16271951929565abdeaf1452422973203cf0266896e6c3db54e559bd1953858cc470376e5
+  checksum: 33100448b026160ff387a872dd5a52d73ea8ba64967bec4a1a074ae672548f7641329940e8c30cd82e95c50303c5d30f3de000f46714c092e6895b19193595f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Aggiornata la versione di `volto-data-grid-widget` a 2.4.1, che include la fix per l'`id` duplicato nel `TermWidget` (checkbox "obbligatorio" che si disattivava sulla riga sbagliata quando c'erano più campi aggiuntivi in una grid).

PR upstream: https://github.com/collective/volto-data-grid-widget/pull/5