### PR TITLE
US#55026 fix: close date picker on Escape when focus is inside the calendar

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@
 ### Fix
 
 - Nella vista di dettaglio di un'Immagine, il link "Clicca per scaricare l'immagine in dimensione originale" ora avvia correttamente il download del file, invece di aprire l'immagine in una nuova pagina.
+- Nei campi data e data + ora, il tasto Esc adesso chiude sempre il calendario. Prima non funzionava se il focus da tastiera era già entrato dentro al calendario.
 
 ## Versione 12.14.2 (30/07/2026)
 

--- a/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
+++ b/src/components/ItaliaTheme/Blocks/Common/SearchFilters/DateFilter.jsx
@@ -234,16 +234,9 @@ const DateFilter = (props) => {
         setFocusedDateInput(null);
       }
     }
-
-    if (e.key === 'Escape') {
-      setFocusedDateInput(null);
-    }
   };
   const endDateListener = (e) => {
     if (e.key === 'Tab' && !e.shiftKey) {
-      setFocusedDateInput(null);
-    }
-    if (e.key === 'Escape') {
       setFocusedDateInput(null);
     }
   };
@@ -288,10 +281,19 @@ const DateFilter = (props) => {
     };
   }, []);
 
+  const handleWrapperKeyDownCapture = (e) => {
+    if (e.key === 'Escape') {
+      setFocusedDateInput(null);
+    }
+  };
+
   const WrapperDate = legendLabel ? 'fielset' : 'div';
 
   return (
-    <div className="me-lg-3 my-2 my-lg-1 filter-wrapper date-filter">
+    <div
+      className="me-lg-3 my-2 my-lg-1 filter-wrapper date-filter"
+      onKeyDownCapture={handleWrapperKeyDownCapture}
+    >
       <WrapperDate>
         {legendLabel && <legend>{legendLabel}</legend>}
         <DateRangePicker

--- a/src/customizations/volto/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/customizations/volto/components/manage/Widgets/DatetimeWidget.jsx
@@ -8,6 +8,9 @@
  * CUSTOMIZATIONS:
  * - accept calendar `openDirection` prop and use it in SingleDatePicker,
  *   default to down if no openDirection is given
+ * - close the calendar on Escape even when focus is inside it, using a
+ *   capture-phase keydown listener (react-dates' DayPicker stops
+ *   propagation on keydown, so a bubble-phase listener never sees it)
  */
 /**
  * DatetimeWidget component.
@@ -189,6 +192,12 @@ export class DatetimeWidgetComponent extends Component {
    */
   onFocusChange = ({ focused }) => this.setState({ focused });
 
+  onWrapperKeyDownCapture = (e) => {
+    if (e.key === 'Escape') {
+      this.setState({ focused: false });
+    }
+  };
+
   render() {
     const { id, resettable, intl, reactDates, widgetOptions, lang } =
       this.props;
@@ -206,6 +215,7 @@ export class DatetimeWidgetComponent extends Component {
             className={cx('ui input date-input', {
               'default-date': this.state.isDefault,
             })}
+            onKeyDownCapture={this.onWrapperKeyDownCapture}
           >
             <SingleDatePicker
               date={datetime}


### PR DESCRIPTION
Risolto un problema di accessibilità nei campi data con calendario (react-dates).

Il tasto Esc chiudeva il calendario solo se il focus si trovava sul campo di input. Se l'utente navigava con la tastiera dentro al calendario stesso (sulle celle dei giorni), Esc non aveva più effetto, perché react-dates interrompe la propagazione dell'evento nel proprio gestore.

La correzione ascolta l'evento Esc nella fase di cattura, prima che react-dates possa interromperne la propagazione, così il calendario si chiude sempre, indipendentemente da dove si trova il focus.

Componenti coinvolti, il filtro data nei blocchi di ricerca e il campo data/ora usato nei formulari di modifica dei contenuti.