### PR TITLE
fix: mark customer satisfaction question as required and rename submit button

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Nella vista di dettaglio di un'Immagine, il link "Clicca per scaricare l'immagine in dimensione originale" ora avvia correttamente il download del file, invece di aprire l'immagine in una nuova pagina.
+- Nel form della soddisfazione del cittadino (customer satisfaction), la domanda obbligatoria del secondo passaggio ora viene segnalata come tale sia visivamente che alle tecnologie assistive, con un messaggio che indica la necessità di scegliere un'opzione per proseguire. Il pulsante finale del form ora si chiama "Invia" invece di "Avanti".
 
 ## Versione 12.14.2 (30/07/2026)
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2509,6 +2509,11 @@ msgstr ""
 msgid "feedback_answers_header_positive"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: Select an option to proceed
+msgid "feedback_answers_required_hint"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: The instructions were clear
 msgid "feedback_clear_instructions"
@@ -2549,6 +2554,11 @@ msgstr ""
 msgid "feedback_error"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: required
+msgid "feedback_field_required"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Feedback form
 msgid "feedback_form_aria_title"
@@ -2562,6 +2572,11 @@ msgstr ""
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Previous
 msgid "feedback_form_button_prev"
+msgstr ""
+
+#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
+# defaultMessage: Send
+msgid "feedback_form_button_send"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2494,6 +2494,11 @@ msgstr ""
 msgid "feedback_answers_header_positive"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: Select an option to proceed
+msgid "feedback_answers_required_hint"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: The instructions were clear
 msgid "feedback_clear_instructions"
@@ -2534,6 +2539,11 @@ msgstr ""
 msgid "feedback_error"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: required
+msgid "feedback_field_required"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Feedback form
 msgid "feedback_form_aria_title"
@@ -2547,6 +2557,11 @@ msgstr ""
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Previous
 msgid "feedback_form_button_prev"
+msgstr ""
+
+#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
+# defaultMessage: Send
+msgid "feedback_form_button_send"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2503,6 +2503,11 @@ msgstr ""
 msgid "feedback_answers_header_positive"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: Select an option to proceed
+msgid "feedback_answers_required_hint"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: The instructions were clear
 msgid "feedback_clear_instructions"
@@ -2543,6 +2548,11 @@ msgstr ""
 msgid "feedback_error"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: required
+msgid "feedback_field_required"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Feedback form
 msgid "feedback_form_aria_title"
@@ -2556,6 +2566,11 @@ msgstr ""
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Previous
 msgid "feedback_form_button_prev"
+msgstr ""
+
+#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
+# defaultMessage: Send
+msgid "feedback_form_button_send"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2511,6 +2511,11 @@ msgstr ""
 msgid "feedback_answers_header_positive"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: Select an option to proceed
+msgid "feedback_answers_required_hint"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: The instructions were clear
 msgid "feedback_clear_instructions"
@@ -2551,6 +2556,11 @@ msgstr ""
 msgid "feedback_error"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: required
+msgid "feedback_field_required"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Feedback form
 msgid "feedback_form_aria_title"
@@ -2564,6 +2574,11 @@ msgstr ""
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Previous
 msgid "feedback_form_button_prev"
+msgstr ""
+
+#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
+# defaultMessage: Send
+msgid "feedback_form_button_send"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2494,6 +2494,11 @@ msgstr "Dove hai incontrato le maggiori difficoltà?"
 msgid "feedback_answers_header_positive"
 msgstr "Quali sono stati gli aspetti che hai preferito?"
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: Select an option to proceed
+msgid "feedback_answers_required_hint"
+msgstr "Scegliere un'opzione per proseguire"
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: The instructions were clear
 msgid "feedback_clear_instructions"
@@ -2534,6 +2539,11 @@ msgstr "Le indicazioni erano complete"
 msgid "feedback_error"
 msgstr "Errore"
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: required
+msgid "feedback_field_required"
+msgstr "obbligatoria"
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Feedback form
 msgid "feedback_form_aria_title"
