### PR TITLE
fix: avoided repeating bc + correct bc name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,7 +54,7 @@
 ### Fix
 
 - Nella vista di dettaglio di un'Immagine, il link "Clicca per scaricare l'immagine in dimensione originale" ora avvia correttamente il download del file, invece di aprire l'immagine in una nuova pagina.
-- Corretto il percorso di navigazione (breadcrumb) nelle sezioni che si aggiornano senza ricaricare la pagina (ad es. aree private): non si accumula più mostrando tutte le sezioni visitate, e indica sempre correttamente la sezione in cui ci si trova.
+- Corretto il percorso di navigazione (breadcrumb) nelle sezioni che si aggiornano senza ricaricare la pagina: non si accumula più mostrando tutte le sezioni visitate, e indica sempre correttamente la sezione in cui ci si trova.
 
 ## Versione 12.14.2 (30/07/2026)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Nella vista di dettaglio di un'Immagine, il link "Clicca per scaricare l'immagine in dimensione originale" ora avvia correttamente il download del file, invece di aprire l'immagine in una nuova pagina.
+- Corretto il percorso di navigazione (breadcrumb) nelle sezioni che si aggiornano senza ricaricare la pagina (ad es. aree private): non si accumula più mostrando tutte le sezioni visitate, e indica sempre correttamente la sezione in cui ci si trova.
 
 ## Versione 12.14.2 (30/07/2026)
 

--- a/src/components/ItaliaTheme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/ItaliaTheme/Breadcrumbs/Breadcrumbs.jsx
@@ -50,15 +50,18 @@ const Breadcrumbs = ({ pathname }) => {
   });
 
   // Funzione per fare match di routes
-  const getMatchingRoute = (p) =>
-    matchPath(location.pathname, p) !== null ||
-    matchPath(location.pathname, p.replace('**/', '')) !== null;
+  const getMatchingRoute = (p, exact) =>
+    matchPath(location.pathname, { path: p, exact: !!exact }) !== null ||
+    matchPath(location.pathname, {
+      path: p.replace('**/', ''),
+      exact: !!exact,
+    }) !== null;
 
   // Funzione per riconoscere se siamo in una route statica
   const getCurrentPathFromAddonRoutes = () =>
     config.addonRoutes.find((route) => {
       const paths = typeof route.path === 'string' ? [route.path] : route.path;
-      return paths.find(getMatchingRoute);
+      return paths.find((p) => getMatchingRoute(p, route.exact));
     }) || {};
 
   // Gestione delle rotte statiche. Se definito nel config della rotta un breadcrumbs_title, lo aggiungo alle breadcrumbs
@@ -70,10 +73,13 @@ const Breadcrumbs = ({ pathname }) => {
       items[items.length - 1].url !== location.pathname) ||
     (items.length === 0 && bcLoaded && route.breadcrumbs_title)
   ) {
-    items.push({
-      url: location.pathname,
-      title: intl.formatMessage(route.breadcrumbs_title),
-    });
+    items = [
+      ...items,
+      {
+        url: location.pathname,
+        title: intl.formatMessage(route.breadcrumbs_title),
+      },
+    ];
   }
   /** fine della gestione delle rotte statiche */
 


### PR DESCRIPTION
Bug notato nella navigazione tra non-content route, quando due route non hanno contesto e si naviga con un link direttamente tra le due route, le breadcrumbs accumulano il titolo della breadcrumb.

 1. Mutazione diretta dello stato Redux — `items` viene letto da `state.breadcrumbs.items` via `useSelector` (riferimento diretto all'array in store), e il branch che gestisce le route statiche con `breadcrumbs_title` faceva `items.push(...)` mutando quell'array condiviso invece di trattarlo come immutabile. Su route non-content navigate via client-side routing (senza mai un reload/refetch che sostituisse l'array in store), ogni cambio pagina appendeva un elemento permanentemente, causando accumulo infinito di breadcrumb.
 
 2. Match di route non rispettava exact — getMatchingRoute chiamava matchPath(location.pathname, p) passando solo la stringa del path, equivalente a matchPath con exact: false di default, ignorando il flag `exact` eventualmente impostato sulla route in `config.addonRoutes`. Con match non esatto, una route con path più corto (es. /area-clienti) matcha come prefisso qualsiasi sotto-percorso (/area-clienti/pratiche, /area-clienti/documenti, ...). Poiché `getCurrentPathFromAddonRoutes` usa `.find()` e le route sono ordinate, veniva sempre restituita la prima route "corta" che matchava, con `breadcrumbs_title` sempre uguale indipendentemente dalla sezione reale.
 
Fix:
 1. Sostituita la mutazione con la creazione di un nuovo array (items = [...items, {...}]), lasciando `state.breadcrumbs.items`immutato tra i render.
  2. `getMatchingRoute`/`getCurrentPathFromAddonRoutes` ora passano esplicitamente `exact: !!route.exact` a `matchPath` (in forma oggetto anziché stringa). Le route wildcard esistenti senza exact (es. /**/search) mantengono il comportamento di match non-esatto invariato; le route con `exact: true` ora matchano solo il proprio path esatto.

Fare anche cherry-pick su main.