### PR TITLE
Fix: BlockDataForm writes spurious "undefined" block key

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Block/Settings.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Block/Settings.jsx
@@ -1,0 +1,50 @@
+/*
+ * original: https://raw.githubusercontent.com/plone/volto/19.1.5/packages/volto/src/components/manage/Blocks/Block/Settings.jsx
+ *
+ * CUSTOMIZATIONS:
+ * - Pass block={block} to BlockDataForm: the original core code omits it, so
+ *   InlineForm's mount effect (which re-syncs schema defaults via
+ *   onChangeFormData) calls onChangeBlock(undefined, data), writing a spurious
+ *   "undefined" key into the blocks map on every sidebar mount/unmount.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
+
+const Settings = ({
+  data,
+  block,
+  onChangeBlock,
+  schema,
+  navRoot,
+  contentType,
+}) => {
+  return (
+    <BlockDataForm
+      block={block}
+      schema={schema}
+      title={schema.title}
+      onChangeField={(id, value) => {
+        onChangeBlock(block, {
+          ...data,
+          [id]: value,
+        });
+      }}
+      onChangeBlock={onChangeBlock}
+      formData={data}
+      applySchemaEnhancers={false}
+      navRoot={navRoot}
+      contentType={contentType}
+    />
+  );
+};
+
+Settings.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+  block: PropTypes.string.isRequired,
+  onChangeBlock: PropTypes.func.isRequired,
+  schema: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default injectIntl(Settings);

--- a/src/customizations/volto/components/manage/Blocks/Search/SearchBlockEdit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/SearchBlockEdit.jsx
@@ -7,8 +7,12 @@
  * - Use a limited templates subset: filter the available listing variations with
  *   config.settings.searchBlockTemplates before building the "Results template" schema field
  *   and before resolving the active item's schemaEnhancer
- * - sortOnOptions removed in schema customization, removed the code that was 
+ * - sortOnOptions removed in schema customization, removed the code that was
  *   setting schema.properties.sortOnOptions.items
+ * - Pass block={block} to BlockDataForm: the original core code omits it, so
+ *   InlineForm's mount effect (which re-syncs schema defaults via
+ *   onChangeFormData) calls onChangeBlock(undefined, data), writing a spurious
+ *   "undefined" key into the blocks map on every sidebar mount/unmount.
  */
 import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
@@ -105,6 +109,7 @@ const SearchBlockEdit = (props) => {
       />
       <SidebarPortal selected={selected}>
         <BlockDataForm
+          block={block}
           schema={schema}
           onChangeField={(id, value) => {
             onChangeBlock(block, {


### PR DESCRIPTION
## Summary

Core Volto (19.1.5) bug: `BlockDataForm` builds `onChangeFormData` as `(data) => onChangeBlock(block, data)` using the `block` prop it receives. Two core components mount `<BlockDataForm>` without passing `block`, so it's `undefined`. Every time a block is selected/deselected, `SidebarPortal` remounts `InlineForm`, whose mount effect re-syncs schema defaults via `onChangeFormData(initialData)` — calling `onChangeBlock(undefined, data)`. `changeBlock()` then writes `{ ...blocks, undefined: value }`, coercing the key to the literal string `"undefined"` and corrupting the real block's data over time (observed on the Search block: facets end up containing the page URL instead of the entered text).

Not specific to the Search block or a particular variation — affects any block, since `Block/Settings.jsx` (the settings sidebar) is shared by all block types.

- `SearchBlockEdit.jsx`: `block` was destructured from props but never passed down to `BlockDataForm` — added `block={block}`.
- `Settings.jsx`: not previously shadowed in this addon — added a new customization shadowing `@plone/volto` core, passing `block={block}` through.

Root-cause fix (pass the prop where it's missing), matching how core already does it correctly elsewhere (`Teaser/Data.jsx`, `Listing/ListingData.jsx`).

An issue will also be reported upstream to `plone/volto` so the fix lands in core and this shadow can eventually be dropped.

## Test plan
- [ ] Add/select a Search block, add facets, save, reload — verify no `"undefined"` key appears in the saved `blocks` JSON and facet values are correct
- [ ] Select/deselect any block a few times, open its settings sidebar, edit a field, save — verify no `"undefined"` key appears