@@ -2548,6 +2558,11 @@ msgstr "Avanti"
 # defaultMessage: Previous
 msgid "feedback_form_button_prev"
 msgstr "Indietro"
+
+#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
+# defaultMessage: Send
+msgid "feedback_form_button_send"
+msgstr "Invia"
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: No

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-08-07T08:58:12.392Z\n"
+"POT-Creation-Date: 2026-08-19T10:31:38.179Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2496,6 +2496,11 @@ msgstr ""
 msgid "feedback_answers_header_positive"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: Select an option to proceed
+msgid "feedback_answers_required_hint"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: The instructions were clear
 msgid "feedback_clear_instructions"
@@ -2536,6 +2541,11 @@ msgstr ""
 msgid "feedback_error"
 msgstr ""
 
+#: components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep
+# defaultMessage: required
+msgid "feedback_field_required"
+msgstr ""
+
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Feedback form
 msgid "feedback_form_aria_title"
@@ -2549,6 +2559,11 @@ msgstr ""
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
 # defaultMessage: Previous
 msgid "feedback_form_button_prev"
+msgstr ""
+
+#: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm
+# defaultMessage: Send
+msgid "feedback_form_button_send"
 msgstr ""
 
 #: components/ItaliaTheme/CustomerSatisfaction/FeedbackForm

--- a/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
+++ b/src/components/ItaliaTheme/CustomerSatisfaction/FeedbackForm.jsx
@@ -65,6 +65,10 @@ const messages = defineMessages({
     id: 'feedback_form_button_next',
     defaultMessage: 'Next',
   },
+  send: {
+    id: 'feedback_form_button_send',
+    defaultMessage: 'Send',
+  },
   prev: {
     id: 'feedback_form_button_prev',
     defaultMessage: 'Previous',
@@ -408,7 +412,7 @@ const FeedbackForm = ({ title, pathname }) => {
                                 sendFormData();
                             }}
                           >
-                            {intl.formatMessage(messages.next)}
+                            {intl.formatMessage(messages.send)}
                           </button>
                         )}
                       </div>

--- a/src/components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep.jsx
+++ b/src/components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep.jsx
@@ -80,7 +80,7 @@ const AnswersStep = ({
         id="vf-more-positive"
         className="answers-step"
         data-step={step}
-        aria-expanded={
+        data-expanded={
           userFeedback !== null && userFeedback > threshold && step === 0
         }
         aria-hidden={
@@ -102,35 +102,48 @@ const AnswersStep = ({
           }
         />
 
-        <Form className="answers-form" role="radiogroup" aria-required="true">
-          {state?.map((s, i) => (
-            <FormGroup
-              check
-              key={'positive-' + s}
-              className="border-bottom border-light mb-4"
-            >
-              <input
-                name="answer-input-positive"
-                id={'positive-' + s}
-                type="radio"
-                checked={s === selectedAnswer}
-                value={s}
-                onChange={handleAnswerChange}
-                autocomplete="off"
-                required
-              />
-              <Label
-                for={'positive-' + s}
+        <fieldset
+          className="answers-form-group"
+          role="radiogroup"
+          aria-required="true"
+          aria-describedby="answers-required-hint-positive"
+        >
+          <legend className="visually-hidden">
+            {intl.formatMessage(messages.header_positive)}
+          </legend>
+          <Form className="answers-form">
+            {state?.map((s, i) => (
+              <FormGroup
                 check
-                className="mb-4"
-                data-element="feedback-rating-answer"
+                key={'positive-' + s}
+                className="border-bottom border-light mb-4"
               >
-                {getTranslatedQuestion(intl, s)}
-              </Label>
-            </FormGroup>
-          ))}
-        </Form>
-        <p className="answers-required-hint small mb-0">
+                <input
+                  name="answer-input-positive"
+                  id={'positive-' + s}
+                  type="radio"
+                  checked={s === selectedAnswer}
+                  value={s}
+                  onChange={handleAnswerChange}
+                  autocomplete="off"
+                  required
+                />
+                <Label
+                  for={'positive-' + s}
+                  check
+                  className="mb-4"
+                  data-element="feedback-rating-answer"
+                >
+                  {getTranslatedQuestion(intl, s)}
+                </Label>
+              </FormGroup>
+            ))}
+          </Form>
+        </fieldset>
+        <p
+          id="answers-required-hint-positive"
+          className="answers-required-hint small mb-0"
+        >
           {intl.formatMessage(messages.required_hint)}
         </p>
       </fieldset>
@@ -138,7 +151,7 @@ const AnswersStep = ({
         id="vf-more-negative"
         className="answers-step"
         data-step={step}
-        aria-expanded={
+        data-expanded={
           userFeedback !== null && userFeedback < threshold && step === 0
         }
         aria-hidden={
@@ -160,34 +173,48 @@ const AnswersStep = ({
           }
         />
 
-        <Form className="answers-form" role="radiogroup" aria-required="true">
-          {state?.map((s, i) => (
-            <FormGroup
-              check
-              key={'negative-' + s}
-              className="border-bottom border-light mb-4"
-            >
-              <input
-                name="answer-input-negative"
-                id={'negative-' + s}
-                type="radio"
-                checked={s === selectedAnswer}
-                value={s}
-                onChange={handleAnswerChange}
-                required
-              />
-              <Label
-                for={'negative-' + s}
+        <fieldset
+          className="answers-form-group"
+          role="radiogroup"
+          aria-required="true"
+          aria-describedby="answers-required-hint-negative"
+        >
+          <legend className="visually-hidden">
+            {intl.formatMessage(messages.header_negative)}
+          </legend>
+          <Form className="answers-form">
+            {state?.map((s, i) => (
+              <FormGroup
                 check
-                className="mb-4"
-                data-element="feedback-rating-answer"
+                key={'negative-' + s}
+                className="border-bottom border-light mb-4"
               >
-                {getTranslatedQuestion(intl, s)}
-              </Label>
-            </FormGroup>
-          ))}
-        </Form>
-        <p className="answers-required-hint small mb-0">
+                <input
+                  name="answer-input-negative"
+                  id={'negative-' + s}
+                  type="radio"
+                  checked={s === selectedAnswer}
+                  value={s}
+                  onChange={handleAnswerChange}
+                  autocomplete="off"
+                  required
+                />
+                <Label
+                  for={'negative-' + s}
+                  check
+                  className="mb-4"
+                  data-element="feedback-rating-answer"
+                >
+                  {getTranslatedQuestion(intl, s)}
+                </Label>
+              </FormGroup>
+            ))}
+          </Form>
+        </fieldset>
+        <p
+          id="answers-required-hint-negative"
+          className="answers-required-hint small mb-0"
+        >
           {intl.formatMessage(messages.required_hint)}
         </p>
       </fieldset>

--- a/src/components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep.jsx
+++ b/src/components/ItaliaTheme/CustomerSatisfaction/Steps/AnswersStep.jsx
@@ -18,7 +18,24 @@ const messages = defineMessages({
     id: 'feedback_answers_header_negative',
     defaultMessage: 'Where did you encounter the biggest problems?',
   },
+  required: {
+    id: 'feedback_field_required',
+    defaultMessage: 'required',
+  },
+  required_hint: {
+    id: 'feedback_answers_required_hint',
+    defaultMessage: 'Select an option to proceed',
+  },
 });
+
+const RequiredTitle = ({ children, intl }) => (
+  <>
+    {children}
+    <span className="required-marker">
+      {` (${intl.formatMessage(messages.required)}) *`}
+    </span>
+  </>
+);
 
 const AnswersStep = ({
   updateFormData,
@@ -72,7 +89,11 @@ const AnswersStep = ({
         data-element={'feedback-rating-positive'}
       >
         <FormHeader
-          title={intl.formatMessage(messages.header_positive)}
+          title={
+            <RequiredTitle intl={intl}>
+              {intl.formatMessage(messages.header_positive)}
+            </RequiredTitle>
+          }
           step={step + 1}
           totalSteps={totalSteps}
           className={'answers-header'}
@@ -81,7 +102,7 @@ const AnswersStep = ({
           }
         />
 
-        <Form className="answers-form">
+        <Form className="answers-form" role="radiogroup" aria-required="true">
           {state?.map((s, i) => (
             <FormGroup
               check
@@ -96,6 +117,7 @@ const AnswersStep = ({
                 value={s}
                 onChange={handleAnswerChange}
                 autocomplete="off"
+                required
               />
               <Label
                 for={'positive-' + s}
@@ -108,6 +130,9 @@ const AnswersStep = ({
             </FormGroup>
           ))}
         </Form>
+        <p className="answers-required-hint small mb-0">
+          {intl.formatMessage(messages.required_hint)}
+        </p>
       </fieldset>
       <fieldset
         id="vf-more-negative"
@@ -122,7 +147,11 @@ const AnswersStep = ({
         data-element={'feedback-rating-negative'}
       >
         <FormHeader
-          title={intl.formatMessage(messages.header_negative)}
+          title={
+            <RequiredTitle intl={intl}>
+              {intl.formatMessage(messages.header_negative)}
+            </RequiredTitle>
+          }
           step={step + 1}
           totalSteps={totalSteps}
           className={'answers-header'}
@@ -131,7 +160,7 @@ const AnswersStep = ({
           }
         />
 
-        <Form className="answers-form">
+        <Form className="answers-form" role="radiogroup" aria-required="true">
           {state?.map((s, i) => (
             <FormGroup
               check
@@ -145,6 +174,7 @@ const AnswersStep = ({
                 checked={s === selectedAnswer}
                 value={s}
                 onChange={handleAnswerChange}
+                required
               />
               <Label
                 for={'negative-' + s}
@@ -157,6 +187,9 @@ const AnswersStep = ({
             </FormGroup>
           ))}
         </Form>
+        <p className="answers-required-hint small mb-0">
+          {intl.formatMessage(messages.required_hint)}
+        </p>
       </fieldset>
     </>
   );

--- a/src/theme/ItaliaTheme/Components/_customerSatisfaction.scss
+++ b/src/theme/ItaliaTheme/Components/_customerSatisfaction.scss
@@ -5,8 +5,8 @@
     max-height: 0;
   }
 
-  .feedback-form #vf-more-positive[aria-expanded='true'],
-  .feedback-form #vf-more-negative[aria-expanded='true'] {
+  .feedback-form #vf-more-positive[data-expanded='true'],
+  .feedback-form #vf-more-negative[data-expanded='true'] {
     max-height: 800px;
   }
 

--- a/src/theme/ItaliaTheme/Components/_customerSatisfaction.scss
+++ b/src/theme/ItaliaTheme/Components/_customerSatisfaction.scss
@@ -90,6 +90,11 @@
       margin-bottom: 0;
     }
 
+    .answers-required-hint {
+      padding: 0 0.875rem 0.875rem;
+      color: #5c6f82;
+    }
+
     .card-wrapper[data-element='feedback'] {
       padding: 1.8rem !important;
     }


### PR DESCRIPTION
Nel form della soddisfazione del cittadino, la domanda obbligatoria del secondo passaggio ora viene segnalata come tale sia visivamente che alle tecnologie assistive.

Principali modifiche
- Aggiunto l'attributo required e aria-required ai campi radio della domanda obbligatoria
- Aggiunta un'indicazione visiva "(obbligatoria) *" nel titolo della domanda
- Aggiunto un messaggio che indica la necessità di scegliere un'opzione per proseguire
- Il pulsante finale del form ora si chiama "Invia" invece di "Avanti"